### PR TITLE
fix(annotator): report an empty face bank early, and read a game feed once per binding (#845, #844)

### DIFF
--- a/annotator/dirstral_annotator/pipeline.py
+++ b/annotator/dirstral_annotator/pipeline.py
@@ -14,6 +14,11 @@ run was picked up at whichever request happened to re-enroll.
 
 A cached recognizer is shared by concurrent requests, and these recognizers are
 not reentrant, so one request at a time enters any one of them. See `_Shared`.
+
+The play-by-play recognizer is the one that is still built per request, because
+it is keyed per media file and holds no model. What made that expensive was its
+LABELS, not its construction: it read the game feed every time. That read is now
+a memo on the binding it came from. See `GameConfig.events` (#844).
 """
 
 from __future__ import annotations
@@ -40,6 +45,13 @@ class GameConfig:
     game_pk: int | None = None
     feed: str | None = None  # saved GUMBO JSON path (wins over game_pk)
 
+    def __post_init__(self) -> None:
+        # Not dataclass fields on purpose, as in `Pipeline`: a Lock is neither
+        # comparable nor copyable, and a game's parsed events have no place in a
+        # repr of the configuration an operator wrote.
+        self._read_lock = threading.Lock()
+        self._parsed: tuple[tuple, list[ground_truth.PitchEvent]] | None = None
+
     @classmethod
     def parse(cls, raw: dict) -> "GameConfig":
         anchors = []
@@ -49,8 +61,53 @@ class GameConfig:
         return cls(anchors=anchors, game_pk=raw.get("game_pk"), feed=raw.get("feed"))
 
     def events(self) -> list[ground_truth.PitchEvent]:
-        feed = ground_truth.load_game(self.feed) if self.feed else ground_truth.fetch_game(self.game_pk)
-        return ground_truth.parse_pitches(feed)
+        """The feed's pitches, read at most once per binding (#844).
+
+        `Pipeline.cues_for` builds `PlayByPlayRecognizer` per request, so this
+        ran per request. Measured on a real 0.901 MB GUMBO feed of 344 pitches:
+        15.33 ms for the saved file, 2892 ms (up to 5953 ms) for the `game_pk`
+        fetch. The file read is noise beside the 46 s that #650 removed; the
+        fetch is seconds of latency per request, spent on a service that has no
+        reason to be live for a recognizer to run.
+
+        This is a memo on the binding, not a cache with an eviction policy.
+        What stays resident is bounded by the bindings games.json declares,
+        which already live as long as the pipeline: 69.5 KiB of parsed events for
+        that 344 pitch game, and the 2.77 MiB raw payload is parsed and dropped.
+
+        Keyed on the binding, so repointing `feed` or `game_pk` is picked up, the
+        same rule the recognizer cache follows. A binding that still points at the
+        same path keeps the parse it made: every request in a run then answers
+        from one label set, instead of from whichever request happened to re-read
+        a file that changed. An operator who wants a changed file reloads the
+        bindings.
+
+        Only a success is remembered. A read that fails raises as it did before,
+        and the next request tries again, because a remembered failure would turn
+        one bad moment into a process that never recognizes play-by-play again.
+        The lock means two concurrent first requests do not both fetch: the second
+        waits and then reads the memo.
+        """
+        with self._read_lock:
+            # The binding is read under the lock, and the read below uses those
+            # locals. A binding sampled before the wait could be repointed while
+            # this request queues, which would file the NEW feed's events under
+            # the OLD key.
+            feed, game_pk = self.feed, self.game_pk
+            binding = (feed, game_pk)
+            memo = self._parsed
+            if memo is None or memo[0] != binding:
+                raw = (
+                    ground_truth.load_game(feed) if feed
+                    else ground_truth.fetch_game(game_pk)
+                )
+                memo = (binding, ground_truth.parse_pitches(raw))
+                self._parsed = memo
+            # A copy of a few hundred pointers, because the memo is now shared by
+            # every request: one caller sorting or filtering in place would
+            # otherwise change what every later request sees. `PitchEvent` is
+            # frozen, so the events themselves need no copy.
+            return list(memo[1])
 
     def alignment(self) -> align.Alignment:
         return align.estimate(self.anchors)

--- a/annotator/dirstral_annotator/recognizers/faces.py
+++ b/annotator/dirstral_annotator/recognizers/faces.py
@@ -12,9 +12,13 @@ and pre-overlay archival material, and is fused with, never trusted over,
 scorebug/play-by-play.
 
 The bank is an optional backend asset, so it follows the package rule for one
-of those: a bank that is missing, is not a directory, or cannot be read raises
-`RecognizerUnavailable` at construction and the pipeline skips this recognizer
-with a note. See `_bank_player_dirs`.
+of those: a bank that cannot be enrolled from raises `RecognizerUnavailable` at
+construction and the pipeline skips this recognizer with a note. That covers a
+bank that is missing, is not a directory or cannot be read
+(`_bank_player_dirs`), and a bank that exists and holds nobody to enroll
+(`_enrollable_players`). Both are checked before the embedder is built, and each
+reason names its own problem, because an empty bank and a missing bank send an
+operator to different places.
 """
 
 from __future__ import annotations
@@ -233,6 +237,115 @@ def _bank_player_dirs(bank_dir: Path) -> list[Path]:
         ) from exc
 
 
+def _enrollable_players(
+    bank_dir: Path, player_dirs: list[Path], roster: Roster
+) -> list[tuple[str, list[Path]]]:
+    """Each roster player in the bank that has an image, or an unavailable
+    recognizer. `(player id, images)` in bank order.
+
+    A bank that EXISTS and holds nobody to enroll is the same missing asset as a
+    bank that is not there, so it takes the same route: `RecognizerUnavailable`
+    at construction, before the embedder is built. The check is a directory
+    listing per player, and the embedder it stands in front of loads and prepares
+    five ONNX models, measured at 0.5 s (#845).
+
+    The reason names WHICH problem it is. An empty bank, a bank whose directories
+    are named for players nobody rostered, a rostered player whose images never
+    got copied, and images that refuse to open are different mistakes with
+    different fixes, so they must not collapse into one message.
+
+    One unreadable player directory, or one unreadable image, still costs only
+    that player: it is skipped with a warning that says who was lost, and the
+    rest of the bank still enrolls. A bank that leaves nobody after that ends as
+    unavailability here.
+    """
+    enrollable: list[tuple[str, list[Path]]] = []
+    off_roster: list[str] = []
+    imageless: list[str] = []
+    unreadable: list[str] = []
+    locked_images: list[str] = []
+    for player_dir in player_dirs:
+        pid = player_dir.name.replace("_", ":", 1)
+        if not roster.get(pid):
+            off_roster.append(player_dir.name)
+            continue
+        try:
+            entries = sorted(player_dir.iterdir())
+        except OSError as exc:
+            logging.getLogger(__name__).warning(
+                "face bank: skipping %s (%s)",
+                player_dir.name, exc.strerror or type(exc).__name__,
+            )
+            unreadable.append(player_dir.name)
+            continue
+        # `is_file()` as well as the suffix: a DIRECTORY called `nested.jpg`
+        # would otherwise count as an image, so a bank with nothing to enroll
+        # would pass this check, build the embedder, and hand it a path that was
+        # never an image. A broken symlink is excluded for the same reason.
+        named = [p for p in entries if p.is_file() and p.suffix.lower() in IMAGE_EXTS]
+        if not named:
+            imageless.append(player_dir.name)
+            continue
+        # An image the process cannot open is not an image it can enroll from.
+        # `is_file()` says nothing about permissions, so each candidate is opened
+        # here: the alternative is that the models load and the adapter then
+        # returns no face, which reports a detector problem for a permission one.
+        # One open per image, against about a second per image to embed.
+        images = []
+        for image in named:
+            try:
+                with image.open("rb"):
+                    pass
+            except OSError as exc:
+                logging.getLogger(__name__).warning(
+                    "face bank: skipping %s/%s (%s)",
+                    player_dir.name, image.name,
+                    exc.strerror or type(exc).__name__,
+                )
+                continue
+            images.append(image)
+        if not images:
+            locked_images.append(player_dir.name)
+            continue
+        enrollable.append((pid, images))
+    if enrollable:
+        return enrollable
+
+    exts = ", ".join(sorted(IMAGE_EXTS))
+    if not player_dirs:
+        raise RecognizerUnavailable(
+            f"face bank is empty: {bank_dir} holds no player directory "
+            "(expected <bank>/<player-id-with-underscores>/*.jpg)"
+        )
+    # Most actionable first. A directory named for a rostered player is one an
+    # operator meant to fill, so say it is unfilled rather than counting the
+    # strangers beside it.
+    if imageless:
+        raise RecognizerUnavailable(
+            "face bank has no image for any rostered player: "
+            f"{', '.join(imageless)} under {bank_dir} hold no {exts} file"
+        )
+    if locked_images:
+        raise RecognizerUnavailable(
+            "face bank has no readable image for any rostered player: "
+            f"every image under {', '.join(locked_images)} in {bank_dir} "
+            "refused to open (check the file permissions)"
+        )
+    if unreadable:
+        raise RecognizerUnavailable(
+            "face bank has no readable player directory: "
+            f"{', '.join(unreadable)} under {bank_dir} could not be read"
+        )
+    # Every remaining directory is off the roster, or `enrollable` would have
+    # won: the five buckets above cover every player directory.
+    raise RecognizerUnavailable(
+        f"face bank has no player on this roster: {', '.join(off_roster)} "
+        f"under {bank_dir} match no roster id "
+        "(expected <bank>/<player-id-with-underscores>, "
+        "e.g. player_webb-logan for player:webb-logan)"
+    )
+
+
 def match(
     embedding: Embedding, gallery: dict[str, Embedding], threshold: float = SIM_THRESHOLD
 ) -> tuple[str, float] | None:
@@ -262,41 +375,35 @@ class FaceRecognizer:
     ):
         self.roster = roster
         bank = Path(bank_dir)
-        # The bank is read BEFORE the embedder is built. Building the default
-        # embedder loads and prepares five ONNX models, and paying that only to
-        # then find the bank is not there is waste with no upside. Both failures
-        # are RecognizerUnavailable, so the cheaper one goes first.
-        player_dirs = _bank_player_dirs(bank)
+        # The bank is read BEFORE the embedder is built, and read far enough to
+        # know there is somebody to enroll. Building the default embedder loads
+        # and prepares five ONNX models, and paying that only to then find an
+        # empty bank is waste with no upside. Both failures are
+        # RecognizerUnavailable, so the cheap one goes first (#651, #845).
+        candidates = _enrollable_players(bank, _bank_player_dirs(bank), roster)
         self.embedder = embedder if embedder is not None else default_embedder()
         self.fps = fps
         self.threshold = threshold
-        self.gallery = self._enroll(bank, player_dirs)
+        self.gallery = self._enroll(bank, candidates)
 
-    def _enroll(self, bank_dir: Path, player_dirs: list[Path]) -> dict[str, Embedding]:
+    def _enroll(
+        self, bank_dir: Path, candidates: list[tuple[str, list[Path]]]
+    ) -> dict[str, Embedding]:
         """Bank layout: `<bank>/<player-id-with-underscores>/*.jpg` (":" is
         awkward in dirnames, so "player:webb-logan" -> "player_webb-logan").
-        Every image contributes its largest detected face."""
+        Every image contributes its largest detected face.
+
+        `candidates` is what `_enrollable_players` already found: the rostered
+        players that have images. So the only failure left here is the one that
+        needs the embedder to know it, which is an image the detector finds no
+        face in.
+        """
         gallery: dict[str, Embedding] = {}
-        for player_dir in player_dirs:
-            pid = player_dir.name.replace("_", ":", 1)
-            if not self.roster.get(pid):
-                continue
-            try:
-                images = sorted(player_dir.iterdir())
-            except OSError as exc:
-                # One player's images being unreadable is not the bank being
-                # unreadable. Degrade by as little as possible: enroll everyone
-                # who can be enrolled, and say who was lost. A bank where that
-                # leaves nobody still ends as unavailability below.
-                logging.getLogger(__name__).warning(
-                    "face bank: skipping %s (%s)",
-                    player_dir.name, exc.strerror or type(exc).__name__,
-                )
-                continue
+        images_read = 0
+        for pid, images in candidates:
             embeddings = []
             for img in images:
-                if img.suffix.lower() not in IMAGE_EXTS:
-                    continue
+                images_read += 1
                 faces = self.embedder(img)
                 if faces:
                     largest = max(faces, key=lambda f: f[1][2] * f[1][3])
@@ -304,7 +411,11 @@ class FaceRecognizer:
             if embeddings:
                 gallery[pid] = centroid(embeddings)
         if not gallery:
-            raise RecognizerUnavailable(f"no enrollable faces found under {bank_dir}")
+            raise RecognizerUnavailable(
+                "face bank has no detectable face: the embedder found none in "
+                f"the {images_read} image(s) under {bank_dir} "
+                "(bank images should show one clear, front-facing face)"
+            )
         return gallery
 
     def recognize(self, media_path: Path) -> list[Cue]:

--- a/annotator/tests/test_face_bank.py
+++ b/annotator/tests/test_face_bank.py
@@ -124,6 +124,183 @@ def test_a_bank_with_nothing_enrollable_is_unavailable(tmp_path, roster):
         FaceRecognizer(roster, stranger, embedder=_embedder())
 
 
+# --- a bank with nothing in it is known before the models load (#845) --------
+#
+# The missing-bank case above already refuses before the embedder is built. A
+# bank that EXISTS and holds nothing enrollable is the same class of problem:
+# the recognizer cannot run, and loading five ONNX models first buys nothing.
+
+
+def _recorder(built: list[str]):
+    """A stand-in `default_embedder` that records that it was called."""
+
+    def default_embedder():
+        built.append("loaded")
+        return _embedder()
+
+    return default_embedder
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["no player directory", "no roster player", "no image"],
+)
+def test_a_bank_with_nothing_to_enroll_refuses_before_the_embedder(
+    tmp_path, roster, monkeypatch, case
+):
+    """Each way a bank can hold nothing enrollable, measured on the ONE thing
+    that costs seconds: whether the models were loaded."""
+    bank = tmp_path / "bank"
+    if case == "no player directory":
+        bank.mkdir()
+    elif case == "no roster player":
+        bank = _bank(tmp_path, player_dir="player_not-on-this-roster")
+    else:
+        (bank / PLAYER_DIR).mkdir(parents=True)
+        (bank / PLAYER_DIR / "notes.txt").write_text("no image ever got copied here")
+
+    built: list[str] = []
+    monkeypatch.setattr(faces, "default_embedder", _recorder(built))
+    with pytest.raises(RecognizerUnavailable):
+        FaceRecognizer(roster, bank)
+    assert built == [], f"the models were loaded for a bank with {case}"
+
+
+def test_a_directory_named_like_an_image_is_not_an_image(tmp_path, roster,
+                                                         monkeypatch):
+    """`nested.jpg` is a legal directory name.
+
+    Counting one as an image would let a bank with nothing to enroll past the
+    check, build the embedder, and then hand it a path that was never an image.
+    So the check tests the suffix AND the file.
+    """
+    bank = tmp_path / "bank"
+    (bank / PLAYER_DIR / "nested.jpg").mkdir(parents=True)
+
+    built: list[str] = []
+    monkeypatch.setattr(faces, "default_embedder", _recorder(built))
+    with pytest.raises(RecognizerUnavailable) as caught:
+        FaceRecognizer(roster, bank)
+    assert "image" in str(caught.value)
+    assert built == [], "a directory named .jpg bought a model load"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root ignores file permissions, so this cannot be provoked",
+)
+def test_an_image_that_refuses_to_open_is_not_an_enrollable_image(tmp_path, roster,
+                                                                 monkeypatch):
+    """`is_file()` says nothing about permissions.
+
+    A bank whose only image cannot be read has nothing to enroll, so it must
+    refuse before the models load. Left to the embedder, the default adapter
+    returns no face for it, which reports a detector problem for a permission
+    one.
+    """
+    bank = _bank(tmp_path, images=("a.jpg",))
+    locked = bank / PLAYER_DIR / "a.jpg"
+    locked.chmod(0o000)
+
+    built: list[str] = []
+    monkeypatch.setattr(faces, "default_embedder", _recorder(built))
+    try:
+        with pytest.raises(RecognizerUnavailable) as caught:
+            FaceRecognizer(roster, bank)
+    finally:
+        locked.chmod(0o644)  # or tmp_path cleanup fails
+    assert "readable image" in str(caught.value), str(caught.value)
+    assert built == [], "an unreadable image bought a model load"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root ignores file permissions, so this cannot be provoked",
+)
+def test_an_unreadable_image_costs_only_its_own_player(tmp_path):
+    """Degrade by as little as possible, as an unreadable player directory
+    already does: the players who can be enrolled are enrolled."""
+    two_players = Roster([
+        Player(id=PLAYER_ID, name="Logan Webb", number="62"),
+        Player(id="player:daylen-lile", name="Daylen Lile", number="4"),
+    ])
+    bank = _bank(tmp_path)
+    other = bank / "player_daylen-lile"
+    other.mkdir()
+    locked = other / "a.jpg"
+    locked.write_bytes(b"stand-in")
+    locked.chmod(0o000)
+    try:
+        rec = FaceRecognizer(two_players, bank, embedder=_embedder())
+    finally:
+        locked.chmod(0o644)
+    assert list(rec.gallery) == [PLAYER_ID]
+
+
+def test_each_empty_bank_reason_says_which_one_it_is(tmp_path, roster):
+    """"Empty" and "missing" send an operator to different places, so they must
+    not collapse into one message. Neither may the two ways a bank that exists
+    can still hold nobody to enroll."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    stranger = _bank(tmp_path / "stranger", player_dir="player_not-on-this-roster")
+    imageless = tmp_path / "imageless"
+    (imageless / PLAYER_DIR).mkdir(parents=True)
+
+    def reason(bank: Path) -> str:
+        with pytest.raises(RecognizerUnavailable) as caught:
+            FaceRecognizer(roster, bank, embedder=_embedder())
+        return str(caught.value)
+
+    missing = reason(tmp_path / "no-such-bank")
+    assert "not found" in missing
+
+    no_dirs = reason(empty)
+    assert "empty" in no_dirs, f"an empty bank does not say so: {no_dirs}"
+
+    off_roster = reason(stranger)
+    assert "roster" in off_roster, f"the reason hides the roster: {off_roster}"
+    assert "player_not-on-this-roster" in off_roster, off_roster
+
+    no_images = reason(imageless)
+    assert "image" in no_images, f"the reason hides the missing images: {no_images}"
+    assert PLAYER_DIR in no_images, no_images
+
+    # Four different problems, four different fixes, so four distinct messages.
+    assert len({missing, no_dirs, off_roster, no_images}) == 4
+    for text in (missing, no_dirs, off_roster, no_images):
+        assert "face bank" in text, text
+
+
+def test_an_empty_bank_is_not_reported_as_a_missing_wheel(tmp_path, roster,
+                                                          monkeypatch):
+    """The operator-facing end of #845.
+
+    A host without the face extra installed reports "install insightface". A
+    host WITH an empty bank must not borrow that message, because installing a
+    wheel would not fix an empty directory. The cheap check runs first, so the
+    reason the pipeline records is the true one.
+    """
+    def uninstalled():
+        raise RecognizerUnavailable(
+            "face recognition needs insightface + opencv "
+            "(pip install 'dirstral-annotator[face]')"
+        )
+
+    monkeypatch.setattr(faces, "default_embedder", uninstalled)
+
+    empty = tmp_path / "empty-bank"
+    empty.mkdir()
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"stand-in; no recognizer reaches frame extraction here")
+
+    pipeline = Pipeline(roster=roster, faces_bank=empty)
+    assert pipeline.cues_for(media) == []
+    note = " ".join(pipeline.skipped)
+    assert "empty" in note, f"an empty bank was reported as something else: {note}"
+    assert "insightface" not in note, note
+
+
 @pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="root ignores directory permissions, so this cannot be provoked",

--- a/annotator/tests/test_feed_cache.py
+++ b/annotator/tests/test_feed_cache.py
@@ -1,0 +1,266 @@
+"""One read of a game feed per binding, not one per request.
+
+`Pipeline.cues_for` builds `PlayByPlayRecognizer` per request, and building it
+calls `GameConfig.events()`. That re-read the saved GUMBO JSON from disk, or
+re-fetched it from MLB statsapi when the binding uses `game_pk`, on every POST to
+/recognize (#844).
+
+Measured on a real 0.901 MB GUMBO feed, 344 pitches, this host:
+
+    events() saved feed   median   15.33 ms per request
+    events() game_pk      median 2892.32 ms per request (min 2211, max 5953)
+
+The disk number is noise beside the 46 s that PR #839 removed, and beside the
+seconds of inference a real request spends. The network number is not: it adds
+seconds to every request and it puts a third party service in the request path.
+So the memo below is about the fetch, and the disk read rides along because the
+two paths are one line of code.
+
+The memo lives on the `GameConfig` the operator's games.json created, so it needs
+no eviction policy: what stays resident is bounded by the bindings that are
+configured, not by the requests that arrive (69.5 KiB of parsed events for that
+344 pitch game; the 2.77 MiB raw payload is parsed and dropped).
+
+Backend-free: no network, no ffmpeg, no CV backend. The feed loader is stubbed,
+which is also how the read count is counted.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from dirstral_annotator.eval import ground_truth
+from dirstral_annotator.model import Player
+from dirstral_annotator.pipeline import GameConfig, Pipeline
+from dirstral_annotator.roster import Roster
+
+FIXTURE = Path(__file__).parent / "fixtures" / "gumbo_min.json"
+WEBB = 657277
+
+#: Read at import time, so no test's own read count includes the anchor it needs.
+FIRST_PITCH_EPOCH = ground_truth.parse_pitches(
+    ground_truth.load_game(FIXTURE)
+)[0].epoch_s
+
+
+@pytest.fixture
+def roster() -> Roster:
+    return Roster(
+        [Player(id="player:webb-logan", name="Logan Webb", number="62")],
+        {WEBB: "player:webb-logan"},
+    )
+
+
+@pytest.fixture
+def media(tmp_path) -> Path:
+    path = tmp_path / "game7.mp4"
+    path.write_bytes(b"stand-in; no recognizer here reads a frame")
+    return path
+
+
+def _counted(monkeypatch, name: str, payload=None, delay: float = 0.0):
+    """Replace `ground_truth.<name>` with a counting stub. Returns the log."""
+    reads: list[str] = []
+    feed = payload if payload is not None else ground_truth.load_game(FIXTURE)
+
+    def stub(*args, **kwargs):
+        reads.append(name)
+        if delay:
+            time.sleep(delay)
+        return feed
+
+    monkeypatch.setattr(ground_truth, name, stub)
+    return reads
+
+
+def _pipeline(roster: Roster, media: Path, game: GameConfig) -> Pipeline:
+    return Pipeline(roster=roster, games={media.name: game})
+
+
+def _anchored(**binding) -> GameConfig:
+    """A binding anchored on the fixture's first pitch, so cues land on the
+    video timeline. It reads no feed of its own."""
+    return GameConfig.parse({"anchors": [f"{FIRST_PITCH_EPOCH}=60.0"], **binding})
+
+
+# --- the headline contract --------------------------------------------------
+
+def test_two_requests_read_a_saved_feed_once(monkeypatch, roster, media):
+    reads = _counted(monkeypatch, "load_game")
+    pipeline = _pipeline(roster, media, _anchored(feed=str(FIXTURE)))
+
+    first = pipeline.cues_for(media)
+    second = pipeline.cues_for(media)
+
+    assert len(reads) == 1, f"the saved feed was read per request: {len(reads)}"
+    assert first, "the fixture must produce cues, or this proves nothing"
+    assert first == second, "the memo stopped answering"
+
+
+def test_two_requests_fetch_a_game_pk_once(monkeypatch, roster, media):
+    """The path the measurement condemns: 2.9 s median per fetch, from a service
+    the recognizer does not need to be live."""
+    fetches = _counted(monkeypatch, "fetch_game")
+    pipeline = _pipeline(roster, media, _anchored(game_pk=823215))
+
+    first = pipeline.cues_for(media)
+    second = pipeline.cues_for(media)
+
+    assert len(fetches) == 1, f"statsapi was called per request: {len(fetches)}"
+    assert first and first == second
+
+
+def test_concurrent_first_requests_read_the_feed_once(monkeypatch, roster, media):
+    """Two requests that arrive together must not both pay the read.
+
+    Same rule as the recognizer cache (#650): the read holds a lock, so the
+    second request waits for the first result instead of duplicating a fetch that
+    is measured in seconds.
+    """
+    reads = _counted(monkeypatch, "load_game", delay=0.05)
+    pipeline = _pipeline(roster, media, _anchored(feed=str(FIXTURE)))
+
+    start = threading.Barrier(2)
+    results: list[list] = []
+    guard = threading.Lock()
+
+    def request():
+        start.wait(timeout=5)
+        cues = pipeline.cues_for(media)
+        with guard:
+            results.append(cues)
+
+    threads = [threading.Thread(target=request) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert len(reads) == 1, f"concurrent first requests both read the feed: {reads}"
+    assert len(results) == 2 and results[0] == results[1]
+
+
+# --- the failure path ------------------------------------------------------
+
+def test_a_feed_that_stops_reading_cannot_break_a_later_request(
+    monkeypatch, roster, media
+):
+    """The question #844 asks: a feed that read at the first request and does not
+    read at the tenth.
+
+    With the memo the tenth request does not read at all, so a service outage or
+    a deleted file after the first request cannot take the labels away. Before
+    the memo the tenth request raised, and `cues_for` calls `events()` outside
+    `try_recognizer`, so it took the whole cascade with it: 502 from the served
+    backend.
+    """
+    calls: list[int] = []
+    payload = ground_truth.load_game(FIXTURE)
+
+    def once_then_never(*args, **kwargs):
+        calls.append(1)
+        if len(calls) > 1:
+            raise OSError("statsapi is down / the saved feed was deleted")
+        return payload
+
+    monkeypatch.setattr(ground_truth, "fetch_game", once_then_never)
+    pipeline = _pipeline(roster, media, _anchored(game_pk=823215))
+
+    first = pipeline.cues_for(media)
+    assert first
+    for _ in range(9):
+        assert pipeline.cues_for(media) == first
+    assert len(calls) == 1
+
+
+def test_a_first_read_failure_is_not_remembered(monkeypatch, roster, media):
+    """Only a successful read is remembered.
+
+    Remembering a failure would turn one bad moment into a process that never
+    recognizes play-by-play again, which is the opposite of what the memo is for.
+    A failure that is not remembered keeps today's behaviour: the request fails,
+    and the next request tries again.
+    """
+    calls: list[int] = []
+    payload = ground_truth.load_game(FIXTURE)
+
+    def broken_then_fixed(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise FileNotFoundError("the feed had not been copied yet")
+        return payload
+
+    monkeypatch.setattr(ground_truth, "load_game", broken_then_fixed)
+    pipeline = _pipeline(roster, media, _anchored(feed=str(FIXTURE)))
+
+    with pytest.raises(FileNotFoundError):
+        pipeline.cues_for(media)
+    assert pipeline.cues_for(media), "the failure was remembered as no events"
+    assert len(calls) == 2
+
+
+# --- the memo may not outlive the binding it was built for ------------------
+
+def test_a_repointed_feed_is_not_hidden_by_the_memo(tmp_path, roster, media):
+    """The same rule the recognizer cache follows: the memo is keyed on what
+    decides its contents, so an operator who repoints the binding gets the new
+    feed rather than the old parse."""
+    original = ground_truth.load_game(FIXTURE)
+    later = json.loads(json.dumps(original))
+    # One pitch fewer, so the two feeds are distinguishable from the cues alone.
+    later["liveData"]["plays"]["allPlays"] = \
+        later["liveData"]["plays"]["allPlays"][:1]
+    second_feed = tmp_path / "gumbo_second.json"
+    second_feed.write_text(json.dumps(later), encoding="utf-8")
+
+    game = _anchored(feed=str(FIXTURE))
+    pipeline = _pipeline(roster, media, game)
+
+    before = pipeline.cues_for(media)
+    game.feed = str(second_feed)
+    after = pipeline.cues_for(media)
+
+    assert before and after
+    assert len(after) < len(before), "the repointed feed reused the old parse"
+
+
+def test_a_saved_feed_edited_on_disk_is_read_once_per_run(monkeypatch, roster,
+                                                          media):
+    """The stated invalidation rule, pinned so it cannot drift by accident.
+
+    A binding that still points at the same path keeps the parse it made. Every
+    request in a run therefore answers from one label set, which is the
+    consistency PR #839 chose for the face bank: before it, a feed edited during
+    a run reached whichever request happened to re-read it, and nothing recorded
+    which. An operator who wants the new file reloads the bindings.
+    """
+    reads = _counted(monkeypatch, "load_game")
+    game = _anchored(feed=str(FIXTURE))
+    pipeline = _pipeline(roster, media, game)
+
+    pipeline.cues_for(media)
+    pipeline.cues_for(media)
+    assert len(reads) == 1
+
+    # A fresh binding is a fresh read, which is what reloading games.json gives.
+    pipeline.games = {media.name: _anchored(feed=str(FIXTURE))}
+    pipeline.cues_for(media)
+    assert len(reads) == 2
+
+
+def test_the_memo_is_not_part_of_the_configuration():
+    """`GameConfig` is a dataclass an operator's file produced. Reading its feed
+    must not change what it compares or prints as, or a caller that logs a
+    binding would dump a whole game into a log line.
+    """
+    a = _anchored(feed=str(FIXTURE))
+    b = _anchored(feed=str(FIXTURE))
+    assert a == b
+    a.events()
+    assert a == b, "reading the feed changed the configuration's identity"
+    assert "PitchEvent" not in repr(a)


### PR DESCRIPTION
## Summary

Two follow-ups from PR #839, one commit each.

1. `fix(annotator): report an empty face bank before the embedder loads` (#845)
2. `perf(annotator): read a game feed once per binding, not once per request` (#844)

Closes #845. Closes #844.

Both changes keep what #839 established. `Pipeline.skipped` stays thread-local.
The recognizer cache, its key and the one build lock per pipeline are untouched.
No Go product code changes here.

## 1. #845, the mechanism

#651 made a MISSING face bank report unavailable, and #839 moved that check in
front of the embedder. A bank that EXISTS and holds nobody to enroll still took
the long path. `default_embedder()` loaded and prepared five ONNX models first,
measured at 0.5 s in #839, and only then did `_enroll` find nothing to enroll.

`_enrollable_players` now runs beside `_bank_player_dirs`, before the embedder is
built. It lists each player directory and keeps the rostered players that have
images. A bank with none of those raises `RecognizerUnavailable`, so the pipeline
records a skip note and the rest of the cascade still runs.

The cost of the new check is one directory listing per player, plus one `open`
per candidate image. The listing replaces the one `_enroll` did, so no directory
is read twice, and an `open` costs microseconds against about a second to embed
the same image.

### The reason names the real problem

"Empty" and "missing" send an operator to different places, so each reason is its
own message:

| bank state | reason |
|---|---|
| absent | `face bank not found: <path> (expected <bank>/<player-id-with-underscores>/*.jpg)` |
| not a directory | `face bank is not a directory: <path>` |
| unreadable | `face bank cannot be read: <path> (<errno>)` |
| no player directory | `face bank is empty: <path> holds no player directory ...` |
| no rostered player | `face bank has no player on this roster: <dirs> under <path> match no roster id ...` |
| no image for a rostered player | `face bank has no image for any rostered player: <dirs> under <path> hold no .jpeg, .jpg, .png, .webp file` |
| every image refuses to open | `face bank has no readable image for any rostered player: every image under <dirs> in <path> refused to open (check the file permissions)` |
| no face in any image | `face bank has no detectable face: the embedder found none in the N image(s) under <path> ...` |

The last one still needs the embedder to know it, so it stays after the models
load. It is the only one that does.

The operator-facing win is bigger than the half second. On a host without the
face extra, an empty bank used to be reported as
`face recognition needs insightface + opencv`, because the wheel check ran first
and failed first. That sends an operator to install a wheel for a problem a wheel
cannot fix. `test_an_empty_bank_is_not_reported_as_a_missing_wheel` pins it.

## 2. #844, the measurement that decides the design

The issue asks for a number before a design, so here is the number. A real GUMBO
feed, game 823215, 0.901 MB, 344 pitches, fetched from statsapi. Timed on this
host with the annotator venv python, `events()` per call, which is what one POST
to /recognize paid:

| path | median | min | max | n |
|---|---|---|---|---|
| saved `feed` file | 15.33 ms | 14.49 ms | 18.19 ms | 20 |
| `game_pk` fetch | 2892.32 ms | 2211.25 ms | 5952.78 ms | 5 |

Split for the file path: 13.50 ms of `read_text` plus `json.loads`, 1.11 ms of
`parse_pitches`.

**The saved file read does not justify a cache on its own.** It is 0.03% of the
46 s that #839 removed, and it is less than one frame of face inference (1.34 s
per frame on CPU, 0.154 s on GPU, both measured in `select_face_providers`). If
that path were the only one, the honest answer would be to do nothing.

**The fetch path is a different number.** It is 2.9 s per request, it varies by a
factor of three, and it makes the latency of a recognition request depend on a
public service that has no reason to be live for a recognizer to run. That is
worth removing. Both paths are one line of code, so one memo removes both.

So this is not the per-media cache with an eviction policy that the issue names as
an option. It is a memo on the `GameConfig` the operator's games.json already
created:

| | request 1 | request 2 |
|---|---|---|
| saved feed | 17.543 ms | 0.007 ms |
| `game_pk` fetch | 3625.927 ms | 0.010 ms |

Request 2 is the measurement that matters. It paid the full cost before, and now
it pays a list copy.

### The three questions the issue asks

**Eviction: none, and none is needed.** The parsed events hang off the binding,
and the bindings live as long as the pipeline already. What stays resident is
bounded by the games an operator declared, not by the requests that arrive.
Measured with `tracemalloc` on that 344 pitch game: 69.5 KiB of parsed events,
207 B per pitch. The 2.77 MiB raw payload is parsed and dropped, so it is not
retained. A hundred configured games is about 7 MiB. A cache with an eviction
policy would add a knob for a number that cannot grow with traffic.

**Invalidation: keyed on the binding, and stable for a run otherwise.** The memo
is keyed on `(feed, game_pk)`, so an operator who repoints either gets a fresh
read. That is the rule the recognizer cache already follows. A binding that still
points at the same path keeps the parse it made, so a saved feed that changes on
disk mid-run is not picked up until the bindings are reloaded. That is the same
choice #839 made for the face bank, and for the same reason: before it, a file
edited during a run reached whichever request happened to re-read it, and nothing
recorded which request answered from which file. One label set per run is a
property a caller can reason about. An arbitrary mixture is not. A mid-game
`game_pk` refresh is deliberately not added: a live game grows, so a refresh
would need its own policy for how stale is too stale, and no measurement here
asks for one.

**Failure: only a success is remembered.** A feed that read at the first request
and fails at the tenth cannot take the labels away, because the tenth request does
not read. Before this change the tenth request raised, and `cues_for` calls
`events()` outside `try_recognizer`, so one statsapi outage took the whole
cascade with it: 502 from the served backend. A first read that fails still
raises, and the next request tries again. A remembered failure would leave a
process that never recognizes play-by-play again, which is worse than the read.

Two concurrent first requests do not both fetch. The read holds one lock per
binding, so the second request waits and then reads the memo. Same rule as the
recognizer build lock in #839.

The eval CLI gains one read as well. It asked for the same feed twice: once
through the pipeline for cues, once for the labels it scores against.

## 3. Tests that fail before and pass after

Both files were run against the parent commit first.

`tests/test_face_bank.py`, 8 new cases, all 8 fail on the parent:

```
FAILED test_a_bank_with_nothing_to_enroll_refuses_before_the_embedder[no player directory]
FAILED test_a_bank_with_nothing_to_enroll_refuses_before_the_embedder[no roster player]
FAILED test_a_bank_with_nothing_to_enroll_refuses_before_the_embedder[no image]
FAILED test_a_directory_named_like_an_image_is_not_an_image
FAILED test_an_image_that_refuses_to_open_is_not_an_enrollable_image
FAILED test_an_unreadable_image_costs_only_its_own_player
FAILED test_each_empty_bank_reason_says_which_one_it_is
FAILED test_an_empty_bank_is_not_reported_as_a_missing_wheel
```

`tests/test_feed_cache.py`, 8 cases, 5 fail on the parent:

```
FAILED test_two_requests_read_a_saved_feed_once
FAILED test_two_requests_fetch_a_game_pk_once
FAILED test_concurrent_first_requests_read_the_feed_once
FAILED test_a_feed_that_stops_reading_cannot_break_a_later_request
FAILED test_a_saved_feed_edited_on_disk_is_read_once_per_run
```

The other three are guards that must pass on both sides: a repointed binding, a
first read failure that is not remembered, and a memo that does not change what
the configuration compares or prints as.

Each commit passes the suite on its own: 311 tests at the #845 commit, 319 at the
#844 commit.

## 4. What I chose not to do

* **No cache with an eviction policy for the feed.** The measurement above says
  the resident set is bounded by the configuration, so a policy would be a knob
  with no number behind it.
* **No mid-game refresh of a `game_pk` fetch.** A live feed grows during a game,
  so a refresh needs a staleness rule. No measurement here asks for one, and
  guessing at it is what #839 refused to do for this recognizer.
* **Play-by-play is still constructed per request.** That construction is a
  `PlayByPlayRecognizer.__init__` with no model and no I/O once the events are
  memoized. It is keyed per media file, so caching the instance would be the
  per-media cache the feed read never needed. The cost this issue named was the
  feed, and the feed is what this fixes.
* **A first feed read that fails still aborts the request.** It raises, exactly
  as it did before, because `cues_for` calls `events()` outside
  `try_recognizer`. Play-by-play labels are an optional backend asset like the
  face bank, so #651's rule argues they should degrade to a skip note instead.
  That is a behaviour change beyond this issue, and it needs its own decision
  about whether a corpus with a feed should ever answer without one. It is not
  in this PR.
* **No parallel inference and no instance pool.** Unchanged from #839.

## 5. Review findings addressed

`coderabbit review --committed` ran on the first version of these commits and
raised two findings. Both were valid. Both are fixed in the commit that
introduced the code.

1. **Major, `pipeline.py`**: the binding was sampled before the lock. A binding
   repointed while a request queued would have filed the new feed's events under
   the old key, so a later change back to that key could return the wrong feed's
   events. The binding is now read under the lock, and the read uses those
   locals.
2. **Minor, `faces.py`**: a DIRECTORY named `nested.jpg` counted as an image. A
   bank with nothing to enroll would then pass the new check, build the embedder,
   and hand it a path that was never an image, which is the abort #845 exists to
   remove. The check now tests `is_file()` as well as the suffix, and
   `test_a_directory_named_like_an_image_is_not_an_image` pins it.

The CodeRabbit bot on the PR then raised a third case in the same family, also
valid and also fixed: `is_file()` says nothing about permissions, so a regular
`.jpg` the process cannot open counted as an image. That bank has nothing to
enroll, and it used to learn so only after the models loaded, from a message
about the detector rather than about a permission. Each candidate image is now
opened during the preflight. One unreadable image costs its own player a warning,
the rest of the bank still enrolls, and a bank that keeps nobody says which
problem it has. Two tests cover it.

A CLI verification pass was refused: the CodeRabbit account is rate limited
("Review limit reached", 51 minutes). So the amended commits got a line-by-line
self-review instead. It found four things, all fixed: a docstring that still
pointed the unreadable-directory warning at `_enroll` after it moved, three
`f`-prefixed literal fragments with no placeholder in them, an `Optional` re-read
of `self._parsed` on the return path, and two unused fixtures in the new test
file.

## Verification

```
make check          # exit 0
make test-annotator # 319 passed
```

## Checklist

- [x] `coderabbit review` run and findings addressed
- [x] `make check` passes locally
- [x] New behaviour has test coverage that fails without the change
- [x] Docstrings in `pipeline.py` and `faces.py` stay truthful
- [x] No unrelated files changed
