### PR TITLE
fix(index): finish a partial init in both networked backends (#675, #666)

### DIFF
--- a/internal/index/pgvectorindex/index.go
+++ b/internal/index/pgvectorindex/index.go
@@ -96,15 +96,28 @@ type Index struct {
 	schema string
 	table  string
 
-	mu         sync.Mutex
-	dim        int  // 0 until known (config or first vector)
-	tableReady bool // vectors table created (+ HNSW index when dim <= HNSWMaxDim)
+	mu  sync.Mutex
+	dim int // 0 until known (config or first vector)
+	// tableReady is true once THIS process created (or re-issued the DDL for) the
+	// vectors table and its HNSW index, so Upsert may skip the DDL.
+	tableReady bool
+	// tableExists is true once the vectors table has been observed in the
+	// database. It gates Search/Delete only, and it is weaker than tableReady on
+	// purpose: a table another process created answers queries here, and a table
+	// whose HNSW index a crashed process never finished still needs the DDL
+	// re-issued by the next Upsert (issue #666).
+	tableExists bool
 }
 
 // Open connects to Postgres, verifies pgvector is available, and ensures the
 // schema (vectors table + HNSW index + identity table) exists. A connection or
 // extension failure returns a clear, remediable error — there is no silent
 // fallback to the in-memory backend (issue #269).
+//
+// With an unknown dimension the vectors table cannot be created here, so Open
+// asks the catalog whether an earlier run already created it. That makes a
+// restart over a populated corpus queryable before it embeds anything, and it
+// keeps a fresh corpus an empty index rather than an error (issue #666).
 func Open(ctx context.Context, cfg Config) (*Index, error) {
 	cfg = cfg.withDefaults()
 	if err := cfg.validate(); err != nil {
@@ -125,12 +138,20 @@ func Open(ctx context.Context, cfg Config) (*Index, error) {
 	}
 	// When the dimension is known up front, create the vectors table eagerly so
 	// a connection/privilege problem surfaces at startup rather than on the
-	// first embedded chunk. With dim==0 the table is created lazily.
+	// first embedded chunk. With dim==0 the table is created lazily, so ask the
+	// catalog whether a previous run already created it: a restart over a
+	// populated corpus must serve searches before it embeds anything (issue
+	// #666).
 	if cfg.Dim > 0 {
 		if err := ix.ensureVectorsTable(ctx, cfg.Dim); err != nil {
 			pool.Close()
 			return nil, err
 		}
+		return ix, nil
+	}
+	if _, err := ix.vectorsTablePresent(ctx); err != nil {
+		pool.Close()
+		return nil, err
 	}
 	return ix, nil
 }
@@ -139,15 +160,17 @@ func Open(ctx context.Context, cfg Config) (*Index, error) {
 // opening a real connection pool. It is the seam out-of-package tests use to
 // exercise the Index methods against a stub Querier (no live database). Schema
 // and Table fall back to the package defaults when empty; if tableReady is true
-// the vectors table is assumed to already exist (Upsert will not re-issue DDL).
+// the vectors table is assumed to already exist, so Upsert does not re-issue the
+// DDL and Search/Delete do not check the catalog for it.
 func NewWithQuerier(db Querier, cfg Config, tableReady bool) *Index {
 	cfg = cfg.withDefaults()
 	return &Index{
-		db:         db,
-		schema:     cfg.Schema,
-		table:      cfg.Table,
-		dim:        cfg.Dim,
-		tableReady: tableReady,
+		db:          db,
+		schema:      cfg.Schema,
+		table:       cfg.Table,
+		dim:         cfg.Dim,
+		tableReady:  tableReady,
+		tableExists: tableReady,
 	}
 }
 
@@ -198,7 +221,53 @@ func (i *Index) ensureVectorsTable(ctx context.Context, dim int) error {
 	}
 	i.dim = dim
 	i.tableReady = true
+	i.tableExists = true
 	return nil
+}
+
+// vectorsTablePresent reports whether the vectors table exists. The answer comes
+// from the database catalog, never from this process's memory, so a table another
+// process (or an earlier run) created is found: a fresh index is an empty index,
+// but a populated table must never be reported empty (issue #666). A positive
+// answer is cached; a negative one is not, because the table appears as soon as
+// something is embedded.
+func (i *Index) vectorsTablePresent(ctx context.Context) (bool, error) {
+	i.mu.Lock()
+	known := i.tableExists
+	i.mu.Unlock()
+	if known {
+		return true, nil
+	}
+	var present bool
+	if err := i.db.QueryRow(ctx, tableExistsSQL, qualifiedTable(i.schema, i.table)).Scan(&present); err != nil {
+		return false, fmt.Errorf("pgvector: check vectors table: %w", err)
+	}
+	if present {
+		i.mu.Lock()
+		i.tableExists = true
+		i.mu.Unlock()
+	}
+	return present, nil
+}
+
+// forgetVectorsTable clears the cached presence and readiness flags. It is called
+// when the database reports the table missing under a query that expected it,
+// which happens when another process dropped it (Reset) after the check. The
+// next call probes again, so the state repairs itself.
+func (i *Index) forgetVectorsTable() {
+	i.mu.Lock()
+	i.tableExists = false
+	i.tableReady = false
+	i.mu.Unlock()
+}
+
+// isUndefinedTable reports whether err is Postgres' undefined_table (42P01).
+func isUndefinedTable(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == undefinedTableCode
+	}
+	return false
 }
 
 // Upsert stores (or replaces) the vector and its payload, keyed by
@@ -235,8 +304,23 @@ func (i *Index) Delete(ctx context.Context, chunkIDs []uint64) error {
 	if len(chunkIDs) == 0 {
 		return nil
 	}
+	// A vectors table that does not exist holds no vector, so there is nothing to
+	// delete. Without this the first reconciliation of a corpus that has not
+	// embedded anything yet fails with "relation ... does not exist" (issue #666).
+	present, err := i.vectorsTablePresent(ctx)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil
+	}
 	sql, args := DeleteSQL(i.schema, i.table, chunkIDs)
 	if _, err := i.db.Exec(ctx, sql, args...); err != nil {
+		if isUndefinedTable(err) {
+			// Dropped between the check and the delete: still nothing to delete.
+			i.forgetVectorsTable()
+			return nil
+		}
 		return fmt.Errorf("pgvector: delete: %w", err)
 	}
 	return nil
@@ -255,9 +339,24 @@ func (i *Index) Search(ctx context.Context, vector []float32, k int, filter mode
 	if k <= 0 {
 		return []model.IndexHit{}, nil
 	}
+	// A vectors table that does not exist holds no vector, so the answer is zero
+	// hits. Without this a search before the first embedded chunk fails with
+	// "relation ... does not exist" (issue #666).
+	present, err := i.vectorsTablePresent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return []model.IndexHit{}, nil
+	}
 	sql, args := SearchSQL(i.schema, i.table, vector, k, filter)
 	rows, err := i.db.Query(ctx, sql, args...)
 	if err != nil {
+		if isUndefinedTable(err) {
+			// Dropped between the check and the query: an empty index again.
+			i.forgetVectorsTable()
+			return []model.IndexHit{}, nil
+		}
 		return nil, fmt.Errorf("pgvector: search: %w", err)
 	}
 	defer rows.Close()
@@ -333,6 +432,7 @@ func (i *Index) Reset(ctx context.Context, identity string) error {
 	}
 	i.mu.Lock()
 	i.tableReady = false
+	i.tableExists = false
 	i.mu.Unlock()
 	upsertIdentity := fmt.Sprintf(`INSERT INTO %s (id, identity) VALUES (true, $1)
 ON CONFLICT (id) DO UPDATE SET identity = EXCLUDED.identity`, identityTable(i.schema, i.table))

--- a/internal/index/pgvectorindex/sql.go
+++ b/internal/index/pgvectorindex/sql.go
@@ -23,6 +23,16 @@ const (
 	// a different embed provider/model/dimension is reset, never silently
 	// reused.
 	identityTableSuffix = "_identity"
+
+	// tableExistsSQL asks the catalog whether a relation exists, by its quoted,
+	// schema-qualified name ($1). to_regclass returns NULL for an absent
+	// relation, so the statement is valid whether or not the table is there,
+	// which is what makes it usable as the guard for Search/Delete on a corpus
+	// that has not embedded anything yet (issue #666).
+	tableExistsSQL = `SELECT to_regclass($1) IS NOT NULL`
+
+	// undefinedTableCode is Postgres' SQLSTATE for "relation does not exist".
+	undefinedTableCode = "42P01"
 )
 
 // quoteIdent quotes a SQL identifier (schema or table name) for safe

--- a/internal/index/qdrantindex/qdrant.go
+++ b/internal/index/qdrantindex/qdrant.go
@@ -39,8 +39,8 @@ type Client interface {
 // Index is a Qdrant-backed model.Index. A single instance maps to one Qdrant
 // collection (one per dir2mcp index kind, e.g. text/code). The collection is
 // created lazily on first Upsert because Qdrant requires the vector dimension
-// up front, which dir2mcp only learns from the first embedding; Search before
-// any Upsert returns no hits.
+// up front, which dir2mcp only learns from the first embedding; Search over a
+// collection that does not exist yet returns no hits.
 type Index struct {
 	client     Client
 	collection string
@@ -49,7 +49,16 @@ type Index struct {
 	// dim is the vector dimension recorded when the collection was created;
 	// 0 means the collection does not exist yet.
 	dim int
-	// ready is true once we have confirmed (or created) the collection.
+	// exists is true once the collection has been observed on the server. It
+	// gates Search/Delete only: an existing collection answers queries and
+	// deletes by id whether or not THIS process has finished its setup.
+	exists bool
+	// ready is true once every required component of the collection is
+	// confirmed: the collection itself, both payload field indexes, and the
+	// embed-identity sentinel. Only then may ensureCollection skip its work
+	// (issue #675). It is deliberately narrower than exists: a collection left
+	// half-built by a failed setup exists but is not ready, so the next call
+	// finishes it.
 	ready bool
 	// identity is the corpus-lifetime embed identity (SPEC 8.1.4) recorded for
 	// this collection, mirrored in memory for cheap Identity() reads.
@@ -168,10 +177,11 @@ func (i *Index) Delete(ctx context.Context, chunkIDs []uint64) error {
 	if len(chunkIDs) == 0 {
 		return nil
 	}
-	i.mu.Lock()
-	ready := i.ready
-	i.mu.Unlock()
-	if !ready {
+	present, err := i.collectionPresent(ctx)
+	if err != nil {
+		return err
+	}
+	if !present {
 		return nil
 	}
 
@@ -179,12 +189,11 @@ func (i *Index) Delete(ctx context.Context, chunkIDs []uint64) error {
 	for _, id := range chunkIDs {
 		ids = append(ids, qdrant.NewIDNum(id))
 	}
-	_, err := i.client.Delete(ctx, &qdrant.DeletePoints{
+	if _, err := i.client.Delete(ctx, &qdrant.DeletePoints{
 		CollectionName: i.collection,
 		Points:         qdrant.NewPointsSelector(ids...),
 		Wait:           qdrant.PtrOf(true),
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("qdrant delete: %w", err)
 	}
 	return nil
@@ -203,10 +212,11 @@ func (i *Index) Search(ctx context.Context, vector []float32, k int, filter mode
 	if k <= 0 {
 		return []model.IndexHit{}, nil
 	}
-	i.mu.Lock()
-	ready := i.ready
-	i.mu.Unlock()
-	if !ready {
+	present, err := i.collectionPresent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
 		return []model.IndexHit{}, nil
 	}
 
@@ -261,7 +271,51 @@ func (i *Index) Identity(ctx context.Context) (string, error) {
 	if !exists {
 		return "", nil
 	}
-	i.ready = true
+	// The collection answers queries from here on, but its setup is NOT known to
+	// be complete: a previous run can have died between the create and the
+	// payload indexes or the sentinel (issue #675). Only ensureCollection, which
+	// reconciles every component, may set ready.
+	i.exists = true
+	stored, err := i.readIdentitySentinel(ctx)
+	if err != nil {
+		return "", err
+	}
+	i.identity = stored
+	return stored, nil
+}
+
+// collectionPresent reports whether the collection exists, which is all Search
+// and Delete need: both are well defined over a collection whose payload indexes
+// or sentinel are still missing.
+//
+// The answer comes from the server whenever this process has not seen the
+// collection yet, never from memory alone. A collection an earlier run created
+// holds vectors, so answering "empty" from a process that has upserted nothing
+// would return silently wrong results. A positive answer is cached; a negative
+// one is not, because the collection appears as soon as something is embedded.
+func (i *Index) collectionPresent(ctx context.Context) (bool, error) {
+	i.mu.Lock()
+	known := i.exists
+	i.mu.Unlock()
+	if known {
+		return true, nil
+	}
+	exists, err := i.client.CollectionExists(ctx, i.collection)
+	if err != nil {
+		return false, fmt.Errorf("qdrant collection exists: %w", err)
+	}
+	if exists {
+		i.mu.Lock()
+		i.exists = true
+		i.mu.Unlock()
+	}
+	return exists, nil
+}
+
+// readIdentitySentinel returns the embed identity recorded in the reserved
+// sentinel point, or "" when the collection carries no sentinel. The caller must
+// hold i.mu.
+func (i *Index) readIdentitySentinel(ctx context.Context) (string, error) {
 	got, err := i.client.Get(ctx, &qdrant.GetPoints{
 		CollectionName: i.collection,
 		Ids:            []*qdrant.PointId{qdrant.NewIDNum(identityPointID)},
@@ -273,8 +327,7 @@ func (i *Index) Identity(ctx context.Context) (string, error) {
 	if len(got) == 0 {
 		return "", nil
 	}
-	i.identity = got[0].GetPayload()[identityKey].GetStringValue()
-	return i.identity, nil
+	return got[0].GetPayload()[identityKey].GetStringValue(), nil
 }
 
 // Reset clears all vectors/payloads and records identity as the new
@@ -297,6 +350,7 @@ func (i *Index) Reset(ctx context.Context, identity string) error {
 			return fmt.Errorf("qdrant delete collection: %w", err)
 		}
 	}
+	i.exists = false
 	i.ready = false
 	i.dim = 0
 	i.identity = identity
@@ -308,9 +362,16 @@ func (i *Index) Close() error {
 	return i.client.Close()
 }
 
-// ensureCollection creates the collection (cosine distance, payload indexes for
-// the pushable filter fields, and the identity sentinel) on first use. It is
-// idempotent: a pre-existing collection is adopted without recreation.
+// ensureCollection brings the collection to its required shape on first use:
+// the collection itself (cosine distance), the keyword payload indexes the
+// pushed-down filter relies on, and the embed-identity sentinel.
+//
+// Every step is idempotent and every step runs on every attempt until they all
+// succeed, so a setup that failed part-way is finished by the next call instead
+// of being adopted half-built (issue #675). A pre-existing collection is still
+// adopted without any destructive recreation: only the missing components are
+// added. ready is set last, so it means "all components confirmed" and never
+// "the collection is there".
 func (i *Index) ensureCollection(ctx context.Context, dim int) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -327,14 +388,22 @@ func (i *Index) ensureCollection(ctx context.Context, dim int) error {
 			return err
 		}
 	}
+	i.exists = true
+	if err := i.ensureFieldIndexes(ctx); err != nil {
+		return err
+	}
+	if err := i.ensureIdentitySentinel(ctx, dim); err != nil {
+		return err
+	}
 	i.dim = dim
 	i.ready = true
 	return nil
 }
 
-// createCollection creates the collection with cosine distance, adds the
-// keyword payload indexes the pushed-down filter relies on, and writes the
-// embed-identity sentinel point.
+// createCollection creates the collection with cosine distance. The payload
+// indexes and the identity sentinel are NOT written here: ensureCollection adds
+// them for a newly created and for an adopted collection alike, so one code path
+// covers both and neither can be skipped.
 func (i *Index) createCollection(ctx context.Context, dim int) error {
 	if err := i.client.CreateCollection(ctx, &qdrant.CreateCollection{
 		CollectionName: i.collection,
@@ -345,7 +414,14 @@ func (i *Index) createCollection(ctx context.Context, dim int) error {
 	}); err != nil {
 		return fmt.Errorf("qdrant create collection: %w", err)
 	}
+	return nil
+}
 
+// ensureFieldIndexes creates the keyword payload indexes for the pushable
+// filter fields. Qdrant treats a create over an existing index of the same
+// schema as a no-op, so this is safe to re-issue on every attempt and repairs a
+// collection whose indexes were lost to a failed setup.
+func (i *Index) ensureFieldIndexes(ctx context.Context) error {
 	for _, field := range []string{fieldDocTypeLC, fieldRelPath} {
 		if _, err := i.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
 			CollectionName: i.collection,
@@ -355,13 +431,44 @@ func (i *Index) createCollection(ctx context.Context, dim int) error {
 			return fmt.Errorf("qdrant create field index %q: %w", field, err)
 		}
 	}
-
-	if i.identity != "" {
-		if err := i.writeIdentitySentinel(ctx, dim); err != nil {
-			return err
-		}
-	}
 	return nil
+}
+
+// ensureIdentitySentinel makes the stored embed identity (SPEC 8.1.4) agree with
+// the one this Index holds, and it never overwrites a stored one. The embed
+// identity is the fence that keeps two vector spaces apart, so the three cases
+// are kept apart deliberately:
+//
+//   - nothing stored: write what this Index holds. A collection is only ever
+//     written to after this returns, so a collection that holds vectors holds
+//     the identity those vectors were built under.
+//   - stored, and this Index holds nothing: adopt the stored value. The server
+//     is the record; Identity() already reports it.
+//   - stored, and it differs from what this Index holds: refuse. Overwriting the
+//     sentinel would relabel another run's vectors, and adopting the stored
+//     value would mislabel the vectors this process is about to write. Neither
+//     is a silent option, so the upsert fails and the operator is told.
+//
+// The caller must hold i.mu.
+func (i *Index) ensureIdentitySentinel(ctx context.Context, dim int) error {
+	stored, err := i.readIdentitySentinel(ctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case stored == "" && i.identity == "":
+		return nil
+	case stored == "":
+		return i.writeIdentitySentinel(ctx, dim)
+	case i.identity == "":
+		i.identity = stored
+		return nil
+	case stored != i.identity:
+		return fmt.Errorf("qdrant collection %q records embed identity %q but this process embeds under %q: refusing to mix vector spaces (SPEC 8.1.4); reindex the corpus or point it at a different collection",
+			i.collection, stored, i.identity)
+	default:
+		return nil
+	}
 }
 
 // writeIdentitySentinel upserts the reserved identity point. The sentinel uses

--- a/tests/index/qdrant_partial_init_675_test.go
+++ b/tests/index/qdrant_partial_init_675_test.go
@@ -1,0 +1,302 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qdrant/go-client/qdrant"
+
+	"github.com/dirstral/dir2mcp/internal/index/qdrantindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// newStubIndexOver builds an Index over any stub client (newStubIndex only takes
+// the plain stubQdrant).
+func newStubIndexOver(t *testing.T, c qdrantindex.Client) *qdrantindex.Index {
+	t.Helper()
+	idx, err := qdrantindex.NewWithClient(c, qdrantindex.Config{Collection: "test"})
+	if err != nil {
+		t.Fatalf("NewWithClient: %v", err)
+	}
+	return idx
+}
+
+// The wire keys the Qdrant backend uses for the two pushed-down filter fields
+// and for the reserved embed-identity sentinel. They are unexported in
+// internal/index/qdrantindex, so the tests name them literally: a rename must
+// break these tests, because the stored shape is what a live collection holds.
+const (
+	fieldIdxDocTypeLC = "doc_type_lc"
+	fieldIdxRelPath   = "rel_path"
+	sentinelKey       = "__embed_identity__"
+	sentinelPointID   = uint64(0)
+)
+
+// partialInitQdrant wraps stubQdrant with fault injection on the steps that run
+// AFTER CreateCollection: the two payload field indexes and the identity
+// sentinel write (issue #675). Each fault fires a fixed number of times and then
+// the step succeeds, which is exactly the transient-failure-then-retry shape the
+// issue describes.
+type partialInitQdrant struct {
+	*stubQdrant
+
+	// failFieldIndex maps a field name to the number of remaining failures.
+	failFieldIndex map[string]int
+	// failSentinel is the number of remaining failures for the sentinel write.
+	failSentinel int
+
+	fieldIndexOK   map[string]int
+	sentinelWrites int
+}
+
+func newPartialInitQdrant() *partialInitQdrant {
+	return &partialInitQdrant{
+		stubQdrant:     newStubQdrant(),
+		failFieldIndex: map[string]int{},
+		fieldIndexOK:   map[string]int{},
+	}
+}
+
+func (p *partialInitQdrant) CreateFieldIndex(ctx context.Context, req *qdrant.CreateFieldIndexCollection) (*qdrant.UpdateResult, error) {
+	field := req.GetFieldName()
+	if p.failFieldIndex[field] > 0 {
+		p.failFieldIndex[field]--
+		return nil, errors.New("injected: create field index failed")
+	}
+	p.fieldIndexOK[field]++
+	return p.stubQdrant.CreateFieldIndex(ctx, req)
+}
+
+func (p *partialInitQdrant) Upsert(ctx context.Context, req *qdrant.UpsertPoints) (*qdrant.UpdateResult, error) {
+	if isSentinelUpsert(req) {
+		if p.failSentinel > 0 {
+			p.failSentinel--
+			return nil, errors.New("injected: sentinel write failed")
+		}
+		p.sentinelWrites++
+	}
+	return p.stubQdrant.Upsert(ctx, req)
+}
+
+// isSentinelUpsert reports whether req writes the reserved identity point.
+func isSentinelUpsert(req *qdrant.UpsertPoints) bool {
+	for _, pt := range req.GetPoints() {
+		if pt.GetId().GetNum() == sentinelPointID {
+			return true
+		}
+	}
+	return false
+}
+
+// storedIdentity returns the identity the stub collection holds, or "".
+func storedIdentity(s *stubQdrant) string {
+	return s.points[sentinelPointID][sentinelKey].GetStringValue()
+}
+
+// seedIdentity records an identity sentinel directly in the stub collection, as
+// a previous process would have left it.
+func seedIdentity(s *stubQdrant, identity string) {
+	s.collExists = true
+	s.points[sentinelPointID] = map[string]*qdrant.Value{
+		sentinelKey: qdrant.NewValueString(identity),
+	}
+}
+
+// TestQdrant_RetryAfterFieldIndexFailureFinishesSetup drives the #675 defect:
+// CreateCollection succeeds, the FIRST payload field index fails once, and the
+// retry must finish every remaining setup step instead of adopting the
+// half-built collection.
+func TestQdrant_RetryAfterFieldIndexFailureFinishesSetup(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	s.failFieldIndex[fieldIdxDocTypeLC] = 1
+	idx := newStubIndexOver(t, s)
+
+	// EnsureIdentity on a fresh index does exactly this: it records the
+	// configured identity, and the collection is created on the next Upsert.
+	if err := idx.Reset(ctx, "ident-A"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	vec := []float32{1, 0, 0}
+	if err := idx.Upsert(ctx, vec, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}); err == nil {
+		t.Fatal("first Upsert must fail: the field index creation was made to fail")
+	}
+	if !s.created {
+		t.Fatal("the collection should have been created before the failing step")
+	}
+
+	// The retry must complete the setup: both payload indexes and the sentinel.
+	if err := idx.Upsert(ctx, vec, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}); err != nil {
+		t.Fatalf("retry Upsert: %v", err)
+	}
+	if s.fieldIndexOK[fieldIdxDocTypeLC] == 0 {
+		t.Errorf("payload index %q was never created: the retry adopted a collection with missing indexes", fieldIdxDocTypeLC)
+	}
+	if s.fieldIndexOK[fieldIdxRelPath] == 0 {
+		t.Errorf("payload index %q was never created: the retry adopted a collection with missing indexes", fieldIdxRelPath)
+	}
+	if got := storedIdentity(s.stubQdrant); got != "ident-A" {
+		t.Errorf("stored embed identity = %q, want %q: the retry adopted a collection with no identity sentinel", got, "ident-A")
+	}
+	// The collection is adopted, never recreated destructively.
+	if s.deletedCol {
+		t.Error("the retry must not delete the collection")
+	}
+}
+
+// TestQdrant_RetryAfterSentinelFailureRecordsIdentity drives the dangerous half
+// of #675: the sentinel write is the last setup step, so a failure there leaves a
+// collection that takes vectors while recording no embed identity. A later
+// process reads no identity, treats the populated collection as fresh, and
+// Reset wipes every vector while sqlite still records those chunks as embedded.
+func TestQdrant_RetryAfterSentinelFailureRecordsIdentity(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	s.failSentinel = 1
+	idx := newStubIndexOver(t, s)
+
+	if err := idx.Reset(ctx, "ident-A"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	vec := []float32{1, 0, 0}
+	if err := idx.Upsert(ctx, vec, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}); err == nil {
+		t.Fatal("first Upsert must fail: the sentinel write was made to fail")
+	}
+	if err := idx.Upsert(ctx, vec, model.IndexPayload{ChunkID: 1, RelPath: "a.md"}); err != nil {
+		t.Fatalf("retry Upsert: %v", err)
+	}
+	if s.sentinelWrites != 1 {
+		t.Errorf("sentinel writes = %d, want 1: the retry must write the identity the failed attempt lost", s.sentinelWrites)
+	}
+
+	// A NEW Index over the same collection is what the next process sees. It must
+	// read the identity from the collection, not from this process's memory.
+	next := newStubIndexOver(t, s)
+	got, err := next.Identity(ctx)
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if got != "ident-A" {
+		t.Fatalf("next process reads identity %q, want %q: a populated collection with no identity is reset and loses every vector", got, "ident-A")
+	}
+}
+
+// TestQdrant_AdoptedCollectionKeepsStoredIdentity guards the other direction:
+// reconciling an existing, fully initialized collection must not rewrite its
+// recorded identity or drop its points.
+func TestQdrant_AdoptedCollectionKeepsStoredIdentity(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	seedIdentity(s.stubQdrant, "ident-A")
+	s.points[7] = map[string]*qdrant.Value{"chunk_id": qdrant.NewValueInt(7)}
+	idx := newStubIndexOver(t, s)
+
+	if err := idx.Upsert(ctx, []float32{1, 0, 0}, model.IndexPayload{ChunkID: 8, RelPath: "b.md"}); err != nil {
+		t.Fatalf("Upsert over an adopted collection: %v", err)
+	}
+	if s.created || s.deletedCol {
+		t.Error("an existing collection must be adopted without recreation")
+	}
+	if got := storedIdentity(s.stubQdrant); got != "ident-A" {
+		t.Errorf("stored identity = %q, want it left at %q", got, "ident-A")
+	}
+	if s.sentinelWrites != 0 {
+		t.Errorf("sentinel writes = %d, want 0: a recorded identity must never be overwritten", s.sentinelWrites)
+	}
+	if _, ok := s.points[7]; !ok {
+		t.Error("the pre-existing point was lost")
+	}
+}
+
+// TestQdrant_MismatchedStoredIdentityIsRefused proves the fence holds: a stored
+// identity that differs from the one this process embeds under is neither
+// adopted nor overwritten. The state is what two processes over one collection
+// leave: this process reset the collection under ident-B, and another process
+// recreated it under ident-A.
+func TestQdrant_MismatchedStoredIdentityIsRefused(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	idx := newStubIndexOver(t, s)
+
+	if err := idx.Reset(ctx, "ident-B"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	// Another process recreated the collection under a different identity.
+	seedIdentity(s.stubQdrant, "ident-A")
+
+	err := idx.Upsert(ctx, []float32{1, 0, 0}, model.IndexPayload{ChunkID: 9, RelPath: "c.md"})
+	if err == nil {
+		t.Fatal("Upsert must refuse a collection recorded under a different embed identity")
+	}
+	if !strings.Contains(err.Error(), "ident-A") || !strings.Contains(err.Error(), "ident-B") {
+		t.Errorf("the error must name both identities, got: %v", err)
+	}
+	if got := storedIdentity(s.stubQdrant); got != "ident-A" {
+		t.Errorf("stored identity = %q, want it left at %q", got, "ident-A")
+	}
+	if _, ok := s.points[9]; ok {
+		t.Error("no vector may be written into a collection of another vector space")
+	}
+}
+
+// TestQdrant_SearchAsksTheServerBeforeReportingAnEmptyIndex covers the same
+// question as #666 on the qdrant side: readiness held in memory must not decide
+// that a collection is empty. A process that has upserted nothing and has not
+// read the identity yet must ask the server, because a collection an earlier run
+// created holds vectors.
+func TestQdrant_SearchAsksTheServerBeforeReportingAnEmptyIndex(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	seedIdentity(s.stubQdrant, "ident-A")
+	s.points[7] = map[string]*qdrant.Value{"chunk_id": qdrant.NewValueInt(7)}
+	idx := newStubIndexOver(t, s)
+
+	hits, err := idx.Search(ctx, []float32{1, 0, 0}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 7 {
+		t.Fatalf("hits = %+v, want the one stored point: an existing collection is not an empty index", hits)
+	}
+	if err := idx.Delete(ctx, []uint64{7}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if s.lastDelete == nil {
+		t.Fatal("Delete must reach the server for an existing collection")
+	}
+}
+
+// TestQdrant_SearchOverAdoptedCollectionBeforeSetup guards the split between
+// "the collection exists" and "the setup is complete". Search and Delete need
+// only the former, so a restart that has not upserted anything yet must still
+// query the server rather than answer an empty result from memory.
+func TestQdrant_SearchOverAdoptedCollectionBeforeSetup(t *testing.T) {
+	ctx := context.Background()
+	s := newPartialInitQdrant()
+	seedIdentity(s.stubQdrant, "ident-A")
+	s.points[7] = map[string]*qdrant.Value{"chunk_id": qdrant.NewValueInt(7)}
+	idx := newStubIndexOver(t, s)
+
+	if _, err := idx.Identity(ctx); err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	hits, err := idx.Search(ctx, []float32{1, 0, 0}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if s.lastQuery == nil {
+		t.Fatal("Search must reach the server for an existing collection")
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 7 {
+		t.Fatalf("hits = %+v, want the one stored point", hits)
+	}
+	if err := idx.Delete(ctx, []uint64{7}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if s.lastDelete == nil {
+		t.Fatal("Delete must reach the server for an existing collection")
+	}
+}

--- a/tests/pgvectorindex/vectors_table_absent_666_test.go
+++ b/tests/pgvectorindex/vectors_table_absent_666_test.go
@@ -1,0 +1,266 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/dirstral/dir2mcp/internal/index/pgvectorindex"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// lazyTableQuerier is a Querier that behaves like a Postgres database in which
+// the dimensioned vectors table is created lazily: while the table is absent,
+// every statement against it fails with undefined_table (42P01), exactly as the
+// server does. It records what the Index issued so the tests can assert that no
+// statement was sent to a table that does not exist (issue #666).
+type lazyTableQuerier struct {
+	// tablePresent mirrors the database: the vectors table exists or it does not.
+	tablePresent bool
+	// searchRows, when > 0, is the number of rows a search over a present table
+	// returns.
+	searchRows int
+
+	execSQL   []string
+	querySQL  []string
+	probes    int
+	dropSeen  bool
+	forceGone bool // report present, then fail the statement: a concurrent drop
+}
+
+func (q *lazyTableQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	q.execSQL = append(q.execSQL, sql)
+	if strings.Contains(sql, "DROP TABLE") {
+		q.dropSeen = true
+		q.tablePresent = false
+		return pgconn.NewCommandTag("DROP TABLE"), nil
+	}
+	if strings.Contains(sql, "CREATE TABLE IF NOT EXISTS") && !strings.Contains(sql, "_identity") {
+		q.tablePresent = true
+		return pgconn.NewCommandTag("CREATE TABLE"), nil
+	}
+	if q.touchesVectors(sql) && !q.tablePresent {
+		return pgconn.CommandTag{}, undefinedTable()
+	}
+	return pgconn.NewCommandTag("OK"), nil
+}
+
+func (q *lazyTableQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	q.querySQL = append(q.querySQL, sql)
+	if q.touchesVectors(sql) && (!q.tablePresent || q.forceGone) {
+		return nil, undefinedTable()
+	}
+	return &cannedRows{remaining: q.searchRows}, nil
+}
+
+func (q *lazyTableQuerier) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	if isCatalogProbe(sql) {
+		q.probes++
+		return &boolRow{value: q.tablePresent || q.forceGone}
+	}
+	return &boolRow{}
+}
+
+// isCatalogProbe reports whether sql asks the catalog whether a relation exists.
+// Such a statement is valid whether or not the table is there.
+func isCatalogProbe(sql string) bool {
+	return strings.Contains(sql, "to_regclass") || strings.Contains(sql, "information_schema")
+}
+
+// touchesVectors reports whether sql reads or writes the vectors table (as
+// opposed to the identity table or the catalog probe).
+func (q *lazyTableQuerier) touchesVectors(sql string) bool {
+	if strings.Contains(sql, "_identity") || isCatalogProbe(sql) {
+		return false
+	}
+	return strings.Contains(sql, pgvectorindex.DefaultTable)
+}
+
+// undefinedTable is the error Postgres returns for a statement against a table
+// that does not exist.
+func undefinedTable() error {
+	return &pgconn.PgError{
+		Code:    "42P01",
+		Message: `relation "public.dir2mcp_vectors" does not exist`,
+	}
+}
+
+// boolRow scans a single boolean, which is what the table-presence probe reads.
+type boolRow struct{ value bool }
+
+func (r *boolRow) Scan(dest ...any) error {
+	if len(dest) == 1 {
+		if p, ok := dest[0].(*bool); ok {
+			*p = r.value
+		}
+	}
+	return nil
+}
+
+// cannedRows is a pgx.Rows over a fixed number of identical search rows.
+type cannedRows struct{ remaining int }
+
+func (r *cannedRows) Close()                                       {}
+func (r *cannedRows) Err() error                                   { return nil }
+func (r *cannedRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *cannedRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *cannedRows) Values() ([]any, error)                       { return nil, nil }
+func (r *cannedRows) RawValues() [][]byte                          { return nil }
+func (r *cannedRows) Conn() *pgx.Conn                              { return nil }
+
+func (r *cannedRows) Next() bool {
+	if r.remaining <= 0 {
+		return false
+	}
+	r.remaining--
+	return true
+}
+
+// Scan fills the projection SearchSQL selects, in order.
+func (r *cannedRows) Scan(dest ...any) error {
+	set := func(i int, v any) {
+		switch p := dest[i].(type) {
+		case *int64:
+			*p = v.(int64)
+		case *string:
+			*p = v.(string)
+		case *int:
+			*p = v.(int)
+		case *float64:
+			*p = v.(float64)
+		case *[]byte:
+			*p = v.([]byte)
+		}
+	}
+	set(0, int64(42))
+	set(1, "a.md")
+	set(2, "md")
+	set(3, "text")
+	set(4, 0)
+	set(5, 0)
+	set(6, "en")
+	set(7, "")
+	set(8, []byte(`{}`))
+	set(9, 0.9)
+	return nil
+}
+
+// TestPgvector_SearchBeforeFirstUpsertIsEmpty drives #666: the vectors table is
+// created on the first Upsert, so a search before any chunk is embedded must
+// report an empty index rather than fail on a missing relation.
+func TestPgvector_SearchBeforeFirstUpsertIsEmpty(t *testing.T) {
+	q := &lazyTableQuerier{}
+	ix := pgvectorindex.NewWithQuerier(q, pgvectorindex.Config{}, false)
+
+	hits, err := ix.Search(context.Background(), []float32{0.1, 0.2}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search on a fresh index must succeed, got: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("hits = %d, want 0", len(hits))
+	}
+	for _, sql := range q.querySQL {
+		if strings.Contains(sql, pgvectorindex.DefaultTable) {
+			t.Fatalf("no statement may be sent to a table that does not exist, got: %q", sql)
+		}
+	}
+}
+
+// TestPgvector_DeleteBeforeFirstUpsertIsNoop drives the other half of #666: a
+// reconciliation that deletes chunk ids before anything is embedded must be a
+// no-op, not an error.
+func TestPgvector_DeleteBeforeFirstUpsertIsNoop(t *testing.T) {
+	q := &lazyTableQuerier{}
+	ix := pgvectorindex.NewWithQuerier(q, pgvectorindex.Config{}, false)
+
+	if err := ix.Delete(context.Background(), []uint64{1, 2, 3}); err != nil {
+		t.Fatalf("Delete on a fresh index must succeed, got: %v", err)
+	}
+	for _, sql := range q.execSQL {
+		if strings.Contains(sql, "DELETE FROM") {
+			t.Fatalf("no DELETE may be sent to a table that does not exist, got: %q", sql)
+		}
+	}
+}
+
+// TestPgvector_SearchAndDeleteOverAnExistingTableStillRunSQL is the guard that
+// keeps the #666 fix from becoming a silent empty result. A restart over a
+// populated corpus has embedded nothing yet in THIS process, so the readiness
+// flag is false while the table is full. The presence check must come from the
+// database, so both operations still run their SQL.
+func TestPgvector_SearchAndDeleteOverAnExistingTableStillRunSQL(t *testing.T) {
+	q := &lazyTableQuerier{tablePresent: true, searchRows: 1}
+	ix := pgvectorindex.NewWithQuerier(q, pgvectorindex.Config{}, false)
+
+	hits, err := ix.Search(context.Background(), []float32{0.1, 0.2}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ChunkID != 42 {
+		t.Fatalf("hits = %+v, want the one stored row", hits)
+	}
+	if err := ix.Delete(context.Background(), []uint64{42}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	var sawDelete bool
+	for _, sql := range q.execSQL {
+		if strings.Contains(sql, "DELETE FROM") {
+			sawDelete = true
+		}
+	}
+	if !sawDelete {
+		t.Fatalf("Delete over a populated table must issue the DELETE, execs: %v", q.execSQL)
+	}
+	// The positive answer is cached: one probe covers both operations.
+	if q.probes != 1 {
+		t.Errorf("catalog probes = %d, want 1 (the presence answer is cached)", q.probes)
+	}
+}
+
+// TestPgvector_ResetRequiresAFreshPresenceCheck covers the window Reset opens:
+// it DROPs the table, so a search after it must not query the dropped table on
+// the strength of a cached answer.
+func TestPgvector_ResetRequiresAFreshPresenceCheck(t *testing.T) {
+	q := &lazyTableQuerier{tablePresent: true, searchRows: 1}
+	ix := pgvectorindex.NewWithQuerier(q, pgvectorindex.Config{}, true)
+
+	if err := ix.Reset(context.Background(), "ident-A"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if !q.dropSeen {
+		t.Fatal("Reset must drop the vectors table")
+	}
+	hits, err := ix.Search(context.Background(), []float32{0.1, 0.2}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search after Reset must succeed, got: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("hits = %d, want 0 after Reset", len(hits))
+	}
+}
+
+// TestPgvector_TableDroppedAfterTheCheckIsStillEmpty covers the one window the
+// presence check cannot close: another process drops the table between the check
+// and the statement. The undefined_table error is then read as the empty index it
+// describes, and the cached answer is discarded so the next call checks again.
+func TestPgvector_TableDroppedAfterTheCheckIsStillEmpty(t *testing.T) {
+	q := &lazyTableQuerier{forceGone: true}
+	ix := pgvectorindex.NewWithQuerier(q, pgvectorindex.Config{}, false)
+
+	hits, err := ix.Search(context.Background(), []float32{0.1, 0.2}, 5, model.Filter{})
+	if err != nil {
+		t.Fatalf("Search must read a dropped table as empty, got: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("hits = %d, want 0", len(hits))
+	}
+	if err := ix.Delete(context.Background(), []uint64{1}); err != nil {
+		t.Fatalf("Delete must read a dropped table as a no-op, got: %v", err)
+	}
+	if q.probes < 2 {
+		t.Errorf("catalog probes = %d, want the cache discarded and re-checked", q.probes)
+	}
+}


### PR DESCRIPTION
Two networked index backends, one defect class in two commits: initialization
that is not atomic, so a later operation runs against a half-built store.

- **#675 (qdrant)**: the setup of a collection is four remote steps. Only the
  first one was conditional on the collection being absent, so a retry after a
  partial creation skipped the other three and declared the index ready.
- **#666 (pgvector)**: the vectors table is created on the first upsert, and
  `Search`/`Delete` queried it before that.

## 1. What the operator sees

| Issue | Symptom | Loud or silent |
| --- | --- | --- |
| #666 | `search` fails with `pgvector: search: relation "public.dir2mcp_vectors" does not exist (SQLSTATE 42P01)` on a corpus that has embedded nothing yet. A reconciliation that deletes chunk ids fails the same way. | **Loud.** An error the operator can read, on a corpus that is valid and simply empty. |
| #675 | Nothing, at first. The run reports `ready`, embeds the whole corpus, and answers queries. Filtered queries (`doc_type`, path prefix) do full scans instead of using the payload indexes, so they are slower with no message. | **Silent, degraded.** |
| #675, next start | The collection records no embed identity, so `EnsureIdentity` reads `""`, treats a populated collection as fresh, and `Reset` drops **every vector**. sqlite still records those chunks as `embedded`. The qdrant backend does not implement `VectorPresence`, so `ReconcileEmbeddedVectors` never re-pends them. | **Silent and wrong.** `status` says the corpus is indexed with 0 errors, and `search`/`ask` answer from an empty collection. This is the one to fear: no error, no log line, and only a manual `reindex` repairs it. |

The two are opposite failures of the same rule. A fresh, valid index is an empty
index, so #666 must not error. A populated index is never empty, so #675 must not
be reported ready when the fence that protects those vectors was never written.

## 2. #675: ordering, and what each failure point leaves

`createCollection` ran four remote mutations: create the collection, create the
`doc_type_lc` payload index, create the `rel_path` payload index, then write the
identity sentinel. All four sat inside `if !exists`. Any failure after the first
returned with `ready=false` and left the collection on the server. The next
`ensureCollection` saw `CollectionExists == true`, skipped the branch, and set
`ready = true` unconditionally.

**Ordering closes this one, so no durable state was added.** This is not #820,
where every prefix of a loop of unlinks was a legal observation that could not be
told apart. Here the server holds the state and can be asked, and every step is
idempotent:

- `createCollection` now only creates the collection.
- `ensureCollection` runs the payload indexes and the sentinel for a **created**
  and for an **adopted** collection alike. One path covers both, so no step can
  be skipped by a branch.
- Qdrant treats a create over an existing payload index of the same schema as a
  no-op, so re-issuing both is safe and repairs a missing one.
- `ready` is set **last**. It now means "every component is confirmed", not "the
  collection is there".

`ready` carried two meanings, so it is split in two. `exists` means the
collection is on the server, which is all `Search` and `Delete` need. `ready`
means the setup is complete. `Identity()` sets `exists` only; on `main` it set
`ready`, which is a second way a half-built collection could be adopted, one that
no upsert ever repaired.

### Failure and crash points

`X` is the collection. "Next attempt" is the next `Upsert` in the same process.

| # | failure point | on the server | in memory | next attempt | next process | verdict |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | `CreateCollection` fails | nothing | `ready=false`, `exists=false` | creates it, then every other step | same | correct: no state to misread |
| 2 | after `CreateCollection`, before the first payload index | X, no indexes, no sentinel, **no vectors** | `ready=false`, `exists=true` | adopts X, creates both indexes, writes the sentinel, sets `ready` | reads no identity, resets an **empty** X, rebuilds | correct and self-correcting (**this PR**; used to be adopted as ready, forever missing both indexes and the sentinel) |
| 3 | first payload index ok, second fails | X + 1 index | `ready=false`, `exists=true` | re-issues both (the first is a no-op), then the sentinel | as row 2 | same as row 2 |
| 4 | the sentinel write fails | X + both indexes, **no vectors** | `ready=false`, `exists=true` | indexes are no-ops, the sentinel is written, `ready` is set | as row 2 | same as row 2. On `main` this was the silent-wrong row: the retry adopted X, the run filled it with vectors, and the next start dropped them all |
| 5 | crash after all four steps, before the first vector | X fully set up, sentinel present | `ready=true` | upserts | reads the sentinel, adopts X, no reset | correct |
| 6 | crash with vectors in X | X + vectors + sentinel | - | - | adopts X; the first upsert re-confirms the two indexes and the sentinel once, then caches `ready` | correct: the invariant below holds |

**The invariant the new order buys.** Nothing is written into a collection until
`ensureCollection` returns, and it returns only after the sentinel is durable.
So **a collection that holds vectors holds the identity those vectors were built
under.** Row 4 is the row that used to break it.

**Cost.** One `CollectionExists`, two `CreateFieldIndex` and one `Get` per
process per kind, on the first upsert only. `ready` then short-circuits.

### Can a mismatched identity ever be adopted? No.

The identity is the fence that stops two vector spaces mixing (SPEC §8.1.4,
§6.4), and a heterogeneous worker pool is a real deployment (`distributed_embed`
requires a shared Tier-C store), so this is stated in full.
`ensureIdentitySentinel` has exactly three outcomes:

- **Nothing stored** → write what this Index holds. Safe, because the only way
  this Index holds an identity is `Reset`, which deletes the collection first, so
  the collection it stamps can only hold this process's vectors.
- **Stored, and this Index holds nothing** → adopt the stored value. The server
  is the record, and `Identity()` already reports exactly this.
- **Stored, and it differs** → **refuse** with an error naming both. Overwriting
  would relabel another run's vectors; adopting would mislabel the vectors this
  process is about to write. The upsert fails instead, which is what SPEC §8.7.3
  requires of a worker whose identity does not match ("MUST fail the job ...
  rather than write a vector").

A stored identity is therefore never overwritten, and a differing one is never
adopted. A legacy recording that `provider.EmbedIdentityMatches` accepted is left
byte for byte as it is: `EnsureIdentity` does not reset it, so the in-memory
value is the recorded string itself and compares equal.

## 3. #666: ask the database, not memory

`Open` with `Config.Dim == 0` (the production path: `NewPgvectorBackend` supplies
no dimension) creates only the extension and the identity table. The vectors
table carries the dimension in its `vector(dim)` column type, so it waits for the
first embedding. `Upsert` called `ensureVectorsTable`; `Search` and `Delete` ran
their SQL straight away.

**The obvious fix is wrong.** Gating on the in-process `tableReady` flag would
trade a loud error for a silent empty result. A restart over a populated corpus
embeds nothing until new content arrives, so that flag is `false` while the table
is full, and every search would answer zero hits. The same applies to a shared
table under `distributed_embed`, where the worker creates the table and the
daemon serves the queries.

So the presence answer comes from the database:

- `Search` and `Delete` ask the catalog (`SELECT to_regclass($1) IS NOT NULL`)
  when they do not already know the table is there. That statement is valid
  whether or not the table exists.
- Absent → zero hits / no-op. Present → the normal SQL runs.
- A positive answer is cached. A negative one is not, because the table appears
  as soon as anything is embedded.
- `Open` asks once when the dimension is unknown, so the restart-over-a-populated
  corpus case costs nothing on the search path.

`tableReady` is likewise split in two. `tableExists` gates `Search`/`Delete`;
`tableReady` still means "this process issued the DDL" and gates the `Upsert`
DDL. Keeping them apart matters: a table an earlier run created but whose
`CREATE INDEX` never ran still gets the DDL re-issued by the next `Upsert`, which
is the same partial-init defect one level down.

### Windows

| # | condition | what happens | verdict |
| --- | --- | --- | --- |
| 1 | fresh corpus, nothing embedded | catalog says absent; `Search` returns 0 hits, `Delete` is a no-op | correct: an empty index (**this PR**; used to be `42P01`) |
| 2 | restart over a populated table, this process has embedded nothing | catalog says present; both run their SQL | correct: no silent empty result |
| 3 | first `Upsert` after row 1 | `ensureVectorsTable` creates the table and the ANN index, sets both flags | correct: lazy creation is unchanged |
| 4 | `CREATE TABLE` ok, `CREATE INDEX` fails | `tableReady` stays false; the table exists | self-correcting: the next `Upsert` re-issues both (`IF NOT EXISTS`) |
| 5 | `Reset` drops the table, then a search | both flags cleared, so the catalog is asked again and says absent | correct: 0 hits, not a query against a dropped table |
| 6 | another process drops the table between the check and the statement | Postgres returns `42P01`, which describes the empty index it is: 0 hits / no-op, and the cached answer is discarded | self-correcting. This is the one window a check cannot close, so it is closed by reading the error rather than by adding state |

Row 6 is the only place an error is swallowed, and only that one SQLSTATE, only
for a table this code names itself. A privilege failure (`42501`), a connection
failure, or a failed catalog check is still returned to the caller: SPEC §6.3
forbids a silent downgrade, and none of these is one.

## 4. SPEC

No SPEC change is needed, so nothing is blocked on `dirstral-spec`.

- **§6.3** (Tier C, `CONFIG_INVALID` at preflight, no silent fallback): unchanged.
  Connection, privilege and catalog failures are still returned, and neither
  backend falls back to an embedded tier. The SPEC pins nothing about a search
  over a fresh Tier-C store; "a fresh index is an empty index" is the same
  contract the qdrant and memory backends already keep.
- **§8.1.4 / §6.4** (embed identity binds every backend, never silently serve a
  collection built under a different identity): the change makes the qdrant
  backend keep this rule where it previously could break it. It never writes over
  a recorded identity and it never adopts a differing one.
- **§8.7.3** (identity enforced per job in a worker pool): the new refusal is the
  behavior that clause requires.

## 5. Tests

One set per issue, both in `tests/`, both on in-memory doubles with no real
qdrant or Postgres.

`tests/index/qdrant_partial_init_675_test.go` (6 cases) injects a fault into each
post-create step through a wrapper over the existing `stubQdrant`:

- `TestQdrant_RetryAfterFieldIndexFailureFinishesSetup` (row 3)
- `TestQdrant_RetryAfterSentinelFailureRecordsIdentity` (row 4, and it reads the
  identity back through a **new** `Index` over the same collection, which is what
  the next process does)
- `TestQdrant_MismatchedStoredIdentityIsRefused` (the fence)
- `TestQdrant_SearchAsksTheServerBeforeReportingAnEmptyIndex`
- `TestQdrant_AdoptedCollectionKeepsStoredIdentity` (guard: no recreation, no
  rewrite of a recorded identity)
- `TestQdrant_SearchOverAdoptedCollectionBeforeSetup` (guard: the `ready`/`exists`
  split keeps a restart queryable)

`tests/pgvectorindex/vectors_table_absent_666_test.go` (5 cases) uses a `Querier`
that behaves like Postgres with a lazily created table: every statement against
an absent vectors table returns a real `*pgconn.PgError` with `42P01`.

- `TestPgvector_SearchBeforeFirstUpsertIsEmpty` (row 1)
- `TestPgvector_DeleteBeforeFirstUpsertIsNoop` (row 1)
- `TestPgvector_SearchAndDeleteOverAnExistingTableStillRunSQL` (row 2: the guard
  that keeps the fix from becoming a silent empty result)
- `TestPgvector_ResetRequiresAFreshPresenceCheck` (row 5)
- `TestPgvector_TableDroppedAfterTheCheckIsStillEmpty` (row 6)

### Proven against `main`

By the copy-aside method (no `git stash`): a worktree at `origin/main` with only
the two new test files added.

```
--- FAIL: TestQdrant_RetryAfterFieldIndexFailureFinishesSetup
    payload index "doc_type_lc" was never created: the retry adopted a collection with missing indexes
    payload index "rel_path" was never created: the retry adopted a collection with missing indexes
    stored embed identity = "", want "ident-A": the retry adopted a collection with no identity sentinel
--- FAIL: TestQdrant_RetryAfterSentinelFailureRecordsIdentity
    sentinel writes = 0, want 1: the retry must write the identity the failed attempt lost
    next process reads identity "", want "ident-A": a populated collection with no identity is reset and loses every vector
--- FAIL: TestQdrant_MismatchedStoredIdentityIsRefused
    Upsert must refuse a collection recorded under a different embed identity
--- FAIL: TestQdrant_SearchAsksTheServerBeforeReportingAnEmptyIndex
    hits = [], want the one stored point: an existing collection is not an empty index
--- PASS: TestQdrant_AdoptedCollectionKeepsStoredIdentity
--- PASS: TestQdrant_SearchOverAdoptedCollectionBeforeSetup
```

```
--- FAIL: TestPgvector_SearchBeforeFirstUpsertIsEmpty
    Search on a fresh index must succeed, got: pgvector: search: : relation "public.dir2mcp_vectors" does not exist (SQLSTATE 42P01)
--- FAIL: TestPgvector_DeleteBeforeFirstUpsertIsNoop
    Delete on a fresh index must succeed, got: pgvector: delete: : relation "public.dir2mcp_vectors" does not exist (SQLSTATE 42P01)
--- FAIL: TestPgvector_SearchAndDeleteOverAnExistingTableStillRunSQL
    catalog probes = 0, want 1 (the presence answer is cached)
--- FAIL: TestPgvector_ResetRequiresAFreshPresenceCheck
    Search after Reset must succeed, got: pgvector: search: : relation "public.dir2mcp_vectors" does not exist (SQLSTATE 42P01)
--- FAIL: TestPgvector_TableDroppedAfterTheCheckIsStillEmpty
    Search must read a dropped table as empty, got: pgvector: search: : relation "public.dir2mcp_vectors" does not exist (SQLSTATE 42P01)
```

The two `PASS` cases are deliberate regression guards, not proofs. All 11 pass on
this branch.

## 6. What was deliberately NOT done

- **The adopted collection's dimension and distance are not re-validated.** The
  `Client` interface exposes no collection-info call, and adding one widens the
  wire surface for a fence that already exists: the dimension is part of the
  embed identity (§8.1.4), so a changed dimension is a `CONFIG_INVALID` /
  reindex, and a wrong dimension fails the upsert loudly at the server. The
  reconcile therefore repairs what it can re-issue idempotently and stays honest
  about the rest.
- **No fault injection into `ensureVectorsTable` on the pgvector side.** Its two
  statements already share the `tableReady` flag, so the retry re-issues both
  (`IF NOT EXISTS`). The presence split is what needed proving, and that is what
  the tests drive.
- **No change to qdrant `Reset` under a shared collection.** A worker whose
  `EnsureIdentity` runs before another worker creates the collection still resets
  it. That race predates this work and needs a lease, not a reorder.
- **The 42P01 tolerance is not a general error filter.** It applies to two call
  sites and one SQLSTATE.

## 7. Checks

- `make check`: pass (exit 0), including `gocyclo -over 15`, `golangci-lint`
  (0 issues), `go vet`, `fmt-check`, the full Go suite and the Python annotator
  suite.
- `coderabbit review`: it ran **once** and returned 1 Major finding, then the
  account hit its review limit ("Review limit reached ... wait 52 minutes"), so a
  second pass was not possible. The finding is **addressed**: it said the qdrant
  `Search`/`Delete` gate still trusted process memory while the pgvector fix
  asked the server, and asked for the same treatment plus a check of the caller
  order. Both were done: `collectionPresent` asks `CollectionExists` once and
  caches a positive answer, `TestQdrant_SearchAsksTheServerBeforeReportingAnEmptyIndex`
  covers it, and the caller order was verified: both networked backends are
  constructed only in `internal/cli/up.go` (`loadQdrantIndex`,
  `loadPgvectorIndex`), and each calls `EnsureIdentity` immediately after, so
  `Identity()` marks the collection seen before the server accepts a query.
- Self-review of the whole diff, line by line, on top of that: no lock is taken
  twice (`readIdentitySentinel` and `ensureIdentitySentinel` are documented as
  running under `i.mu`; `collectionPresent` and `vectorsTablePresent` take it
  themselves and are never called from a holder), the identity strings in the new
  error carry no secret (a normalized `base_url` drops userinfo per §8.1.4), and
  the two suites that stub these backends still compile against the unchanged
  interfaces.

Closes #675
Closes #666
