### PR TITLE
fix(config): stop accepting two inert config surfaces in silence (#661, #655)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,25 @@ Use it for persistent, non‑sensitive settings such as connector definitions, d
 you might want to check into source control. Values defined here may be overridden at runtime by
 environment variables.
 
+A key that no setting claims does not fail the load. `dir2mcp up` prints one warning that
+names every unrecognized key, then starts, so a typo or a stale key from an older release
+is reported instead of being dropped in silence.
+
+#### Chunking keys
+
+```yaml
+chunking:
+  max_tokens: 0        # 0 = the chunker default
+  overlap_tokens: 0    # must be smaller than max_tokens when max_tokens is set
+```
+
+`chunking.strategy` is **not** a setting. Releases before this one accepted the key, saved
+it, and never read it: chunking is selected per document type (characters for text, line
+windows for code, time windows for a transcript), and the canonical spec defines no
+strategy selector. The key is now unrecognized, so a config that still carries it loads
+with the warning above and no longer publishes the key back into the saved config or the
+effective snapshot.
+
 ### Environment variables (overrides / secrets)
 
 Sensitive keys and temporary runtime overrides are supplied via environment variables. They take

--- a/README.md
+++ b/README.md
@@ -430,6 +430,43 @@ An extractor counts as *available* only when it can actually **run**, not merely
 - *Expected docling but the banner shows `mistral-ocr (fallback ...)`* — docling either isn't on `PATH` or is present-but-broken (it failed the `docling --version` functional check, e.g. an ABI-incompatible venv). Under `auto` a non-functional docling is skipped and the cascade continues to docling-serve/Mistral; fix the install (or use the `-full` track), or pin `extractor: docling` to turn the broken install into a loud error instead of a silent fallback.
 - *Wrong host's docling chosen / pointing at a custom binary* — set `ingest.docling.command` (`DIR2MCP_DOCLING_COMMAND`) to the command template; the resolved path is redacted from diagnostics. Confirm via the `extractor` row of `dir2mcp doctor` or `routing.json` in a support bundle.
 
+#### Per-format mode keys: validated, no runtime effect yet
+
+The config template also carries one mode key per format:
+
+```yaml
+ingest:
+  pdf:
+    mode: ocr          # off|ocr|auto
+  images:
+    mode: ocr_auto     # off|ocr_auto|ocr_on
+  audio:
+    mode: auto         # off|auto|on
+  archives:
+    mode: deep         # off|shallow|deep
+```
+
+Each of the four is a closed set. A value outside its set is rejected at startup
+with `CONFIG_INVALID`, so `ingest.archives.mode: shalow` fails instead of loading as
+if it had been understood. The value is also case-normalized, and an absent key keeps
+the default above.
+
+**No accepted value changes behavior yet.** The canonical spec lists the members of
+each set without defining what any member does, so dir2mcp validates them and waits
+for that definition rather than inventing one (see `dirstral-spec`). Until then, use
+the keys that do work:
+
+| Goal | Setting that works today |
+|---|---|
+| Turn PDF/image text extraction off | `ingest.extractor: off` |
+| Choose the PDF/image engine | `ingest.extractor` (table above) |
+| Turn audio/video transcription off | `stt.provider: off` |
+| Report a format nothing can read | `ingest.on_unsupported: strict` |
+
+Archive handling today expands the top level of an archive. An archive nested inside
+an archive is not expanded; it is recorded as a skipped document with
+`skip_reason=archive`, so the gap appears in the coverage report.
+
 ### docling extraction over HTTP (docling-serve)
 
 Instead of spawning the docling CLI per document, dir2mcp can call a long-running [**docling-serve**](https://github.com/docling-project/docling-serve) HTTP container. This is the same docling engine and produces **byte-identical** output (the same structured `DoclingDocument` → Markdown + region citations) — only the transport differs (spec 0.10.0 §7.4.B).

--- a/internal/cli/support_bundle_redact.go
+++ b/internal/cli/support_bundle_redact.go
@@ -149,7 +149,6 @@ var snapshotAllowedKeys = map[string]bool{
 
 	// Chunking and ingest routing — the settings an extraction/OCR bug report
 	// is actually triaged against.
-	"chunking_strategy":       true,
 	"chunking_max_tokens":     true,
 	"chunking_overlap_tokens": true,
 	"ingest_gitignore":        true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,9 +490,9 @@ type Config struct {
 	// CohereBaseURL overrides the Cohere API endpoint (self-hosted /
 	// proxied deployments and tests). Empty = provider default. Not a
 	// secret; persisted to the config snapshot.
-	CohereBaseURL         string
-	RerankModel           string
-	RerankCandidatePool   int
+	CohereBaseURL       string
+	RerankModel         string
+	RerankCandidatePool int
 	// `chunking.strategy` used to be accepted here as ChunkingStrategy. It is
 	// gone on purpose (issue #661). No runtime path ever read it, the canonical
 	// spec defines no chunking-strategy selector, and the chunker picks its
@@ -536,7 +536,21 @@ type Config struct {
 	// `node_modules` is blocked in retrieval as well
 	// (internal/retrieval/service.go defaultPathExcludes), so it needs a third
 	// edit.
-	IngestExcludeDirs  []string
+	IngestExcludeDirs []string
+	// IngestPDFMode / IngestImagesMode / IngestAudioMode / IngestArchivesMode are
+	// the per-format mode keys of the SPEC §16.2 config template
+	// (`ingest.pdf.mode`, `ingest.images.mode`, `ingest.audio.mode`,
+	// `ingest.archives.mode`). Each one is a CLOSED enum, listed with the
+	// template: off|ocr|auto, off|ocr_auto|ocr_on, off|auto|on and
+	// off|shallow|deep.
+	//
+	// Validate rejects a value outside the advertised set (issue #655), so a typo
+	// no longer loads. The ingestion runtime does NOT read these values yet, and
+	// that half of #655 is deliberately not implemented here: the canonical spec
+	// names the enum members without defining what any member DOES, so writing
+	// the behavior would author normative semantics this repository does not own
+	// (spec-first governance; compare dirstral-spec#68). The README says the same
+	// thing, so an operator is not told the modes work.
 	IngestPDFMode      string
 	IngestImagesMode   string
 	IngestAudioMode    string
@@ -4591,6 +4605,7 @@ func (c *Config) Validate() error {
 	for _, validate := range []func() error{
 		c.validateIngestOnUnsupported,
 		c.validateIngestExtractor,
+		c.validateIngestFormatModes,
 		c.validateIndexBackend,
 		// Before the provider-resolving gates (STT/media): an unrecognized
 		// provider `kind:` must fail here with its own root-cause CONFIG_INVALID
@@ -4911,19 +4926,75 @@ func (c *Config) validateMediaSubtitles() error {
 	return nil
 }
 
-// validateIngestExtractor normalizes IngestExtractor (defaulting empty)
-// and rejects any value outside auto/docling/docling-serve/mistral/off.
+// validateIngestExtractor normalizes IngestExtractor (defaulting empty) and
+// rejects any value outside auto/docling/docling-serve/pandoc/mistral/off. The
+// accepted set is the one the error message prints, so the two cannot drift.
 func (c *Config) validateIngestExtractor() error {
-	extractorMode := strings.ToLower(strings.TrimSpace(c.IngestExtractor))
-	if extractorMode == "" {
-		extractorMode = Default().IngestExtractor
+	normalized, err := normalizeClosedEnum("ingest.extractor", c.IngestExtractor, Default().IngestExtractor,
+		[]string{"auto", "docling", "docling-serve", "pandoc", "mistral", "off"})
+	if err != nil {
+		return err
 	}
-	switch extractorMode {
-	case "auto", "docling", "docling-serve", "pandoc", "mistral", "off":
-	default:
-		return fmt.Errorf("ingest.extractor must be one of auto, docling, docling-serve, pandoc, mistral, off: %q", c.IngestExtractor)
+	c.IngestExtractor = normalized
+	return nil
+}
+
+// normalizeClosedEnum lowercases and trims value, substitutes fallback for an
+// empty value, and returns an error naming key and the accepted set when the
+// result is outside allowed. It is the shared body of the small closed-enum
+// gates (ingest.extractor, ingest.on_unsupported, the per-format ingest modes),
+// so a new enum costs one line here instead of another switch chain, and the
+// gate that holds four of them stays inside the cyclomatic-complexity budget.
+func normalizeClosedEnum(key, value, fallback string, allowed []string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		normalized = fallback
 	}
-	c.IngestExtractor = extractorMode
+	for _, candidate := range allowed {
+		if normalized == candidate {
+			return normalized, nil
+		}
+	}
+	return "", fmt.Errorf("%s must be one of %s: %q", key, strings.Join(allowed, ", "), value)
+}
+
+// validateIngestFormatModes rejects a per-format ingest mode outside its
+// advertised enum (issue #655).
+//
+// The four keys were parsed, persisted and reported with meaningful defaults, and
+// nothing validated them: `ingest.archives.mode: shalow` loaded exactly as
+// happily as `deep`. That is the dangerous half for media and archives, because
+// an operator who mistypes a value believes a provider-cost or privacy setting is
+// in force when no value at all was understood.
+//
+// The gate lives in Validate(), not in the `up` command, for the reason
+// validateMCPPath gives: Validate() is the one gate every entry point runs (a
+// persisted config, the CLI flag overlay, and the save paths), so a value that
+// cannot be honored is refused wherever it is written, and no single command is
+// the only place that notices. It also runs after the CLI overrides are merged,
+// which is what the issue asks for.
+//
+// Each value is normalized in place, so the accepted set is closed and the stored
+// value is canonical (`OFF` becomes `off`).
+func (c *Config) validateIngestFormatModes() error {
+	defaults := Default()
+	for _, mode := range []struct {
+		key      string
+		value    *string
+		fallback string
+		allowed  []string
+	}{
+		{"ingest.pdf.mode", &c.IngestPDFMode, defaults.IngestPDFMode, []string{"off", "ocr", "auto"}},
+		{"ingest.images.mode", &c.IngestImagesMode, defaults.IngestImagesMode, []string{"off", "ocr_auto", "ocr_on"}},
+		{"ingest.audio.mode", &c.IngestAudioMode, defaults.IngestAudioMode, []string{"off", "auto", "on"}},
+		{"ingest.archives.mode", &c.IngestArchivesMode, defaults.IngestArchivesMode, []string{"off", "shallow", "deep"}},
+	} {
+		normalized, err := normalizeClosedEnum(mode.key, *mode.value, mode.fallback, mode.allowed)
+		if err != nil {
+			return err
+		}
+		*mode.value = normalized
+	}
 	return nil
 }
 
@@ -4931,16 +5002,12 @@ func (c *Config) validateIngestExtractor() error {
 // the lenient default) and rejects any value outside lenient/strict. It is the
 // §7.4.B.2 degradation-mode knob mirroring the tri-state opt-outs used elsewhere.
 func (c *Config) validateIngestOnUnsupported() error {
-	mode := strings.ToLower(strings.TrimSpace(c.IngestOnUnsupported))
-	if mode == "" {
-		mode = Default().IngestOnUnsupported
+	normalized, err := normalizeClosedEnum("ingest.on_unsupported", c.IngestOnUnsupported, Default().IngestOnUnsupported,
+		[]string{"lenient", "strict"})
+	if err != nil {
+		return err
 	}
-	switch mode {
-	case "lenient", "strict":
-	default:
-		return fmt.Errorf("ingest.on_unsupported must be one of lenient, strict: %q", c.IngestOnUnsupported)
-	}
-	c.IngestOnUnsupported = mode
+	c.IngestOnUnsupported = normalized
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -493,7 +493,15 @@ type Config struct {
 	CohereBaseURL         string
 	RerankModel           string
 	RerankCandidatePool   int
-	ChunkingStrategy      string
+	// `chunking.strategy` used to be accepted here as ChunkingStrategy. It is
+	// gone on purpose (issue #661). No runtime path ever read it, the canonical
+	// spec defines no chunking-strategy selector, and the chunker picks its
+	// strategy from the doc type (SPEC §7.5: characters for text, line windows
+	// for code, time windows for a transcript). The key is therefore an
+	// unrecognized key like any other typo: config load names it in a warning
+	// (issue #628) and it is no longer written to a generated config or snapshot.
+	// Do not re-add the field without a spec that says what a strategy value
+	// means and a chunker that reads it.
 	ChunkingMaxTokens     int
 	ChunkingOverlapTokens int
 
@@ -1165,7 +1173,6 @@ type fileConfig struct {
 	CohereBaseURL                      *string
 	RerankModel                        *string
 	RerankCandidatePool                *int
-	ChunkingStrategy                   *string
 	ChunkingMaxTokens                  *int
 	ChunkingOverlapTokens              *int
 	IngestGitignore                    *bool
@@ -1328,7 +1335,6 @@ type persistedConfig struct {
 	CohereBaseURL                      string        `yaml:"cohere_base_url"`
 	RerankModel                        string        `yaml:"rerank_model"`
 	RerankCandidatePool                int           `yaml:"rerank_candidate_pool"`
-	ChunkingStrategy                   string        `yaml:"chunking_strategy"`
 	ChunkingMaxTokens                  int           `yaml:"chunking_max_tokens"`
 	ChunkingOverlapTokens              int           `yaml:"chunking_overlap_tokens"`
 	IngestGitignore                    bool          `yaml:"ingest_gitignore"`
@@ -1581,7 +1587,6 @@ func Default() Config {
 		CohereBaseURL:             "",
 		RerankModel:               "rerank-v3.5",
 		RerankCandidatePool:       50,
-		ChunkingStrategy:          "",
 		ChunkingMaxTokens:         0,
 		ChunkingOverlapTokens:     0,
 		IngestGitignore:           true,
@@ -1750,7 +1755,6 @@ func buildPersistedConfig(cfg *Config) persistedConfig {
 		CohereBaseURL:                      cfg.CohereBaseURL,
 		RerankModel:                        cfg.RerankModel,
 		RerankCandidatePool:                cfg.RerankCandidatePool,
-		ChunkingStrategy:                   cfg.ChunkingStrategy,
 		ChunkingMaxTokens:                  cfg.ChunkingMaxTokens,
 		ChunkingOverlapTokens:              cfg.ChunkingOverlapTokens,
 		IngestGitignore:                    cfg.IngestGitignore,
@@ -2574,9 +2578,6 @@ func applyIngestFileParsed(cfg *Config, fc fileConfig) {
 
 // applyChunkingFileParsed copies the set chunking file fields onto cfg.
 func applyChunkingFileParsed(cfg *Config, fc fileConfig) {
-	if fc.ChunkingStrategy != nil {
-		cfg.ChunkingStrategy = *fc.ChunkingStrategy
-	}
 	if fc.ChunkingMaxTokens != nil {
 		cfg.ChunkingMaxTokens = *fc.ChunkingMaxTokens
 	}
@@ -3227,7 +3228,6 @@ var configKeyAliases = map[string]string{
 	"rerank.provider":                         "rerank_provider",
 	"rerank.model":                            "rerank_model",
 	"rerank_candidate_pool":                   "rerank.candidate_pool",
-	"chunking_strategy":                       "chunking.strategy",
 	"chunking_max_tokens":                     "chunking.max_tokens",
 	"chunking_overlap_tokens":                 "chunking.overlap_tokens",
 	"ingest_gitignore":                        "ingest.gitignore",
@@ -3744,8 +3744,6 @@ func setModelStringFileScalar(cfg *fileConfig, key, value string) {
 		cfg.IngestPandocCommand = strPtr(value)
 	case "rag.system_prompt":
 		cfg.RAGSystemPrompt = strPtr(value)
-	case "chunking.strategy":
-		cfg.ChunkingStrategy = strPtr(value)
 	case "retrieval.hyde.mode":
 		cfg.RetrievalHyDEMode = strPtr(value)
 	}
@@ -4052,7 +4050,6 @@ func marshalConfigYAML(cfg persistedConfig) ([]byte, error) {
 	writeScalar("cohere_base_url", cfg.CohereBaseURL)
 	writeScalar("rerank_model", cfg.RerankModel)
 	writeInt("rerank_candidate_pool", cfg.RerankCandidatePool)
-	writeScalar("chunking_strategy", cfg.ChunkingStrategy)
 	writeInt("chunking_max_tokens", cfg.ChunkingMaxTokens)
 	writeInt("chunking_overlap_tokens", cfg.ChunkingOverlapTokens)
 	writeComment(

--- a/tests/config/chunking_strategy_removed_661_test.go
+++ b/tests/config/chunking_strategy_removed_661_test.go
@@ -1,0 +1,122 @@
+package tests
+
+// chunking.strategy is no longer a recognized key: dir2mcp #661.
+//
+// The key was parsed, kept in the config struct, and written back to the config
+// file and the effective snapshot. No runtime path ever read it, so
+// `chunking.strategy: semantic` succeeded and chunking behavior did not change.
+// The canonical spec defines no chunking-strategy selector either (it is absent
+// from SPEC §16.2 and from bs-011), and the chunker selects its strategy from
+// the doc type (SPEC §7.5).
+//
+// So the key leaves the recognized surface. It is now an unrecognized key like
+// any other typo: load names it in a warning (#628) rather than accepting it in
+// silence, and no generated file carries it forward. A hard startup error was
+// rejected deliberately: #628 fixed exactly this class of problem with a
+// warning, on the stated ground that an unknown key must not break an existing
+// deployment.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// loadWithChunkingStrategy writes a config carrying the dead key in the given
+// spelling and loads it.
+func loadWithChunkingStrategy(t *testing.T, body string) config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dir2mcp.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	return cfg
+}
+
+// TestChunkingStrategy_FlatSpellingIsReportedUnrecognized is the headline case.
+// Before the fix the key was accepted without a word and did nothing.
+func TestChunkingStrategy_FlatSpellingIsReportedUnrecognized(t *testing.T) {
+	cfg := loadWithChunkingStrategy(t, "root_dir: .\nchunking_strategy: semantic\n")
+	got := warningsText(cfg)
+	if !strings.Contains(got, "unrecognized") || !strings.Contains(got, "chunking_strategy") {
+		t.Fatalf("a config setting chunking_strategy must be told the key is unrecognized; warnings: %q", got)
+	}
+}
+
+// TestChunkingStrategy_NestedSpellingIsReportedUnrecognized covers the canonical
+// nested spelling, which reaches the same setter table through the `chunking`
+// section.
+func TestChunkingStrategy_NestedSpellingIsReportedUnrecognized(t *testing.T) {
+	cfg := loadWithChunkingStrategy(t, "root_dir: .\nchunking:\n  strategy: semantic\n")
+	got := warningsText(cfg)
+	if !strings.Contains(got, "unrecognized") || !strings.Contains(got, "strategy") {
+		t.Fatalf("the nested chunking.strategy spelling must be reported too; warnings: %q", got)
+	}
+}
+
+// TestChunkingStrategy_LoadStillSucceeds pins the deliberate choice of a warning
+// over an error: an existing deployment that carries the dead key still starts
+// (#628), and the live chunking keys next to it still apply.
+func TestChunkingStrategy_LoadStillSucceeds(t *testing.T) {
+	cfg := loadWithChunkingStrategy(t,
+		"root_dir: .\nchunking_strategy: semantic\nchunking_max_tokens: 700\nchunking_overlap_tokens: 70\n")
+	if cfg.ChunkingMaxTokens != 700 || cfg.ChunkingOverlapTokens != 70 {
+		t.Fatalf("the recognized chunking keys must still apply: max=%d overlap=%d",
+			cfg.ChunkingMaxTokens, cfg.ChunkingOverlapTokens)
+	}
+}
+
+// TestChunkingStrategy_IsNotWrittenBack pins that no generated file carries the
+// dead knob forward. Before the fix every saved config and every effective
+// snapshot published a `chunking_strategy:` line, which advertised a knob that
+// did nothing.
+func TestChunkingStrategy_IsNotWrittenBack(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dir2mcp.yaml")
+	cfg := config.Default()
+	cfg.RootDir = dir
+	cfg.StateDir = filepath.Join(dir, ".dir2mcp")
+	if err := config.SaveFile(path, cfg); err != nil {
+		t.Fatalf("SaveFile: %v", err)
+	}
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if strings.Contains(string(saved), "chunking_strategy") {
+		t.Fatalf("a saved config must not publish chunking_strategy:\n%s", string(saved))
+	}
+}
+
+// TestChunkingStrategy_SnapshotDoesNotCarryIt is the same guarantee for the
+// effective-config snapshot, which is the file support bundles and `status`
+// report from.
+func TestChunkingStrategy_SnapshotDoesNotCarryIt(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	cfg := config.Default()
+	cfg.RootDir = dir
+	cfg.StateDir = stateDir
+	snapshotPath, err := config.SaveEffectiveSnapshot(cfg, config.SecretSourceMetadata{})
+	if err != nil {
+		t.Fatalf("SaveEffectiveSnapshot: %v", err)
+	}
+	snapshot, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if strings.Contains(string(snapshot), "chunking_strategy") {
+		t.Fatalf("the effective snapshot must not publish chunking_strategy:\n%s", string(snapshot))
+	}
+}

--- a/tests/config/ingest_format_modes_validation_655_test.go
+++ b/tests/config/ingest_format_modes_validation_655_test.go
@@ -1,0 +1,192 @@
+package tests
+
+// Per-format ingest modes are validated closed enums: dir2mcp #655.
+//
+// `ingest.pdf.mode`, `ingest.images.mode`, `ingest.audio.mode` and
+// `ingest.archives.mode` are advertised in the SPEC §16.2 config template as
+// closed sets (off|ocr|auto, off|ocr_auto|ocr_on, off|auto|on, off|shallow|deep).
+// Nothing validated them, so `ingest.archives.mode: shalow` loaded exactly as
+// happily as `deep`, and the operator could believe a provider-cost or privacy
+// setting was in force when no value at all had been understood.
+//
+// Validate() is the gate, so the check covers every entry point: a persisted
+// config, the CLI flag overlay and the save paths.
+//
+// What each accepted mode DOES is still not implemented, and that is deliberate.
+// The canonical spec names the enum members without defining the behavior of any
+// member, so implementing one would author normative semantics this repository
+// does not own. These tests therefore pin the validation contract only, and the
+// README states plainly that the modes have no runtime effect yet.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// ingestModeCase describes one key: its YAML spelling, a setter, every advertised
+// value, and a plausible typo.
+type ingestModeCase struct {
+	key      string
+	yamlKey  string
+	set      func(*config.Config, string)
+	get      func(config.Config) string
+	accepted []string
+	typo     string
+}
+
+func ingestModeCases() []ingestModeCase {
+	return []ingestModeCase{
+		{
+			key: "ingest.pdf.mode", yamlKey: "ingest_pdf_mode",
+			set: func(c *config.Config, v string) { c.IngestPDFMode = v },
+			get: func(c config.Config) string { return c.IngestPDFMode },
+			// `auto` is advertised; the typo is a value that looks reasonable.
+			accepted: []string{"off", "ocr", "auto"}, typo: "ocr_auto",
+		},
+		{
+			key: "ingest.images.mode", yamlKey: "ingest_images_mode",
+			set:      func(c *config.Config, v string) { c.IngestImagesMode = v },
+			get:      func(c config.Config) string { return c.IngestImagesMode },
+			accepted: []string{"off", "ocr_auto", "ocr_on"}, typo: "ocr",
+		},
+		{
+			key: "ingest.audio.mode", yamlKey: "ingest_audio_mode",
+			set:      func(c *config.Config, v string) { c.IngestAudioMode = v },
+			get:      func(c config.Config) string { return c.IngestAudioMode },
+			accepted: []string{"off", "auto", "on"}, typo: "yes",
+		},
+		{
+			key: "ingest.archives.mode", yamlKey: "ingest_archives_mode",
+			set:      func(c *config.Config, v string) { c.IngestArchivesMode = v },
+			get:      func(c config.Config) string { return c.IngestArchivesMode },
+			accepted: []string{"off", "shallow", "deep"}, typo: "shalow",
+		},
+	}
+}
+
+// TestIngestFormatModes_TypoIsRejected is the headline case. Each key gets a
+// plausible wrong value, including one borrowed from a NEIGHBOURING key's enum,
+// which is the mistake an operator is most likely to make.
+func TestIngestFormatModes_TypoIsRejected(t *testing.T) {
+	for _, tc := range ingestModeCases() {
+		cfg := config.Default()
+		tc.set(&cfg, tc.typo)
+		err := cfg.Validate()
+		if err == nil {
+			t.Errorf("%s=%q must be rejected; Validate returned no error", tc.key, tc.typo)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.key) {
+			t.Errorf("the error for %s must name the key so an operator can fix it; got %v", tc.key, err)
+		}
+		for _, accepted := range tc.accepted {
+			if !strings.Contains(err.Error(), accepted) {
+				t.Errorf("the error for %s must list the accepted value %q; got %v", tc.key, accepted, err)
+			}
+		}
+	}
+}
+
+// TestIngestFormatModes_AdvertisedValuesAreAccepted is the false-positive guard:
+// every value the canonical template advertises must validate. A gate that
+// refused a documented value would be worse than the missing check.
+func TestIngestFormatModes_AdvertisedValuesAreAccepted(t *testing.T) {
+	for _, tc := range ingestModeCases() {
+		for _, value := range tc.accepted {
+			cfg := config.Default()
+			tc.set(&cfg, value)
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("%s=%q is advertised by the spec template and must validate: %v", tc.key, value, err)
+			}
+		}
+	}
+}
+
+// TestIngestFormatModes_EmptyKeepsTheDefault pins that an absent value still
+// resolves to the documented default, so a bare config validates unchanged.
+func TestIngestFormatModes_EmptyKeepsTheDefault(t *testing.T) {
+	defaults := config.Default()
+	for _, tc := range ingestModeCases() {
+		cfg := config.Default()
+		tc.set(&cfg, "")
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("an empty %s must validate: %v", tc.key, err)
+			continue
+		}
+		if got, want := tc.get(cfg), tc.get(defaults); got != want {
+			t.Errorf("an empty %s must resolve to the default %q; got %q", tc.key, want, got)
+		}
+	}
+}
+
+// TestIngestFormatModes_ValueIsNormalized pins the canonical stored form, so a
+// consumer of the effective config compares against one spelling.
+func TestIngestFormatModes_ValueIsNormalized(t *testing.T) {
+	for _, tc := range ingestModeCases() {
+		cfg := config.Default()
+		tc.set(&cfg, "  "+strings.ToUpper(tc.accepted[0])+" ")
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("%s must accept a padded upper-case value: %v", tc.key, err)
+			continue
+		}
+		if got := tc.get(cfg); got != tc.accepted[0] {
+			t.Errorf("%s must normalize to %q; got %q", tc.key, tc.accepted[0], got)
+		}
+	}
+}
+
+// TestIngestFormatModes_LoadFailsOnATypo is the startup-error proof: the gate
+// runs on the load path, so a persisted typo stops the server instead of being
+// accepted in silence.
+func TestIngestFormatModes_LoadFailsOnATypo(t *testing.T) {
+	for _, tc := range ingestModeCases() {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".dir2mcp.yaml")
+		body := "root_dir: .\n" + tc.yamlKey + ": " + tc.typo + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		if _, err := config.LoadFile(path); err == nil {
+			t.Errorf("loading a config with %s: %s must fail", tc.yamlKey, tc.typo)
+		} else if !strings.Contains(err.Error(), tc.key) {
+			t.Errorf("the load error must name %s; got %v", tc.key, err)
+		}
+	}
+}
+
+// TestIngestFormatModes_LoadFailsOnANestedTypo covers the nested spelling the
+// canonical template and the README both use, which reaches the same gate through
+// the `ingest.archives` section.
+func TestIngestFormatModes_LoadFailsOnANestedTypo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dir2mcp.yaml")
+	body := "root_dir: .\ningest:\n  archives:\n    mode: shalow\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := config.LoadFile(path)
+	if err == nil {
+		t.Fatal("loading a config with a nested ingest.archives.mode typo must fail")
+	}
+	if !strings.Contains(err.Error(), "ingest.archives.mode") {
+		t.Fatalf("the load error must name ingest.archives.mode; got %v", err)
+	}
+}
+
+// TestIngestFormatModes_SaveRefusesATypo keeps a bad value out of a persisted
+// file, which is the other half of gating in Validate() rather than in a command.
+func TestIngestFormatModes_SaveRefusesATypo(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".dir2mcp.yaml")
+	cfg := config.Default()
+	cfg.RootDir = dir
+	cfg.StateDir = filepath.Join(dir, ".dir2mcp")
+	cfg.IngestArchivesMode = "shalow"
+	if err := config.SaveFile(path, cfg); err == nil {
+		t.Fatal("SaveFile must refuse an unrecognized ingest.archives.mode")
+	}
+}


### PR DESCRIPTION
## User-visible symptom

An operator sets a config key. The server accepts it, saves it, and reports it
back in the effective config. The behavior does not change. Nothing warns.

- `chunking.strategy` was a recognized key. `chunking.strategy: semantic` loaded,
  was written back into `.dir2mcp.yaml` and into the effective snapshot, and no
  code ever read it. It was supposed to select a chunking strategy. Chunking in
  fact selects itself per document type, and the canonical spec defines no
  strategy selector at all.
- `ingest.pdf.mode`, `ingest.images.mode`, `ingest.audio.mode` and
  `ingest.archives.mode` are advertised as closed sets (`off|ocr|auto`,
  `off|ocr_auto|ocr_on`, `off|auto|on`, `off|shallow|deep`). Nothing validated
  them, so `ingest.archives.mode: shalow` loaded exactly as happily as `deep`.
  They were supposed to select per-format handling. The ingestion runtime never
  reads any of them, so no value changes anything, and a typo was accepted in
  silence. That is worst for media and archives, where the operator's belief
  about provider cost and privacy can be wrong.

## Decision per key

Two commits, one decision each, so each one reads on its own.

### 1. `chunking.strategy`: REJECTED as unrecognized (commit 1, closes #661)

The spec never mentions the key. It is absent from the SPEC §16.2 config template
and from `bs-011`, and §7.5 selects chunking by document type: characters for
text, line windows for code, time windows for a transcript. The chunker has no
strategy concept, so there is nothing to wire the value into and no specified
meaning to wire it to.

The key therefore leaves the recognized config surface. It is now an unrecognized
key like any typo: config load names it in a warning (#628) and `up` prints that
warning, and no generated config or snapshot carries it forward.

An effective snapshot written by an older release still loads unchanged. The
snapshot loader ignores the dead line without a warning, which is the right split:
a snapshot is machine-written and carries no operator intent, while a hand-edited
`.dir2mcp.yaml` does and gets the warning.

A hard startup error was rejected on purpose. #628 fixed this exact class of
problem with a warning, on the stated ground that an unknown key must not break an
existing deployment. An error would stop a running deployment over a key that
never did anything, while the warning tells the operator the same fact.

### 2. The four `ingest.*.mode` keys: VALIDATED now, behavior is spec-blocked (commit 2, refs #655)

Two halves, and they have different owners.

**Validation is ours, and it lands here.** The sets are advertised as closed, so a
value outside a set can be refused without deciding what any member means.
`Validate()` now rejects it and normalizes the accepted value. The gate lives in
`Validate()`, not in the `up` command, for the reason `validateMCPPath` gives in
#837: `Validate()` is the one gate every entry point runs, so a persisted config,
the CLI flag overlay and the save paths are all covered, and the check also runs
after the CLI overrides merge, which is what #655 asks for.

**Behavior is the spec's, and it stops here.** The canonical spec names the members
of each set and defines the behavior of none of them. Writing what `pdf.mode: auto`
or `images.mode: ocr_on` does would author normative semantics this repository does
not own; this repository is spec-first. One concrete example of the cost of
guessing: the template's default is `archives.mode: deep`, and the shipped
behavior expands only the top level of an archive, recording a nested archive as
`skip_reason=archive`. So the default value already names a behavior the
implementation does not have, and "deep" cannot be implemented as a side effect of
a validation PR. `dirstral-spec#68` is open on the adjacent question of
representation reconciliation across pipeline config changes.

So #655 stays open for the behavior half, and this PR says so instead of closing it.
Meanwhile the README stops implying that the modes work, and names the keys that
really control extraction, transcription and archive depth today.

### 3. `rag.k_default` and `rag.generate_answer`: NOT in this PR (#654 stays open)

`dirstral-spec#61` is open and owns this decision. It says in its own summary that
the ambiguity "has produced inert implementation fields and conflicting defaults in
dir2mcp#654", and it asks which surfaces `k_default` applies to, what the precedence
is among a request `k`, the per-tool schema default and the server config, and
whether `k_default` must satisfy the same 1..50 bound. Threading an effective
default `k` through `parseKArg` and the five tool schemas answers those questions,
which is spec work. The spec PR merges first, then the code PR re-pins the submodule.

For the record, the spec support for these two keys is thinner than it looks:
`k_default` and `generate_answer` each appear on exactly ONE line of the pinned
spec, inside the §16.2 "Minimal config template" block. A value in a template is
not a specified default.

## Tests

New behavioral tests, both files under `tests/`:

- `tests/config/chunking_strategy_removed_661_test.go`
- `tests/config/ingest_format_modes_validation_655_test.go`

### Proof they fail on main

Run against the unmodified `internal/config` from `main` (`d7b6354`):

```
--- FAIL: TestChunkingStrategy_FlatSpellingIsReportedUnrecognized
--- FAIL: TestChunkingStrategy_NestedSpellingIsReportedUnrecognized
--- FAIL: TestChunkingStrategy_IsNotWrittenBack
--- FAIL: TestChunkingStrategy_SnapshotDoesNotCarryIt

--- FAIL: TestIngestFormatModes_TypoIsRejected
--- FAIL: TestIngestFormatModes_EmptyKeepsTheDefault
--- FAIL: TestIngestFormatModes_ValueIsNormalized
--- FAIL: TestIngestFormatModes_LoadFailsOnATypo
--- FAIL: TestIngestFormatModes_LoadFailsOnANestedTypo
--- FAIL: TestIngestFormatModes_SaveRefusesATypo
```

Both suites pass on this branch. Two tests pass on main by design and are kept as
guards: `TestChunkingStrategy_LoadStillSucceeds` (an existing deployment carrying
the dead key must still start) and
`TestIngestFormatModes_AdvertisedValuesAreAccepted` (the false-positive guard: no
documented value may be refused).

`make check` passes locally, gocyclo `-over 15` included.

## Docs

`README.md` gains two pieces, because behavior and docs must agree:

- a chunking-keys block that names `chunking.max_tokens` / `chunking.overlap_tokens`
  and states that `chunking.strategy` is not a setting;
- a per-format mode block that gives each enum and its default, says plainly that
  no accepted value changes behavior yet, and gives the working alternative for each
  goal (`ingest.extractor: off`, `stt.provider: off`, `ingest.on_unsupported: strict`).

`docs/*.md` are pointer stubs to the `dirstral-spec` submodule, so they need no edit.

Closes #661
Refs #655
Refs #654
