### PR TITLE
fix(corpusfs): stop the scan cache from hiding a file added inside one mtime second (#667)

### DIFF
--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -442,9 +442,14 @@ embedded, and the coordinator enqueues the chunk's current form on its next pass
   ```
 
   The cache keys each directory on its own mtime plus its direct children's
-  name/size/mtime/mode, so a changed directory is still rescanned. It is only
-  consulted for the local-filesystem backend (not the native `source.kind: s3`
-  object listing).
+  name/size/mtime/mode, so a changed directory is still rescanned. Every
+  timestamp is compared to the nanosecond, and a directory whose mtime is less
+  than two seconds old is not cached at all: a further write in the same
+  filesystem timestamp tick would leave the stamp unchanged, and the cached
+  child list could then hide a new file. A directory that is being written to
+  during the scan therefore keeps the full read until it settles. The cache is
+  only consulted for the local-filesystem backend (not the native
+  `source.kind: s3` object listing).
 
 - **Video time-window reads currently download the whole object.** Range reads
   over S3 avoid whole-object downloads for plain byte-slice reads, but the

--- a/docs/dual-machine-deployment.md
+++ b/docs/dual-machine-deployment.md
@@ -442,13 +442,10 @@ embedded, and the coordinator enqueues the chunk's current form on its next pass
   ```
 
   The cache keys each directory on its own mtime plus its direct children's
-  name/size/mtime/mode, so a changed directory is still rescanned. Every
-  timestamp is compared to the nanosecond, and a directory whose mtime is less
-  than two seconds old is not cached at all: a further write in the same
-  filesystem timestamp tick would leave the stamp unchanged, and the cached
-  child list could then hide a new file. A directory that is being written to
-  during the scan therefore keeps the full read until it settles. The cache is
-  only consulted for the local-filesystem backend (not the native
+  name/size/mtime/mode, so a changed directory is still rescanned. A directory
+  that is being written to while the scan runs keeps the full read, so a corpus
+  under active write gains less from the cache than a settled archive. The cache
+  is only consulted for the local-filesystem backend (not the native
   `source.kind: s3` object listing).
 
 - **Video time-window reads currently download the whole object.** Range reads

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -556,8 +556,16 @@ type Config struct {
 	// re-sorting its entries. Correctness is never traded for speed: every cached
 	// child file is still stat'd so an in-place modification is detected, and any
 	// add/remove/rename (which bumps the parent directory mtime) or stat failure
-	// falls the directory back to a full re-walk. Default OFF: discovery behaves
-	// exactly as before. Only consulted for the local-filesystem backend.
+	// falls the directory back to a full re-walk.
+	//
+	// Every timestamp is compared to the NANOSECOND, and a directory whose mtime
+	// is not yet settled (older than the coarsest filesystem timestamp
+	// granularity) is not cached at all (#667). Both rules exist because a
+	// second-resolution comparison read a change inside the recorded second as no
+	// change, and a file added in that window was never enumerated.
+	//
+	// Default OFF: discovery behaves exactly as before. Only consulted for the
+	// local-filesystem backend.
 	IngestScanCache bool
 
 	// IngestLateChunking opts IN to "late chunking" (issue #332, Jina's

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -212,7 +212,18 @@ type CachedDirEntry struct {
 	Name      string
 	IsDir     bool
 	SizeBytes int64
-	MTimeUnix int64
+	// MTimeUnixNano is the child's modification time in NANOSECONDS (#667).
+	//
+	// It was seconds. A same-size in-place edit inside one Unix second therefore
+	// matched the cached entry, and the directory was served from cache instead of
+	// being re-read. Nanoseconds separate those two writes on every filesystem
+	// that keeps a sub-second stamp (ext4, APFS, XFS, btrfs, NTFS).
+	//
+	// Note this field is a fallback TRIGGER, not the change signal a caller acts
+	// on: a validated child is emitted with its LIVE stat, so the file's reported
+	// size and mtime are always current. See CachedDirSignature for the field that
+	// carries the correctness weight.
+	MTimeUnixNano int64
 	// Mode is the file mode bits recorded for a regular file so a cache hit can
 	// reconstruct the DiscoveredFile.Mode without re-stat beyond the size/mtime
 	// confirmation the walker already performs.
@@ -222,12 +233,20 @@ type CachedDirEntry struct {
 // CachedDirSignature is the persisted fingerprint of a single directory: the
 // directory's own mtime (which POSIX bumps on any add/remove/rename of a direct
 // child) plus the sorted list of its direct children. A live directory whose
-// mtime equals DirMTimeUnix has the same set of children as when the signature
-// was stored, so the walker can validate the cached children with per-file stats
-// instead of re-reading the directory.
+// mtime equals DirMTimeUnixNano has the same set of children as when the
+// signature was stored, so the walker can validate the cached children with
+// per-file stats instead of re-reading the directory.
+//
+// That deduction only holds when the recorded mtime is OLDER than the moment the
+// child list was read, by more than the filesystem's timestamp granularity
+// (#667). A child added in the same timestamp tick the walk read the directory in
+// leaves the mtime equal to the recorded one, so the walk would keep serving a
+// child list the new file is not in. The walker therefore refuses to store a
+// signature for a directory whose mtime is not yet settled; see
+// dirSignatureIsSettled in local.go for the rule and the proof.
 type CachedDirSignature struct {
-	DirMTimeUnix int64
-	Entries      []CachedDirEntry
+	DirMTimeUnixNano int64
+	Entries          []CachedDirEntry
 }
 
 // ScanCache persists per-directory discovery signatures keyed by a directory's
@@ -240,6 +259,10 @@ type CachedDirSignature struct {
 // Implementations must be safe for the walker's usage (sequential within one
 // Walk). Lookup returning ok=false (or any inconsistency) must make the walker
 // fall back to a full directory read.
+//
+// Timestamps in a signature are NANOSECONDS (#667). An implementation that
+// persists them must keep the full precision; truncating to seconds reopens the
+// window this cache used to have.
 type ScanCache interface {
 	// LookupDir returns the cached signature for relDir, or ok=false when none is
 	// recorded. An error is treated by the walker as a cache miss (full re-walk).

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -322,11 +322,15 @@ func (w *discoverWalker) walkDirFull(ctx context.Context, absDir, relDir string,
 	// TOCTOU: if a child is added concurrently with the read, the mtime bumps and
 	// we decline to cache a possibly-partial snapshot rather than risk recording a
 	// new mtime against a stale child set (which a later run would wrongly trust).
+	//
+	// The clock is read first, and it is the PRE-read instant that the settle rule
+	// is measured against (#667). See dirReadStamp.
 	caching := w.options.ScanCache != nil && !w.options.FollowSymlinks
-	var preReadMTime time.Time
+	var stamp dirReadStamp
 	if caching {
+		stamp.readAt = time.Now()
 		if info, statErr := os.Stat(absDir); statErr == nil {
-			preReadMTime = info.ModTime()
+			stamp.mtime = info.ModTime()
 		} else {
 			caching = false
 		}
@@ -366,9 +370,25 @@ func (w *discoverWalker) walkDirFull(ctx context.Context, absDir, relDir string,
 	}
 
 	if caching {
-		w.storeDirSignature(absDir, relDir, preReadMTime, sigEntries)
+		w.storeDirSignature(absDir, relDir, stamp, sigEntries)
 	}
 	return nil
+}
+
+// dirReadStamp is what walkDirFull observed about a directory immediately BEFORE
+// it read the directory's entries: the directory's mtime, and the wall-clock
+// instant at which that observation was made.
+//
+// Both halves are pre-read on purpose (#667). The settle rule asks whether a write
+// arriving after the child list was determined is guaranteed to move the stamp,
+// so it must be measured against an instant no later than the read. Measuring it
+// at STORE time instead would be weaker by the duration of the read: a directory
+// whose listing takes seconds (a large directory on a slow NFS mount) could then
+// accept a stamp that a concurrent same-tick add had already made stale, which is
+// the one case the pre-read mtime comparison cannot see either.
+type dirReadStamp struct {
+	mtime  time.Time
+	readAt time.Time
 }
 
 // processFullEntry handles a single freshly-read child of a directory: it stats
@@ -558,25 +578,25 @@ func (w *discoverWalker) emitCachedChildren(ctx context.Context, confirmed []cac
 // failed or skipped store only forgoes the optimization next run.
 //
 // 1. The directory's mtime must be unchanged since it was sampled before the read
-// (preReadMTime). A changed mtime means a child was added/removed/renamed during
+// (stamp.mtime). A changed mtime means a child was added/removed/renamed during
 // the read, so the captured child set may be partial; in that case we skip the
 // store rather than record a new mtime against a stale set (which a later run
 // would wrongly trust).
 //
-// 2. The mtime must be SETTLED (#667): older than this instant by more than the
-// coarsest filesystem timestamp granularity. Guard 1 compares two stamps, so it
-// cannot see a change that landed in the same tick as the stamp it is comparing;
-// guard 2 is what refuses that case. See mtimeSettleWindow.
-func (w *discoverWalker) storeDirSignature(absDir, relDir string, preReadMTime time.Time, entries []CachedDirEntry) {
+// 2. The mtime must be SETTLED (#667): older than the moment of that observation
+// by more than the coarsest filesystem timestamp granularity. Guard 1 compares two
+// stamps, so it cannot see a change that landed in the same tick as the stamp it is
+// comparing; guard 2 is what refuses that case. See mtimeSettleWindow.
+func (w *discoverWalker) storeDirSignature(absDir, relDir string, stamp dirReadStamp, entries []CachedDirEntry) {
 	info, err := os.Stat(absDir)
-	if err != nil || !info.ModTime().Equal(preReadMTime) {
+	if err != nil || !info.ModTime().Equal(stamp.mtime) {
 		return
 	}
-	if !dirSignatureIsSettled(preReadMTime, time.Now()) {
+	if !dirSignatureIsSettled(stamp.mtime, stamp.readAt) {
 		return
 	}
 	_ = w.options.ScanCache.StoreDir(relDir, CachedDirSignature{
-		DirMTimeUnixNano: preReadMTime.UnixNano(),
+		DirMTimeUnixNano: stamp.mtime.UnixNano(),
 		Entries:          entries,
 	})
 }
@@ -606,7 +626,8 @@ func (w *discoverWalker) storeDirSignature(absDir, relDir string, preReadMTime t
 const mtimeSettleWindow = 2 * time.Second
 
 // dirSignatureIsSettled reports whether a directory whose mtime is dirMTime, read
-// by a walk that reached this point at readAt, may have its child list cached.
+// by a walk that observed it at readAt, may have its child list cached. readAt is
+// the PRE-read instant (see dirReadStamp), never a later one.
 //
 // The answer is yes only when dirMTime is at least mtimeSettleWindow behind
 // readAt. Any later write to the directory then produces a stamp that differs

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // ErrPathEscapesRoot is returned by Open/Localize when a relPath resolves
@@ -322,10 +323,10 @@ func (w *discoverWalker) walkDirFull(ctx context.Context, absDir, relDir string,
 	// we decline to cache a possibly-partial snapshot rather than risk recording a
 	// new mtime against a stale child set (which a later run would wrongly trust).
 	caching := w.options.ScanCache != nil && !w.options.FollowSymlinks
-	var preReadMTime int64
+	var preReadMTime time.Time
 	if caching {
 		if info, statErr := os.Stat(absDir); statErr == nil {
-			preReadMTime = info.ModTime().Unix()
+			preReadMTime = info.ModTime()
 		} else {
 			caching = false
 		}
@@ -411,10 +412,10 @@ func (w *discoverWalker) processFullEntry(ctx context.Context, absDir, relDir, n
 	}
 
 	sig := CachedDirEntry{
-		Name:      name,
-		SizeBytes: lstat.Size(),
-		MTimeUnix: lstat.ModTime().Unix(),
-		Mode:      uint32(lstat.Mode()),
+		Name:          name,
+		SizeBytes:     lstat.Size(),
+		MTimeUnixNano: lstat.ModTime().UnixNano(),
+		Mode:          uint32(lstat.Mode()),
 	}
 	if w.shouldAddFile(lstat, relPath, rules) {
 		*w.files = append(*w.files, DiscoveredFile{
@@ -459,7 +460,12 @@ func (w *discoverWalker) walkDirFromCache(ctx context.Context, absDir, relDir st
 		return false, nil //nolint:nilerr // unreadable dir is a miss; full path reports the error
 	}
 	sig, ok, err := w.options.ScanCache.LookupDir(relDir)
-	if err != nil || !ok || sig.DirMTimeUnix != info.ModTime().Unix() {
+	// Nanoseconds, not seconds (#667): a second-resolution comparison accepted a
+	// directory whose child list had changed within the recorded Unix second.
+	// A signature written by an older build carries a seconds value here, which
+	// cannot equal a nanosecond stamp, so it reads as a miss and the directory is
+	// re-read and re-stored once. The cache is self-healing by design.
+	if err != nil || !ok || sig.DirMTimeUnixNano != info.ModTime().UnixNano() {
 		return false, nil //nolint:nilerr // a cache error/miss/mtime drift is a full-read fallback
 	}
 
@@ -506,6 +512,10 @@ func (w *discoverWalker) validateCachedChildren(ctx context.Context, absDir, rel
 // cachedChildMatches reports whether a live stat is consistent with the cached
 // entry: a directory must still be a directory; a regular file must still be a
 // regular file with the same size and mtime (so an in-place modification fails).
+//
+// The mtime is compared in NANOSECONDS (#667). At second resolution a same-size
+// edit made inside the recorded Unix second matched, and the directory kept its
+// cache hit.
 func cachedChildMatches(e CachedDirEntry, lstat os.FileInfo) bool {
 	if e.IsDir {
 		return lstat.IsDir()
@@ -513,7 +523,7 @@ func cachedChildMatches(e CachedDirEntry, lstat os.FileInfo) bool {
 	if lstat.IsDir() || !lstat.Mode().IsRegular() {
 		return false
 	}
-	return lstat.Size() == e.SizeBytes && lstat.ModTime().Unix() == e.MTimeUnix
+	return lstat.Size() == e.SizeBytes && lstat.ModTime().UnixNano() == e.MTimeUnixNano
 }
 
 // emitCachedChildren appends the confirmed files and recurses into confirmed
@@ -543,22 +553,78 @@ func (w *discoverWalker) emitCachedChildren(ctx context.Context, confirmed []cac
 	return nil
 }
 
-// storeDirSignature persists the freshly observed directory signature, but only
-// if the directory's mtime has not changed since it was sampled before the read
+// storeDirSignature persists the freshly observed directory signature, subject to
+// two guards. Errors are non-fatal: discovery already produced correct results; a
+// failed or skipped store only forgoes the optimization next run.
+//
+// 1. The directory's mtime must be unchanged since it was sampled before the read
 // (preReadMTime). A changed mtime means a child was added/removed/renamed during
 // the read, so the captured child set may be partial; in that case we skip the
 // store rather than record a new mtime against a stale set (which a later run
-// would wrongly trust). Errors are non-fatal: discovery already produced correct
-// results; a failed store only forgoes the optimization next run.
-func (w *discoverWalker) storeDirSignature(absDir, relDir string, preReadMTime int64, entries []CachedDirEntry) {
+// would wrongly trust).
+//
+// 2. The mtime must be SETTLED (#667): older than this instant by more than the
+// coarsest filesystem timestamp granularity. Guard 1 compares two stamps, so it
+// cannot see a change that landed in the same tick as the stamp it is comparing;
+// guard 2 is what refuses that case. See mtimeSettleWindow.
+func (w *discoverWalker) storeDirSignature(absDir, relDir string, preReadMTime time.Time, entries []CachedDirEntry) {
 	info, err := os.Stat(absDir)
-	if err != nil || info.ModTime().Unix() != preReadMTime {
+	if err != nil || !info.ModTime().Equal(preReadMTime) {
+		return
+	}
+	if !dirSignatureIsSettled(preReadMTime, time.Now()) {
 		return
 	}
 	_ = w.options.ScanCache.StoreDir(relDir, CachedDirSignature{
-		DirMTimeUnix: preReadMTime,
-		Entries:      entries,
+		DirMTimeUnixNano: preReadMTime.UnixNano(),
+		Entries:          entries,
 	})
+}
+
+// mtimeSettleWindow is how far in the past a directory's mtime must sit, relative
+// to the moment the walk read that directory, before the walk is allowed to cache
+// the directory's child list (#667).
+//
+// Why a window is needed. A filesystem records an mtime with a finite
+// granularity, so the stamp names a BUCKET, not an instant. Say the walk reads
+// directory D at time O and D's recorded mtime is M. A file added at any later
+// time C gives D a new mtime of bucket(C). If bucket(C) == M the add is invisible
+// to a walk that compares mtimes, and the cached child list keeps hiding the new
+// file for as long as nothing else touches D.
+//
+// Why 2 seconds closes it. Require M <= O - 2s. Then for any C >= O we have
+// bucket(C) >= bucket(O) > M whenever the granularity G is at most 2s, so the
+// add always changes the stamp. G is 1s on ext3 and on many NFS mounts, 2s on
+// FAT32 (the coarsest stamp in real use: an SD card or a USB stick), and
+// nanoseconds on ext4/APFS/XFS/btrfs/NTFS. A filesystem with a stamp coarser
+// than 2s would need this constant raised.
+//
+// What it costs. Only a directory modified within 2 seconds of the walk reaching
+// it goes uncached, and only until the next scan, which caches it once the stamp
+// has settled. A corpus that is not being written to during the scan pays
+// nothing.
+const mtimeSettleWindow = 2 * time.Second
+
+// dirSignatureIsSettled reports whether a directory whose mtime is dirMTime, read
+// by a walk that reached this point at readAt, may have its child list cached.
+//
+// The answer is yes only when dirMTime is at least mtimeSettleWindow behind
+// readAt. Any later write to the directory then produces a stamp that differs
+// from dirMTime whatever the filesystem's granularity, so the next walk sees the
+// change instead of serving a child list the change is not in (#667).
+//
+// A directory whose mtime is in the FUTURE relative to readAt is not settled, so
+// it is not cached. A corpus on a mount whose server clock runs ahead of this
+// host therefore loses the fast path and keeps the full read, which is the safe
+// direction to fail in.
+//
+// Nanosecond comparison needs the stamp to be exactly representable as an int64
+// nanosecond count, which holds for 1678..2262. No mainstream filesystem can
+// report a stamp before that range (ext4 clamps at 1901, APFS counts 64-bit
+// nanoseconds), and a stamp after it is in the future, which this test already
+// refuses. So the range needs no separate check.
+func dirSignatureIsSettled(dirMTime, readAt time.Time) bool {
+	return !dirMTime.After(readAt.Add(-mtimeSettleWindow))
 }
 
 func (w *discoverWalker) handleSymlink(ctx context.Context, symlinkPath, relPath string, rules []gitIgnoreRule) error {

--- a/internal/scancache/scancache.go
+++ b/internal/scancache/scancache.go
@@ -5,6 +5,9 @@
 // local archive can skip re-reading and re-sorting directories whose contents
 // are unchanged, while still detecting any added/removed/modified file.
 //
+// Every timestamp is stored in NANOSECONDS (#667). Seconds were too coarse: a
+// change inside the recorded second read as no change at all.
+//
 // The cache is purely a performance optimization: the walker only trusts a
 // signature after confirming the directory's live mtime is unchanged AND
 // re-stat'ing every cached child, so a stale or corrupt cache can never cause a
@@ -88,15 +91,25 @@ func (c *SQLiteCache) ensureDB(ctx context.Context) (*sql.DB, error) {
 			return nil, fmt.Errorf("scancache: pragma: %w", err)
 		}
 	}
-	schema := `
-CREATE TABLE IF NOT EXISTS dir_signatures (
-  rel_dir       TEXT PRIMARY KEY,
-  dir_mtime_unix INTEGER NOT NULL,
-  entries_json  TEXT NOT NULL
-);`
-	if _, err := db.ExecContext(ctx, schema); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("scancache: init schema: %w", err)
+	// The table is versioned in its NAME and the previous version is dropped
+	// (#667). Timestamps moved from seconds to nanoseconds, so a row written by an
+	// older build states a number this build reads as a different instant. Such a
+	// row is harmless (the walker compares it, sees a mismatch, and re-reads the
+	// directory), but keeping it wastes a lookup and a row per directory forever.
+	// The cache holds no authoritative state and is safe to delete at any time, so
+	// dropping is the whole migration.
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS dir_signatures;`,
+		`CREATE TABLE IF NOT EXISTS dir_signatures_v2 (
+  rel_dir             TEXT PRIMARY KEY,
+  dir_mtime_unix_nano INTEGER NOT NULL,
+  entries_json        TEXT NOT NULL
+);`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("scancache: init schema: %w", err)
+		}
 	}
 	c.db = db
 	return db, nil
@@ -113,11 +126,11 @@ func (c *SQLiteCache) LookupDir(relDir string) (corpusfs.CachedDirSignature, boo
 		return corpusfs.CachedDirSignature{}, false, nil //nolint:nilerr // a cache error is a miss
 	}
 
-	var mtime int64
+	var mtimeNano int64
 	var entriesJSON string
 	row := db.QueryRowContext(ctx,
-		`SELECT dir_mtime_unix, entries_json FROM dir_signatures WHERE rel_dir = ?`, relDir)
-	if err := row.Scan(&mtime, &entriesJSON); err != nil {
+		`SELECT dir_mtime_unix_nano, entries_json FROM dir_signatures_v2 WHERE rel_dir = ?`, relDir)
+	if err := row.Scan(&mtimeNano, &entriesJSON); err != nil {
 		c.recordMiss()
 		return corpusfs.CachedDirSignature{}, false, nil //nolint:nilerr // no row / scan error -> miss
 	}
@@ -130,7 +143,7 @@ func (c *SQLiteCache) LookupDir(relDir string) (corpusfs.CachedDirSignature, boo
 		}
 	}
 	c.recordHit()
-	return corpusfs.CachedDirSignature{DirMTimeUnix: mtime, Entries: entries}, true, nil
+	return corpusfs.CachedDirSignature{DirMTimeUnixNano: mtimeNano, Entries: entries}, true, nil
 }
 
 // StoreDir upserts the signature for relDir.
@@ -145,12 +158,12 @@ func (c *SQLiteCache) StoreDir(relDir string, sig corpusfs.CachedDirSignature) e
 		return fmt.Errorf("scancache: marshal entries: %w", err)
 	}
 	_, err = db.ExecContext(ctx,
-		`INSERT INTO dir_signatures (rel_dir, dir_mtime_unix, entries_json)
+		`INSERT INTO dir_signatures_v2 (rel_dir, dir_mtime_unix_nano, entries_json)
 		 VALUES (?, ?, ?)
 		 ON CONFLICT(rel_dir) DO UPDATE SET
-		   dir_mtime_unix = excluded.dir_mtime_unix,
-		   entries_json   = excluded.entries_json`,
-		relDir, sig.DirMTimeUnix, string(entriesJSON))
+		   dir_mtime_unix_nano = excluded.dir_mtime_unix_nano,
+		   entries_json        = excluded.entries_json`,
+		relDir, sig.DirMTimeUnixNano, string(entriesJSON))
 	if err != nil {
 		return fmt.Errorf("scancache: store signature: %w", err)
 	}

--- a/tests/corpusfs/scancache_mtime_667_test.go
+++ b/tests/corpusfs/scancache_mtime_667_test.go
@@ -13,8 +13,17 @@ import (
 // children's mtimes at SECOND resolution, so a change that landed inside the
 // recorded Unix second read as no change at all.
 //
-// Every timestamp below is set with os.Chtimes. Nothing here waits on the clock,
-// and nothing depends on how fast the test host is.
+// Every timestamp below is set with os.Chtimes, and no assertion depends on how
+// long the test took. That has to hold in BOTH directions:
+//
+//   - a test that needs a directory to be SETTLED stamps it with anchor667, years
+//     in the past, so no amount of speed can make it unsettled;
+//   - a test that needs a directory to be UNSETTLED stamps it with
+//     unsettledStamp667, an hour ahead, so no amount of stalling can settle it.
+//
+// Stamping "now" would satisfy neither: the outcome would then turn on whether the
+// walk started inside the settle window, which is a timing coincidence and not the
+// property under test.
 
 // anchor667 is a fixed instant with a zero nanosecond part, so a test can place a
 // second write at a chosen offset INSIDE the same Unix second. It is years in the
@@ -141,24 +150,42 @@ func TestScanCache667_SameSizeSameSecondEditIsReObserved(t *testing.T) {
 	}
 }
 
+// unsettledStamp667 returns a stamp that no walk in this test run can consider
+// settled, whatever the host does between the Chtimes call and the walk.
+//
+// "Not settled" is ONE predicate with two ways in: a stamp too RECENT (what a
+// coarse-granularity filesystem reports for a write happening now) and a stamp in
+// the FUTURE (a corpus on a mount whose clock runs ahead of this host). Both reach
+// the same comparison, so a future stamp exercises the same branch.
+//
+// Using time.Now() instead would make the assertion depend on the walk starting
+// within the settle window. A host that stalled for longer would settle the
+// directory, a CORRECT walker would then cache it, and the test would go red with
+// no defect present. That is the same failure shape this PR is about: an outcome
+// decided by a timing coincidence rather than by the property under test. The
+// offset is an hour, so only an hour-long stall could reach it.
+func unsettledStamp667() time.Time {
+	return time.Now().Add(time.Hour).Truncate(time.Second)
+}
+
 // TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd covers what nanosecond
 // comparison alone cannot: a filesystem whose mtime granularity is a whole second
 // (ext3, many NFS mounts) or two seconds (FAT32).
 //
 // On such a filesystem both writes below produce the SAME stamp, so no comparison
 // of stamps can tell them apart. The settle guard is what saves it: a directory
-// whose stamp is not yet older than the coarsest granularity is not cached at all,
-// so the next walk reads it and sees the new file.
+// whose stamp is not settled is not cached at all, so the next walk reads it and
+// sees the new file.
 //
-// The coarse filesystem is simulated by stamping the directory with the current
-// second truncated to a whole second, which is exactly what such a filesystem
-// would report for a write happening now.
+// The coarse filesystem is simulated in the part that matters and can be
+// controlled: the stamp does not move across the add, and it is not settled when
+// the first walk reads it. See unsettledStamp667 for why the stamp is not "now".
 func TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "dir")
 	mustWrite(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
 
-	bucket := time.Now().Truncate(time.Second)
+	bucket := unsettledStamp667()
 	setMTime667(t, dir, bucket)
 	setMTime667(t, root, bucket)
 
@@ -167,8 +194,8 @@ func TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd(t *testing.T) {
 		t.Fatalf("first walk: got %v want [dir/a.txt]", got)
 	}
 
-	// A write later in the same second, reported by the same coarse clock: the
-	// stamp does not move at all.
+	// A write later in the same tick, reported by the same coarse clock: the stamp
+	// does not move at all.
 	mustWrite(t, filepath.Join(dir, "b.txt"), []byte("beta"))
 	setMTime667(t, dir, bucket)
 
@@ -176,19 +203,28 @@ func TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd(t *testing.T) {
 	assertRelPaths667(t, "second walk", got, []string{"dir/a.txt", "dir/b.txt"})
 }
 
-// TestScanCache667_FreshlyWrittenDirectoryIsNotCached pins the settle guard
-// directly. A directory written moments ago cannot be cached safely, because a
-// further write in the same timestamp tick would leave its stamp unchanged.
-func TestScanCache667_FreshlyWrittenDirectoryIsNotCached(t *testing.T) {
+// TestScanCache667_UnsettledDirectoryIsNotCached pins the settle guard directly. A
+// directory whose stamp is not settled cannot be cached safely, because a further
+// write in the same timestamp tick would leave that stamp unchanged.
+//
+// The refusal must be scoped to the affected directory, so the settled root in the
+// same tree must still take the cheap path.
+func TestScanCache667_UnsettledDirectoryIsNotCached(t *testing.T) {
 	root := t.TempDir()
-	mustWrite(t, filepath.Join(root, "dir", "a.txt"), []byte("alpha"))
+	dir := filepath.Join(root, "dir")
+	mustWrite(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+	settleDirs667(t, root)
+	setMTime667(t, dir, unsettledStamp667())
 
 	cache := newFakeScanCache()
 	if got := relPaths(walkWith(t, root, cache)); len(got) != 1 {
 		t.Fatalf("walk: got %v want [dir/a.txt]", got)
 	}
-	if cache.stores != 0 {
-		t.Fatalf("a just-written tree was cached (stores=%d); its stamp is still inside the ambiguity window", cache.stores)
+	if sig, ok := cache.sigs["dir"]; ok {
+		t.Fatalf("an unsettled directory was cached: %+v", sig)
+	}
+	if _, ok := cache.sigs[""]; !ok {
+		t.Fatalf("the settled root was not cached; the refusal must be scoped to the affected directory")
 	}
 }
 

--- a/tests/corpusfs/scancache_mtime_667_test.go
+++ b/tests/corpusfs/scancache_mtime_667_test.go
@@ -1,0 +1,312 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+)
+
+// Regression suite for #667: the scan cache compared a directory's mtime and its
+// children's mtimes at SECOND resolution, so a change that landed inside the
+// recorded Unix second read as no change at all.
+//
+// Every timestamp below is set with os.Chtimes. Nothing here waits on the clock,
+// and nothing depends on how fast the test host is.
+
+// anchor667 is a fixed instant with a zero nanosecond part, so a test can place a
+// second write at a chosen offset INSIDE the same Unix second. It is years in the
+// past, which also makes any directory stamped with it "settled" (see
+// mtimeSettleWindow), so these tests exercise the mtime comparison rather than the
+// settle guard. TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd covers
+// the guard.
+var anchor667 = time.Date(2021, 3, 4, 5, 6, 7, 0, time.UTC)
+
+// setMTime667 stamps a path with an exact instant and confirms the filesystem kept
+// it. The confirmation matters: a filesystem that silently truncated the stamp
+// would make a test pass for the wrong reason.
+func setMTime667(t *testing.T, path string, ts time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, ts, ts); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if !info.ModTime().Equal(ts) {
+		t.Skipf("filesystem does not keep the requested mtime for %s: want %s got %s",
+			path, ts, info.ModTime())
+	}
+}
+
+// requireSubSecondMTime667 skips the calling test when the filesystem under root
+// cannot hold a sub-second mtime. A test that needs two writes inside one second
+// to be distinguishable has nothing to assert on such a filesystem.
+func requireSubSecondMTime667(t *testing.T, root string) {
+	t.Helper()
+	probe := filepath.Join(root, ".mtime-probe-667")
+	mustWrite(t, probe, []byte("probe"))
+	defer func() { _ = os.Remove(probe) }()
+	ts := anchor667.Add(123 * time.Millisecond)
+	if err := os.Chtimes(probe, ts, ts); err != nil {
+		t.Skipf("chtimes probe: %v", err)
+	}
+	info, err := os.Stat(probe)
+	if err != nil {
+		t.Skipf("stat probe: %v", err)
+	}
+	if info.ModTime().UnixNano()%int64(time.Second) == 0 {
+		t.Skip("filesystem keeps whole-second mtimes only; sub-second cases are not observable here")
+	}
+}
+
+// TestScanCache667_SameSecondAddIsDiscovered is the user-visible defect.
+//
+// A file added to a directory whose mtime stays in the recorded Unix second was
+// never enumerated. Discovery reported the corpus as if the file did not exist,
+// and it stayed invisible until something else changed that directory.
+func TestScanCache667_SameSecondAddIsDiscovered(t *testing.T) {
+	root := t.TempDir()
+	requireSubSecondMTime667(t, root)
+	dir := filepath.Join(root, "dir")
+	mustWrite(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+
+	// Age the tree so the first walk is allowed to cache it.
+	setMTime667(t, dir, anchor667)
+	setMTime667(t, root, anchor667)
+
+	cache := newFakeScanCache()
+	if got := relPaths(walkWith(t, root, cache)); len(got) != 1 {
+		t.Fatalf("first walk: got %v want [dir/a.txt]", got)
+	}
+	if cache.stores == 0 {
+		t.Fatalf("first walk stored no signature, so this test cannot observe a cache hit")
+	}
+
+	// Add a file, then put the directory mtime back inside the SAME Unix second at
+	// a later nanosecond. This is what a 1-second-granularity clock reading would
+	// look like for two writes in one second.
+	mustWrite(t, filepath.Join(dir, "b.txt"), []byte("beta"))
+	setMTime667(t, dir, anchor667.Add(700*time.Millisecond))
+
+	got := relPaths(walkWith(t, root, cache))
+	want := []string{"dir/a.txt", "dir/b.txt"}
+	assertRelPaths667(t, "second walk", got, want)
+}
+
+// TestScanCache667_SameSizeSameSecondEditIsReObserved constructs the exact case
+// the issue names: same size, same Unix second, different bytes.
+//
+// The cached child entry matched on (size, second), so the directory kept its
+// cache hit and the cache kept its stale stamp for that file. Both must change:
+// the directory is re-read, and the signature now records the new mtime.
+func TestScanCache667_SameSizeSameSecondEditIsReObserved(t *testing.T) {
+	root := t.TempDir()
+	requireSubSecondMTime667(t, root)
+	dir := filepath.Join(root, "dir")
+	target := filepath.Join(dir, "a.txt")
+	mustWrite(t, target, []byte("AAAAA"))
+
+	setMTime667(t, target, anchor667)
+	setMTime667(t, dir, anchor667)
+	setMTime667(t, root, anchor667)
+
+	cache := newFakeScanCache()
+	_ = walkWith(t, root, cache)
+	if cache.stores == 0 {
+		t.Fatalf("first walk stored no signature, so this test cannot observe a cache hit")
+	}
+
+	// Same length, different bytes, mtime moved only below the second.
+	mustWrite(t, target, []byte("BBBBB"))
+	edited := anchor667.Add(400 * time.Millisecond)
+	setMTime667(t, target, edited)
+	setMTime667(t, dir, anchor667) // an in-place write leaves the parent stamp alone
+
+	cache.hits, cache.misses, cache.stores, cache.lookups = 0, 0, 0, 0
+	assertRelPaths667(t, "second walk", relPaths(walkWith(t, root, cache)), []string{"dir/a.txt"})
+
+	if cache.stores == 0 {
+		t.Fatalf("the edited file was accepted as unchanged: the directory was served from cache (stores=0)")
+	}
+	sig, ok := cache.sigs["dir"]
+	if !ok || len(sig.Entries) != 1 {
+		t.Fatalf("no refreshed signature for dir: %+v", sig)
+	}
+	if got, want := sig.Entries[0].MTimeUnixNano, edited.UnixNano(); got != want {
+		t.Fatalf("cache kept a stale stamp for the edited file: got %d want %d", got, want)
+	}
+}
+
+// TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd covers what nanosecond
+// comparison alone cannot: a filesystem whose mtime granularity is a whole second
+// (ext3, many NFS mounts) or two seconds (FAT32).
+//
+// On such a filesystem both writes below produce the SAME stamp, so no comparison
+// of stamps can tell them apart. The settle guard is what saves it: a directory
+// whose stamp is not yet older than the coarsest granularity is not cached at all,
+// so the next walk reads it and sees the new file.
+//
+// The coarse filesystem is simulated by stamping the directory with the current
+// second truncated to a whole second, which is exactly what such a filesystem
+// would report for a write happening now.
+func TestScanCache667_CoarseTimestampFilesystemStillSeesAnAdd(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "dir")
+	mustWrite(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+
+	bucket := time.Now().Truncate(time.Second)
+	setMTime667(t, dir, bucket)
+	setMTime667(t, root, bucket)
+
+	cache := newFakeScanCache()
+	if got := relPaths(walkWith(t, root, cache)); len(got) != 1 {
+		t.Fatalf("first walk: got %v want [dir/a.txt]", got)
+	}
+
+	// A write later in the same second, reported by the same coarse clock: the
+	// stamp does not move at all.
+	mustWrite(t, filepath.Join(dir, "b.txt"), []byte("beta"))
+	setMTime667(t, dir, bucket)
+
+	got := relPaths(walkWith(t, root, cache))
+	assertRelPaths667(t, "second walk", got, []string{"dir/a.txt", "dir/b.txt"})
+}
+
+// TestScanCache667_FreshlyWrittenDirectoryIsNotCached pins the settle guard
+// directly. A directory written moments ago cannot be cached safely, because a
+// further write in the same timestamp tick would leave its stamp unchanged.
+func TestScanCache667_FreshlyWrittenDirectoryIsNotCached(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "dir", "a.txt"), []byte("alpha"))
+
+	cache := newFakeScanCache()
+	if got := relPaths(walkWith(t, root, cache)); len(got) != 1 {
+		t.Fatalf("walk: got %v want [dir/a.txt]", got)
+	}
+	if cache.stores != 0 {
+		t.Fatalf("a just-written tree was cached (stores=%d); its stamp is still inside the ambiguity window", cache.stores)
+	}
+}
+
+// TestScanCache667_SettledTreeKeepsTheCheapPath is the false-positive guard. The
+// fix must not cost the case the cache exists for: an unchanged, settled corpus
+// is still served entirely from the cache, with no directory re-read and no
+// re-store.
+func TestScanCache667_SettledTreeKeepsTheCheapPath(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	mustWrite(t, filepath.Join(root, "sub", "b.txt"), []byte("beta"))
+	mustWrite(t, filepath.Join(root, "sub", "deep", "c.txt"), []byte("gamma"))
+	settleDirs667(t, root)
+
+	cache := newFakeScanCache()
+	first := relPaths(walkWith(t, root, cache))
+	if cache.stores != 3 {
+		t.Fatalf("settled tree: want a signature for all 3 directories, got %d", cache.stores)
+	}
+
+	cache.hits, cache.misses, cache.stores, cache.lookups = 0, 0, 0, 0
+	second := relPaths(walkWith(t, root, cache))
+
+	assertRelPaths667(t, "re-walk", second, first)
+	if cache.misses != 0 {
+		t.Fatalf("settled unchanged tree: want 0 cache misses, got %d (hits=%d)", cache.misses, cache.hits)
+	}
+	if cache.hits == 0 {
+		t.Fatalf("settled unchanged tree: want cache hits on the re-walk, got 0")
+	}
+	if cache.stores != 0 {
+		t.Fatalf("settled unchanged tree: want no re-stores, got %d", cache.stores)
+	}
+}
+
+// TestScanCache667_SecondsSignatureIsNotTrusted covers the upgrade path. A
+// signature written by an older build states seconds where this build reads
+// nanoseconds. It must not be trusted, and the directory must be re-read and
+// re-stored with the full precision.
+func TestScanCache667_SecondsSignatureIsNotTrusted(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
+	settleDirs667(t, root)
+
+	info, err := os.Stat(root)
+	if err != nil {
+		t.Fatalf("stat root: %v", err)
+	}
+	cache := newFakeScanCache()
+	cache.sigs[""] = corpusfsSecondsSignature667(t, root, info.ModTime())
+
+	got := relPaths(walkWith(t, root, cache))
+	assertRelPaths667(t, "walk over a seconds signature", got, []string{"a.txt"})
+	if cache.stores == 0 {
+		t.Fatalf("a seconds signature was trusted: the directory was served from cache")
+	}
+	if got, want := cache.sigs[""].DirMTimeUnixNano, info.ModTime().UnixNano(); got != want {
+		t.Fatalf("signature not rewritten in nanoseconds: got %d want %d", got, want)
+	}
+}
+
+// settleDirs667 stamps every directory in the tree with a fixed instant years in
+// the past, so the walk is allowed to cache them. Only a directory's own stamp
+// gates the child-list cache, so files are left alone. It runs after the files are
+// written, because writing a file bumps its parent's stamp.
+func settleDirs667(t *testing.T, root string) {
+	t.Helper()
+	var dirs []string
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	for _, dir := range dirs {
+		setMTime667(t, dir, anchor667)
+	}
+}
+
+// corpusfsSecondsSignature667 builds the signature an older build would have
+// written for dir: every timestamp in whole SECONDS, in the fields this build
+// reads as nanoseconds.
+func corpusfsSecondsSignature667(t *testing.T, dir string, dirMTime time.Time) corpusfs.CachedDirSignature {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	sig := corpusfs.CachedDirSignature{DirMTimeUnixNano: dirMTime.Unix()}
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			t.Fatalf("stat %s: %v", e.Name(), err)
+		}
+		sig.Entries = append(sig.Entries, corpusfs.CachedDirEntry{
+			Name:          e.Name(),
+			IsDir:         e.IsDir(),
+			SizeBytes:     info.Size(),
+			MTimeUnixNano: info.ModTime().Unix(),
+			Mode:          uint32(info.Mode()),
+		})
+	}
+	return sig
+}
+
+func assertRelPaths667(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %v want %v", label, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s: got %v want %v", label, got, want)
+		}
+	}
+}

--- a/tests/corpusfs/scancache_walk_test.go
+++ b/tests/corpusfs/scancache_walk_test.go
@@ -68,11 +68,17 @@ func walkWith(t *testing.T, root string, cache corpusfs.ScanCache) []corpusfs.Di
 // TestScanCache_UnchangedTreeSkipsReWalk verifies that a second walk of an
 // unchanged tree is served from the cache (every directory is a hit and no
 // directory is re-stored) and returns byte-identical discovery results.
+//
+// The directory stamps are aged first (#667). A directory written milliseconds ago
+// is deliberately NOT cached: a further write in the same timestamp tick would
+// leave its stamp unchanged, so the cached child list could hide a new file. This
+// test used to walk a tree it had just created, which is exactly that window.
 func TestScanCache_UnchangedTreeSkipsReWalk(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "a.txt"), []byte("alpha"))
 	mustWrite(t, filepath.Join(root, "sub", "b.txt"), []byte("beta"))
 	mustWrite(t, filepath.Join(root, "sub", "deep", "c.txt"), []byte("gamma"))
+	settleDirs667(t, root)
 
 	cache := newFakeScanCache()
 

--- a/tests/ingest/scan_cache_mtime_667_test.go
+++ b/tests/ingest/scan_cache_mtime_667_test.go
@@ -1,0 +1,158 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Regression suite for #667, end to end through a real scan with the sqlite scan
+// cache enabled. The corpusfs suite pins the walker; this pins what an operator
+// sees: which documents the run indexed.
+//
+// Every timestamp is set with os.Chtimes. Nothing waits on the clock.
+
+// anchor667 is a fixed instant with a zero nanosecond part, so a second write can
+// be placed inside the same Unix second. It is years in the past, so a directory
+// stamped with it is settled and therefore cacheable.
+var anchor667 = time.Date(2021, 3, 4, 5, 6, 7, 0, time.UTC)
+
+func setMTime667(t *testing.T, path string, ts time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, ts, ts); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if !info.ModTime().Equal(ts) {
+		t.Skipf("filesystem does not keep the requested mtime for %s: want %s got %s", path, ts, info.ModTime())
+	}
+}
+
+// TestServiceRun667_SameSecondAddIsIndexed is the operator-visible defect.
+//
+// A file added to a directory whose stamp stayed in the recorded Unix second was
+// never enumerated, so the run never indexed it, never skipped it, and never
+// errored on it. `search` and `ask` could not reach it, and `dir2mcp status`
+// reported a clean, complete scan. It stayed that way until something else changed
+// that directory or the cache file was deleted.
+func TestServiceRun667_SameSecondAddIsIndexed(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "dir")
+	mustWriteFile(t, filepath.Join(dir, "a.txt"), []byte("alpha text"))
+	setMTime667(t, dir, anchor667)
+	setMTime667(t, root, anchor667)
+
+	cfg := scanCacheTestConfig(t, root)
+
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if _, ok := activeDocPaths(st)["dir/a.txt"]; !ok {
+		t.Fatalf("first run did not index dir/a.txt: %v", activeDocPaths(st))
+	}
+
+	// Add a file and put the directory stamp back inside the same Unix second.
+	mustWriteFile(t, filepath.Join(dir, "b.txt"), []byte("beta text"))
+	setMTime667(t, dir, anchor667.Add(700*time.Millisecond))
+
+	st2 := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st2).Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	active := activeDocPaths(st2)
+	if _, ok := active["dir/b.txt"]; !ok {
+		t.Fatalf("a file added inside the recorded mtime second was never indexed: %v", active)
+	}
+	if _, ok := active["dir/a.txt"]; !ok {
+		t.Fatalf("the pre-existing file was lost: %v", active)
+	}
+}
+
+// TestServiceRun667_CoarseTimestampAddIsIndexed is the same defect on a filesystem
+// whose mtime granularity is a whole second or coarser, where no comparison of
+// stamps can separate the two writes. The settle guard is what covers it: a
+// directory whose stamp is still inside the ambiguity window is not cached, so the
+// next run reads it and finds the new file.
+//
+// The coarse filesystem is simulated by stamping the directory with the current
+// second truncated to a whole second, which is what such a filesystem reports for
+// a write happening now.
+func TestServiceRun667_CoarseTimestampAddIsIndexed(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "dir")
+	mustWriteFile(t, filepath.Join(dir, "a.txt"), []byte("alpha text"))
+
+	bucket := time.Now().Truncate(time.Second)
+	setMTime667(t, dir, bucket)
+	setMTime667(t, root, bucket)
+
+	cfg := scanCacheTestConfig(t, root)
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+
+	// A write later in the same second leaves the coarse stamp exactly where it was.
+	mustWriteFile(t, filepath.Join(dir, "b.txt"), []byte("beta text"))
+	setMTime667(t, dir, bucket)
+
+	st2 := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st2).Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if _, ok := activeDocPaths(st2)["dir/b.txt"]; !ok {
+		t.Fatalf("a file added inside a coarse mtime tick was never indexed: %v", activeDocPaths(st2))
+	}
+}
+
+// TestServiceRun667_SameSizeSameSecondEditUpdatesContentHash constructs the exact
+// case the issue names (same size, same Unix second, different bytes) and pins the
+// answer at the level an operator cares about: the stored content_hash.
+//
+// This case is NOT a content-staleness bug, and this test passes on main. The scan
+// cache never gated the byte read: a validated child is emitted with its live stat,
+// and SPEC §7.8 makes content_hash the confirm step for a local corpus, so the
+// edit is caught by the hash whatever the cache decided. The test is here to keep
+// that true, and to record that the same root cause is only a correctness defect
+// where a cached child LIST is served, not where a cached child stamp is compared.
+func TestServiceRun667_SameSizeSameSecondEditUpdatesContentHash(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "dir")
+	target := filepath.Join(dir, "a.txt")
+	mustWriteFile(t, target, []byte("AAAAAAAAAA"))
+	setMTime667(t, target, anchor667)
+	setMTime667(t, dir, anchor667)
+	setMTime667(t, root, anchor667)
+
+	cfg := scanCacheTestConfig(t, root)
+	st := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st).Run(context.Background()); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	before := st.docs["dir/a.txt"].ContentHash
+	if before == "" {
+		t.Fatalf("first run recorded no content hash for dir/a.txt")
+	}
+
+	mustWriteFile(t, target, []byte("BBBBBBBBBB")) // same length, different bytes
+	setMTime667(t, target, anchor667.Add(400*time.Millisecond))
+	setMTime667(t, dir, anchor667)
+
+	st2 := newMemoryStore()
+	if err := mustNewIngestService(t, cfg, st2).Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	after := st2.docs["dir/a.txt"].ContentHash
+	if after == "" {
+		t.Fatalf("dir/a.txt is missing after the edit")
+	}
+	if after == before {
+		t.Fatalf("a same-size edit inside one mtime second was treated as unchanged: hash still %s", after)
+	}
+}

--- a/tests/ingest/scan_cache_mtime_667_test.go
+++ b/tests/ingest/scan_cache_mtime_667_test.go
@@ -12,7 +12,11 @@ import (
 // cache enabled. The corpusfs suite pins the walker; this pins what an operator
 // sees: which documents the run indexed.
 //
-// Every timestamp is set with os.Chtimes. Nothing waits on the clock.
+// Every timestamp is set with os.Chtimes, and no assertion depends on how long the
+// test took. A directory that must be SETTLED is stamped years in the past
+// (anchor667); a directory that must be UNSETTLED is stamped an hour ahead
+// (unsettledStamp667). Stamping "now" would make the outcome turn on whether the
+// scan started inside the settle window.
 
 // anchor667 is a fixed instant with a zero nanosecond part, so a second write can
 // be placed inside the same Unix second. It is years in the past, so a directory
@@ -74,21 +78,37 @@ func TestServiceRun667_SameSecondAddIsIndexed(t *testing.T) {
 	}
 }
 
+// unsettledStamp667 returns a stamp that no scan in this test run can consider
+// settled, whatever the host does between the Chtimes call and the scan.
+//
+// "Not settled" is ONE predicate with two ways in: a stamp too RECENT (what a
+// coarse-granularity filesystem reports for a write happening now) and a stamp in
+// the FUTURE (a corpus on a mount whose clock runs ahead of this host). Both reach
+// the same comparison.
+//
+// Using time.Now() instead would make the assertion depend on the scan starting
+// within the settle window. A host that stalled for longer would settle the
+// directory, a CORRECT walker would cache it, and the test would go red with no
+// defect present.
+func unsettledStamp667() time.Time {
+	return time.Now().Add(time.Hour).Truncate(time.Second)
+}
+
 // TestServiceRun667_CoarseTimestampAddIsIndexed is the same defect on a filesystem
 // whose mtime granularity is a whole second or coarser, where no comparison of
 // stamps can separate the two writes. The settle guard is what covers it: a
-// directory whose stamp is still inside the ambiguity window is not cached, so the
-// next run reads it and finds the new file.
+// directory whose stamp is not settled is not cached, so the next run reads it and
+// finds the new file.
 //
-// The coarse filesystem is simulated by stamping the directory with the current
-// second truncated to a whole second, which is what such a filesystem reports for
-// a write happening now.
+// The coarse filesystem is simulated in the part that matters and can be
+// controlled: the stamp does not move across the add, and it is not settled when
+// the first scan reads it. See unsettledStamp667 for why the stamp is not "now".
 func TestServiceRun667_CoarseTimestampAddIsIndexed(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "dir")
 	mustWriteFile(t, filepath.Join(dir, "a.txt"), []byte("alpha text"))
 
-	bucket := time.Now().Truncate(time.Second)
+	bucket := unsettledStamp667()
 	setMTime667(t, dir, bucket)
 	setMTime667(t, root, bucket)
 
@@ -98,7 +118,7 @@ func TestServiceRun667_CoarseTimestampAddIsIndexed(t *testing.T) {
 		t.Fatalf("first Run: %v", err)
 	}
 
-	// A write later in the same second leaves the coarse stamp exactly where it was.
+	// A write later in the same tick leaves the coarse stamp exactly where it was.
 	mustWriteFile(t, filepath.Join(dir, "b.txt"), []byte("beta text"))
 	setMTime667(t, dir, bucket)
 

--- a/tests/scancache/scancache_test.go
+++ b/tests/scancache/scancache_test.go
@@ -13,10 +13,14 @@ func TestSQLiteCache_StoreAndLookupRoundTrip(t *testing.T) {
 	c := scancache.Open(path)
 	defer func() { _ = c.Close() }()
 
+	// Nanosecond values with a non-zero sub-second part (#667). A seconds-magnitude
+	// value would round-trip even through a column that silently lost precision.
+	const dirNano = int64(1700000000_123456789)
+	const fileNano = int64(1699999999_987654321)
 	sig := corpusfs.CachedDirSignature{
-		DirMTimeUnix: 1700000000,
+		DirMTimeUnixNano: dirNano,
 		Entries: []corpusfs.CachedDirEntry{
-			{Name: "a.txt", SizeBytes: 5, MTimeUnix: 1699999999, Mode: 0o644},
+			{Name: "a.txt", SizeBytes: 5, MTimeUnixNano: fileNano, Mode: 0o644},
 			{Name: "sub", IsDir: true},
 		},
 	}
@@ -31,14 +35,17 @@ func TestSQLiteCache_StoreAndLookupRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatalf("LookupDir: expected hit")
 	}
-	if got.DirMTimeUnix != sig.DirMTimeUnix {
-		t.Fatalf("mtime mismatch: got %d want %d", got.DirMTimeUnix, sig.DirMTimeUnix)
+	if got.DirMTimeUnixNano != sig.DirMTimeUnixNano {
+		t.Fatalf("mtime mismatch: got %d want %d", got.DirMTimeUnixNano, sig.DirMTimeUnixNano)
 	}
 	if len(got.Entries) != 2 {
 		t.Fatalf("entry count mismatch: got %d want 2", len(got.Entries))
 	}
 	if got.Entries[0].Name != "a.txt" || got.Entries[0].SizeBytes != 5 || got.Entries[0].Mode != 0o644 {
 		t.Fatalf("file entry round-trip mismatch: %+v", got.Entries[0])
+	}
+	if got.Entries[0].MTimeUnixNano != fileNano {
+		t.Fatalf("child mtime lost precision: got %d want %d", got.Entries[0].MTimeUnixNano, fileNano)
 	}
 	if !got.Entries[1].IsDir || got.Entries[1].Name != "sub" {
 		t.Fatalf("dir entry round-trip mismatch: %+v", got.Entries[1])
@@ -62,11 +69,11 @@ func TestSQLiteCache_StoreUpsertsAndPersists(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "scan.sqlite")
 
 	c := scancache.Open(path)
-	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnix: 1}); err != nil {
+	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnixNano: 1}); err != nil {
 		t.Fatalf("first store: %v", err)
 	}
 	// Overwrite the same key with a new mtime.
-	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnix: 2}); err != nil {
+	if err := c.StoreDir("d", corpusfs.CachedDirSignature{DirMTimeUnixNano: 2}); err != nil {
 		t.Fatalf("upsert store: %v", err)
 	}
 	if err := c.Close(); err != nil {
@@ -81,8 +88,8 @@ func TestSQLiteCache_StoreUpsertsAndPersists(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("reopened LookupDir: ok=%v err=%v", ok, err)
 	}
-	if got.DirMTimeUnix != 2 {
-		t.Fatalf("upsert not persisted: got mtime %d want 2", got.DirMTimeUnix)
+	if got.DirMTimeUnixNano != 2 {
+		t.Fatalf("upsert not persisted: got mtime %d want 2", got.DirMTimeUnixNano)
 	}
 }
 

--- a/tests/scancache/schema_migration_667_test.go
+++ b/tests/scancache/schema_migration_667_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/scancache"
+
+	_ "modernc.org/sqlite" // same pure-Go driver the cache itself uses.
+)
+
+// TestSQLiteCache667_LegacySecondsTableIsDropped covers the upgrade path for #667.
+//
+// The old table stored whole seconds in `dir_signatures.dir_mtime_unix`. This build
+// reads nanoseconds, so every one of those rows states an instant it does not mean.
+// Such a row is harmless (the walker compares it, sees a mismatch, and re-reads the
+// directory), but an operator upgrading with a warm cache would carry one dead row
+// per directory forever. The cache holds no authoritative state, so it is dropped.
+func TestSQLiteCache667_LegacySecondsTableIsDropped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.sqlite")
+	seedLegacyCache667(t, path)
+
+	// Open through the cache: the legacy row must not be served.
+	c := scancache.Open(path)
+	if _, ok, err := c.LookupDir("docs"); err != nil || ok {
+		t.Fatalf("legacy row survived the upgrade: ok=%v err=%v", ok, err)
+	}
+	assertNanoRoundTrip667(t, c)
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	assertTableAbsent667(t, path, "dir_signatures")
+}
+
+// seedLegacyCache667 writes a cache file exactly as the previous build left it: a
+// `dir_signatures` table holding whole seconds.
+func seedLegacyCache667(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close legacy db: %v", err)
+		}
+	}()
+	for _, stmt := range []string{
+		`CREATE TABLE dir_signatures (
+  rel_dir        TEXT PRIMARY KEY,
+  dir_mtime_unix INTEGER NOT NULL,
+  entries_json   TEXT NOT NULL
+);`,
+		`INSERT INTO dir_signatures
+		 VALUES ('docs', 1700000000, '[{"Name":"a.txt","SizeBytes":5,"MTimeUnix":1699999999}]');`,
+	} {
+		if _, err := db.ExecContext(context.Background(), stmt); err != nil {
+			t.Fatalf("seed legacy db: %v", err)
+		}
+	}
+}
+
+// assertNanoRoundTrip667 confirms the upgraded file still works and keeps full
+// nanosecond precision.
+func assertNanoRoundTrip667(t *testing.T, c *scancache.SQLiteCache) {
+	t.Helper()
+	want := corpusfs.CachedDirSignature{
+		DirMTimeUnixNano: 1700000000_123456789,
+		Entries: []corpusfs.CachedDirEntry{
+			{Name: "a.txt", SizeBytes: 5, MTimeUnixNano: 1699999999_987654321},
+		},
+	}
+	if err := c.StoreDir("docs", want); err != nil {
+		t.Fatalf("StoreDir after upgrade: %v", err)
+	}
+	got, ok, err := c.LookupDir("docs")
+	if err != nil || !ok {
+		t.Fatalf("LookupDir after upgrade: ok=%v err=%v", ok, err)
+	}
+	if got.DirMTimeUnixNano != want.DirMTimeUnixNano {
+		t.Fatalf("dir mtime after upgrade: got %d want %d", got.DirMTimeUnixNano, want.DirMTimeUnixNano)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].MTimeUnixNano != want.Entries[0].MTimeUnixNano {
+		t.Fatalf("child mtime after upgrade: got %+v want %+v", got.Entries, want.Entries)
+	}
+}
+
+// assertTableAbsent667 confirms the named table is gone, not merely unused.
+func assertTableAbsent667(t *testing.T, path, table string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var name string
+	err = db.QueryRowContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`, table).Scan(&name)
+	if err == nil {
+		t.Fatalf("legacy table %q still present after the upgrade", name)
+	}
+	if err != sql.ErrNoRows {
+		t.Fatalf("query sqlite_master: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #667.

## What an operator saw

**A file in the corpus that no tool could reach, and a scan that reported nothing wrong.**

With `ingest.scan_cache: true`, a file created in the same Unix second as the recorded directory mtime was never enumerated. The run did not index it, did not skip it, and did not error on it. `dir2mcp status` reported `scanned`, `skipped` and `errors` exactly as if the file did not exist, `search` could not return it, and it appeared in no `skip_reasons` bucket and no `recent_failures` row.

**How long it lasted.** Until something else changed that directory: another add, a remove, or a rename. An in-place edit of the missing file does not qualify, because an in-place write leaves the parent directory's stamp alone. So a file written into a settled archive directory could stay invisible for as long as that directory stayed settled, which for an archive is the normal state. Deleting the cache file (`StateDir/cache/scan.sqlite`) or turning the cache off also cleared it, but nothing told an operator to do either.

## The issue's premise, corrected

The issue predicted that a same-size edit inside one mtime second would leave the corpus serving OLD content. I measured that against `main` before writing code, and it does not happen. The scan cache never gated the byte read:

* a validated cached child is emitted with its **live** `os.Lstat`, so `DiscoveredFile` always carries the current size and mtime;
* SPEC §7.8 makes `content_hash` the confirm step for a `local`/`nfs` corpus, and `processDocument` computes it on every scan.

`TestServiceRun667_SameSizeSameSecondEditUpdatesContentHash` builds exactly that case (same length, same Unix second, different bytes) and **passes on `main`**. It is in the PR to keep that true, not as a regression proof.

The same root cause is a correctness defect in one place only: where a cached child **LIST** is served. There, the directory mtime is the sole evidence that no child was added, and at second resolution that evidence is wrong for a full second. That is the missed file above.

## The mechanism

### 1. Nanoseconds, not seconds

`walkDirFromCache`, `cachedChildMatches`, `processFullEntry` and `storeDirSignature` now compare and record `ModTime().UnixNano()`. `CachedDirEntry.MTimeUnix` became `MTimeUnixNano` and `CachedDirSignature.DirMTimeUnix` became `DirMTimeUnixNano`, so a truncating implementation cannot compile against the old name and quietly reopen the window.

This separates two writes in one second on ext4, APFS, XFS, btrfs and NTFS.

### 2. A directory's stamp must be SETTLED before its child list is cached

Nanoseconds alone are not enough, and this is the part that carries the fix.

A filesystem records an mtime with a finite granularity, so the stamp names a **bucket**, not an instant. The walk reads directory `D` at time `O`; `D`'s stamp is `M`. A file added at any later time `C` gives `D` a new stamp of `bucket(C)`. If `bucket(C) == M`, the add is invisible to **any** comparison of stamps, at any precision. On a filesystem with 1-second granularity (ext3, many NFS mounts) or 2-second granularity (FAT32: an SD card, a USB stick) that is the ordinary case, not a corner one.

`storeDirSignature` therefore refuses to store a signature unless `M <= O - 2s`. The proof: for any `C >= O`, `bucket(C) >= bucket(O) > M` whenever the granularity is at most 2 seconds, so a later add always moves the stamp. 2 seconds is the coarsest granularity in real use.

The guard is applied at **store** time rather than lookup time, so the cache never holds a row it would refuse to trust. Once stored, a signature stays trustworthy forever: the proof only needs the relation between `M` and the moment the child list was read, and both are fixed at that point. Nothing new is persisted, so the guard costs no schema field.

`O` is the **pre-read** instant, sampled before the `Stat` and carried alongside the mtime in `dirReadStamp`. That matters, and the second commit on this branch fixes it: measuring at store time instead is weaker by the duration of the read. If the listing takes seconds (a large directory on a slow NFS mount), a same-tick add landing during the read would pass a store-time guard, and it is also the one case the pre-read mtime comparison cannot see, so nothing else would refuse it. With the pre-read instant the arithmetic refuses it: a same-bucket add during the read forces `M == bucket(O)`, hence `M > O - 2s`, which fails the guard.

**A stamp in the future is not settled either**, so a corpus on a mount whose server clock runs ahead of this host loses the fast path and keeps the full read. That is the safe direction to fail in.

### 3. The sqlite table is renamed and the old one dropped

`dir_signatures(dir_mtime_unix)` becomes `dir_signatures_v2(dir_mtime_unix_nano)`. A row written by an older build states seconds where this build reads nanoseconds. Such a row was already harmless (the walker compares it, sees a mismatch, and re-reads the directory: the cache is self-healing by construction), but keeping it would leave one dead row per directory forever. The package doc already says the cache holds no authoritative state and is safe to delete at any time, so `DROP TABLE IF EXISTS` is the whole migration.

## The cost, measured

A scan cache exists so a scan does not re-read the whole corpus every time, so a fix that hashes more, or reads more, has to justify it. **This fix hashes nothing extra and reads no file bytes at all.** It changes only which directories take the `ReadDir` path.

**What the cache actually saves.** Worth stating plainly, because it bounds the cost of every decision below. Both paths `Lstat` every child: the full path does it in `processFullEntry`, the cached path in `validateCachedChildren`. The cache saves exactly one `os.ReadDir` plus one sort per directory. Measured on a 2000-entry directory (macOS, APFS, M4):

| path | per directory |
| --- | --- |
| `ReadDir` + sort + 2000 `Lstat` (full) | 33.5 ms |
| 2000 `Lstat` only (cached) | 25.0 ms |

So a cache hit saves about 25% of a directory pass, and a directory that falls back costs about 34% more than one that does not. The N stat calls dominate either way.

**Who pays, and how much.**

| corpus | effect |
| --- | --- |
| a settled archive (every directory's stamp older than 2s: the case the cache is for) | **nothing.** Every directory is cached and served from cache. `TestScanCache667_SettledTreeKeepsTheCheapPath` pins 0 misses, 0 re-stores. |
| a directory written to within 2s of the scan reaching it | one full read, and one more on the next scan (which then caches it). Bounded to the directories being written to. |
| a first scan of a corpus that was just copied in | no signature stored, so the cache warms on the second scan instead of the first. The first scan was a full walk anyway; only the caching of it is deferred. |
| a corpus on a mount whose clock runs ahead of this host | the cache does not engage. Correct, and as fast as `scan_cache: false`, which is the default. |

**The cheap path was kept for the common case and the cost pushed onto the ambiguous one**, which is what the task asked for. The alternative I rejected was to drop the child-list shortcut and always `ReadDir`; that is also sound, but it makes the cache pure overhead (both paths still `Lstat` every child), which effectively deletes an opt-in feature the issue did not ask to delete.

## SPEC: no dirstral-spec PR needed

I read the submodule before writing code.

* **§7.8 change-detection identity** pins the *pipeline's* signal: "`local` / `nfs`: the cheap pre-check is `(size, mtime)`; on a change, `content_hash` over the file body **confirms** before re-ingest." That path is untouched. `content_hash` is still computed on every local scan and is still the reprocess trigger.
* **§7.6 incremental indexing** keys on `content_hash` / `rep_hash` / `text_hash`. Unchanged.
* **§5.1 / §15.2 schema** pins `documents.mtime_unix` as an integer of **seconds**. `DiscoveredFile.MTimeUnix` still carries seconds and still comes from the live stat, so no persisted document field and no tool payload changes shape or precision.
* **§7.7 CorpusFS `list`** requires the backend to "enumerate the documents under the corpus root". A file the walk never returns is a violation of that requirement, so this PR enforces what the SPEC already demands.

The scan cache itself is not a SPEC concept. It is an internal, opt-in, disposable optimization (`ingest.scan_cache`, dir2mcp #267 item 5) whose only contract is that it must not change discovery output. Nanosecond precision and the settle window are both internal to that cache. No new config surface, no new error code, no new skip reason, no schema change to any persisted document field. **The submodule pointer is untouched.**

## Tests

New:

* `tests/corpusfs/scancache_mtime_667_test.go` (6 cases) — the walker.
* `tests/ingest/scan_cache_mtime_667_test.go` (3 cases) — end to end through a real scan with the sqlite cache.
* `tests/scancache/schema_migration_667_test.go` — the upgrade path, on a seeded legacy cache file.

Every timestamp is set with `os.Chtimes`, and **no assertion depends on how long the test took, in either direction.** That rule needed a fix in review, see below.

* A case that needs a directory **settled** stamps it `anchor667` (2021), so no amount of speed can unsettle it.
* A case that needs a directory **unsettled** stamps it an hour AHEAD (`unsettledStamp667`), so no amount of stalling can settle it. "Not settled" is one predicate with two ways in (a stamp too recent, a stamp in the future), so the future stamp reaches the same comparison.
* `"now"` is never used as a stamp.

`setMTime667` re-stats after each `Chtimes` and skips if the filesystem did not keep the stamp, so a test cannot pass for the wrong reason. `requireSubSecondMTime667` skips the sub-second cases on a filesystem that cannot express them.

Stress-run at `-count=20` (corpusfs) and `-count=10` (ingest) with no flake.

### Verified against `main`

`git stash` is banned in this repository (`refs/stash` is shared across worktrees). The files were copied to a uniquely named scratch directory, the tracked files reverted with `git checkout HEAD --`, the tests run, and everything restored afterwards.

`tests/ingest/scan_cache_mtime_667_test.go` names no new API, so it ran against `main` **unmodified**. The corpusfs and scancache files name the renamed fields, so they cannot compile there; the proof run used them with `MTimeUnixNano` → `MTimeUnix` and `DirMTimeUnixNano` → `DirMTimeUnix`, a faithful translation that changes no assertion.

| test | on `main` |
| --- | --- |
| `ServiceRun667_SameSecondAddIsIndexed` | **FAIL**: `a file added inside the recorded mtime second was never indexed: map[dir/a.txt:{}]` |
| `ServiceRun667_CoarseTimestampAddIsIndexed` | **FAIL**: `a file added inside a coarse mtime tick was never indexed: map[dir/a.txt:{}]` |
| `ScanCache667_SameSecondAddIsDiscovered` | **FAIL**: `got [dir/a.txt] want [dir/a.txt dir/b.txt]` |
| `ScanCache667_SameSizeSameSecondEditIsReObserved` | **FAIL**: `the edited file was accepted as unchanged: the directory was served from cache (stores=0)` |
| `ScanCache667_CoarseTimestampFilesystemStillSeesAnAdd` | **FAIL**: `got [dir/a.txt] want [dir/a.txt dir/b.txt]` |
| `ScanCache667_UnsettledDirectoryIsNotCached` | **FAIL**: `an unsettled directory was cached: {DirMTimeUnix:1786530102 ...}` |
| `ScanCache667_SecondsSignatureIsNotTrusted` | **FAIL**: `a seconds signature was trusted: the directory was served from cache` |
| `SQLiteCache667_LegacySecondsTableIsDropped` | **FAIL**: `legacy row survived the upgrade: ok=true` |
| `ScanCache667_SettledTreeKeepsTheCheapPath` | **PASS** (false-positive guard, as it must be) |
| `ServiceRun667_SameSizeSameSecondEditUpdatesContentHash` | **PASS** (see "the issue's premise, corrected") |

### One existing test changed

`TestScanCache_UnchangedTreeSkipsReWalk` walked a tree it had created milliseconds earlier and asserted that the second walk was fully cached. That is precisely the ambiguity window, so the assertion encoded the defect. It now ages the directory stamps first, which also removes its dependence on the wall clock. The two ingest scan-cache tests needed no change: they assert on documents, not on cache counters.

## Not in scope

* **A representable-range check on the mtime.** I wrote one (`UnixNano` is undefined outside 1678..2262, so two different instants could alias) and then removed it. The branch is unreachable: no mainstream filesystem reports a stamp before that range (ext4 clamps at 1901, APFS counts 64-bit nanoseconds), and a stamp after it is in the future, which the settle test already refuses. A test for it skipped on every filesystem it ran on, because `os.Chtimes(1600-01-01)` came back as `2184-07-20`. The reasoning is kept in the doc comment as a stated property rather than shipped as an untested branch.
* **`CachedDirEntry.Mode` is dead.** `emitCachedChildren` reads `p.lstat.Mode()`, never the cached value, so the field is stored and never used. Harmless, and removing it is a separate cleanup.
* **The sidecar fingerprint uses second-resolution mtimes** (`internal/ingest/sidecar.go`: `fmt.Sprintf("%s@%d", sc.RelPath, sc.MTimeUnix)`). A sidecar edited inside one second keeps its fingerprint. That is the same class of defect in a different subsystem, it is gated by `documents.mtime_unix`, which SPEC §5.1 pins to seconds, and fixing it needs its own issue.
* **A test for the pre-read instant.** The trigger needs a directory listing that takes more than two seconds, which a test cannot produce without a corpus of a size that does not belong in the suite. The change is strictly tighter than what it replaced, so no directory that was refused before is accepted now, and the existing settle tests show it does not over-refuse an ordinary settled directory.
* **A clock-free settle reference.** Git solves this exact problem ("racily clean" index entries) by comparing against the index file's own mtime, so both stamps come from one filesystem. dir2mcp cannot: the state directory is always local (§1.2) while the corpus may not be, and a CorpusFS is read-only (§7.7), so there is nowhere to place a probe. The guard uses the local wall clock. A corpus clock running AHEAD fails safe (no caching); a corpus clock more than 2 seconds BEHIND leaves a residual same-tick window. That is still a large improvement on `main`, where the window is a full second on every directory of every filesystem unconditionally.

## Review

`coderabbit review --committed --base main` could not run: `Review failed: A valid organization session is required`. `coderabbit auth status` reports `Plan: Free`, `Seat: not assigned` for `dirstral/yidakra`, so the CLI review is unavailable on this account.

The GitHub CodeRabbit bot first answered `Review limit reached` (free OSS quota). After a re-request it reviewed and returned **2 findings. Both were valid, both are fixed in commit 3, and both threads are resolved.** Greptile posted `Your trial has ended`, so it produced no findings.

**Finding 1: substantive behavior text in a pointer stub** (`docs/dual-machine-deployment.md`). Fixed by CUTTING the mechanism, not by moving it. The suggested action was to move it into `dirstral-spec/docs/` and leave a pointer; I did not, because the scan cache is not a spec concept, and pinning one backend's walker detail as normative behavior for every implementation is the wrong direction. **No dirstral-spec PR was opened.** The mechanism lives in the `mtimeSettleWindow` / `dirSignatureIsSettled` doc comments and the `IngestScanCache` field comment. The stub keeps one sentence on the deployment consequence.

**Finding 2: the settle-window tests could fail with no defect present.** This one contradicted a claim I had made above, and it was right. The unsettled cases stamped `time.Now().Truncate(time.Second)` and then needed the first pre-read within two seconds of it. A host stalling longer settles the directory, a CORRECT walker caches it, and the test goes red. That is the same failure shape this PR is about: an outcome decided by a timing coincidence rather than by the property under test. Fixed by controlling the input (see "Tests"). Three tests were affected; `FreshlyWrittenDirectoryIsNotCached` is renamed `UnsettledDirectoryIsNotCached` and now also proves the refusal is scoped to one directory. Both files were re-audited in both directions.

I also line-reviewed the diff myself, which produced two more changes:

1. The **pre-read instant** fix above (a real, reachable gap: commit 2).
2. A representable-range check on the mtime that I wrote, proved unreachable, and removed rather than ship untested. See "not in scope".

## Checklist

- [x] `make check` passes locally, including `gocyclo -over 15` (`storeDirSignature` grew, so the settle rule is extracted into `dirSignatureIsSettled`)
- [x] new behaviour has test coverage that fails against `main`, proven above
- [x] no test depends on real timing; every mtime is set explicitly
- [x] no secret and no file content is logged or persisted
- [x] `README.md` and `docs/` remain truthful (`docs/dual-machine-deployment.md` and the `IngestScanCache` doc comment both claimed the cache detected every add; both now state the rule)
- [x] no unrelated files changed, submodule pointer untouched
- [x] `coderabbit review` findings addressed: CLI unavailable (no seat), GitHub bot returned 2 findings, both fixed, both threads resolved
- [x] no assertion depends on elapsed time, in either direction (the finding-2 fix)
