### PR TITLE
fix(cli): identify the daemon by proof, not by a weak signal (#665, #671)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -103,6 +103,14 @@ type App struct {
 	// successful termination rather than an interrupted command. See
 	// resolveProcessExitCode (#434).
 	serverGracefulStop bool
+
+	// daemonChildOnce/daemonChildVerified cache the daemon-child launch
+	// handshake for this process (#671). The verdict must not change while a
+	// server runs: the parent removes the handshake file once the child is
+	// ready, so re-verifying later would flip the role mid-flight. See
+	// isDaemonChild in daemon_child.go.
+	daemonChildOnce     sync.Once
+	daemonChildVerified bool
 }
 
 type indexingStateAware interface {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -20,34 +20,8 @@ import (
 	"github.com/dirstral/dir2mcp/internal/ingest"
 )
 
-// daemonChildEnv carries a per-spawn nonce that the parent sets on the
-// child's environment. The child treats itself as a daemon body only if
-// the env value is non-empty AND matches the value the parent's process
-// memory still holds, so a manually-exported `DIR2MCP_DAEMON_CHILD=1`
-// in a user's shell can't accidentally trip the daemon-child code paths
-// (which would silently drop the banner, the stdin quit listener, and
-// the parent's pid-file write — confusing footgun, no security boundary
-// crossed but worth eliminating).
-const daemonChildEnv = "DIR2MCP_DAEMON_CHILD"
-
-// minDaemonChildNonceLen is the floor we require on the daemonChildEnv
-// value before accepting it as proof that this process was spawned by a
-// matching parent. Our parent sets a 32-character hex nonce; we accept
-// 16+ chars to give us slack for future format changes while still
-// rejecting "1" / "true" / other shell-exported values.
-const minDaemonChildNonceLen = 16
-
-// isRunningAsDaemonChild reports whether the current process was spawned
-// by an earlier dir2mcp invocation as the daemon body. We require the
-// env var to look like the parent-generated nonce rather than treating
-// any presence as truthy, so a manually-exported `DIR2MCP_DAEMON_CHILD=1`
-// can't accidentally trip the daemon code paths (which would silently
-// drop the banner, the stdin quit listener, and the pid-file write —
-// confusing footgun, no security boundary crossed).
-func isRunningAsDaemonChild() bool {
-	v := os.Getenv(daemonChildEnv)
-	return len(v) >= minDaemonChildNonceLen
-}
+// The daemon-child marker and the launch handshake that proves it live in
+// daemon_child.go (issue #671).
 
 // pidFileName is the canonical filename for the dir2mcp daemon pid file
 // inside the state directory. Kept short so it lines up with the other
@@ -150,7 +124,7 @@ func serverLogPath(stateDir string) string {
 // is additive: existing destinations (terminal in the foreground, the service
 // manager under launchd/systemd) keep receiving logs.
 func (a *App) teeServerLog(stateDir string) func() {
-	if isRunningAsDaemonChild() {
+	if a.isDaemonChild() {
 		return nil
 	}
 	logPath := serverLogPath(stateDir)

--- a/internal/cli/daemon_child.go
+++ b/internal/cli/daemon_child.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// Daemon-child identity (issue #671).
+//
+// `dir2mcp up` daemonizes by spawning itself: the parent starts a detached
+// copy of the binary, and that copy runs the server body. The copy must know
+// which of the two roles it holds, because the daemon body drops the banner,
+// drops the stdin quit listener, skips the server.log tee (its stderr is
+// already that file) and installs the SIGTERM handler `dir2mcp down` relies
+// on. The parent marks the copy through the environment.
+//
+// The marker used to be accepted on length alone: any value of 16 or more
+// characters selected daemon-child behaviour. A length check is not an
+// identity check. An exported shell variable, a variable inherited from a CI
+// runner, or a value injected into the environment of a normal `dir2mcp up`
+// therefore turned that run into a foreground-attached process that behaved
+// like a daemon body: silent, unstoppable with q+Enter, and with its log tee
+// disabled. A grandchild process inherited the marker and claimed the role
+// too.
+//
+// The marker is now proof of one specific launch. The parent draws a 32
+// hex-character CSPRNG nonce, writes it to an owner-only file inside the
+// state directory, and passes both the nonce and the file path to the child.
+// The child compares the value it was handed with the file contents in
+// constant time and consumes the file, so:
+//
+//   - An arbitrary value never verifies, whatever its length.
+//   - The nonce admits exactly one process, once.
+//   - A grandchild that inherits the environment finds the file gone.
+//
+// Nothing here logs the marker, the nonce or the file contents. The value is
+// a shared secret for the lifetime of one spawn.
+
+// daemonChildEnv carries the per-spawn nonce the parent hands to the child.
+const daemonChildEnv = "DIR2MCP_DAEMON_CHILD"
+
+// daemonChildHandshakeEnv carries the path of the file that holds the same
+// nonce. The child needs the path before it has loaded any config, so the
+// parent passes it in the environment rather than deriving it.
+const daemonChildHandshakeEnv = "DIR2MCP_DAEMON_HANDSHAKE"
+
+// daemonChildNonceHexLen is the exact length of the hex nonce
+// generateDaemonNonce produces (16 random bytes). The length is a published
+// constant of the format, not a secret, so rejecting a wrong-length value
+// before the constant-time compare reveals nothing.
+const daemonChildNonceHexLen = 32
+
+// daemonChildHandshakeMaxBytes bounds the read of the handshake file so a
+// hostile or corrupt file cannot make startup allocate.
+const daemonChildHandshakeMaxBytes = 128
+
+// daemonChildHandshakeMode is the mode the handshake file must carry: readable
+// and writable by the owner only. The child refuses a group- or world-readable
+// file, because the nonce is a secret for the duration of the spawn.
+const daemonChildHandshakeMode os.FileMode = 0o600
+
+// isDaemonChild reports whether this process is the daemon body an earlier
+// dir2mcp invocation spawned. It verifies the launch handshake once per
+// process and caches the verdict, which matters for correctness: the parent
+// removes the handshake file once the child reports ready, so a second,
+// unverified evaluation later in the child's life would flip the role
+// mid-flight and change how the running server handles signals and logs.
+//
+// A marker that is present but does not verify is reported to stderr once,
+// because the run then behaves differently from what the operator who set the
+// variable expected. The message names the variable and nothing else; the
+// value is never printed.
+func (a *App) isDaemonChild() bool {
+	a.daemonChildOnce.Do(func() {
+		a.daemonChildVerified = a.verifyDaemonChildHandshake()
+		if !a.daemonChildVerified && os.Getenv(daemonChildEnv) != "" {
+			writef(a.stderr, "warning: %s is set but the daemon launch handshake did not verify; running in the foreground\n", daemonChildEnv)
+		}
+	})
+	return a.daemonChildVerified
+}
+
+// verifyDaemonChildHandshake compares the marker this process was handed with
+// the nonce the spawning parent wrote to the handshake file, in constant time.
+// It returns true only for an exact match.
+//
+// A successful match consumes the file. The nonce then admits no further
+// process: a stale environment, a replayed value or an inherited grandchild
+// environment all fail the next check. A failed match leaves the file alone,
+// so a process that guesses wrong cannot deny the real child its handshake;
+// the parent removes the file when it exits either way.
+//
+// A failed removal does not withdraw a verdict this process has already
+// proved. The daemon body has no terminal, so a withdrawn verdict would start
+// the stdin quit listener on /dev/null and stop the server on the EOF it reads
+// at once. The residual risk is small in exchange: the file stays readable to
+// the owner of the state directory only, and the parent removes it when it
+// returns. The failure is reported so it is not silent.
+func (a *App) verifyDaemonChildHandshake() bool {
+	claim := os.Getenv(daemonChildEnv)
+	path := strings.TrimSpace(os.Getenv(daemonChildHandshakeEnv))
+	if len(claim) != daemonChildNonceHexLen || path == "" {
+		return false
+	}
+	expected, ok := readDaemonChildHandshake(path)
+	if !ok {
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(claim), []byte(expected)) != 1 {
+		return false
+	}
+	if rerr := os.Remove(path); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+		writef(a.stderr, "warning: consume daemon handshake file: %v\n", rerr)
+	}
+	return true
+}
+
+// readDaemonChildHandshake returns the nonce recorded in the handshake file.
+// It reports false when the file is missing, is not a regular file, is
+// readable beyond its owner, or cannot be read. Errors are deliberately not
+// reported: every one of them means "this process is not the daemon child",
+// which the caller handles, and the file contents must never reach a log.
+//
+// The path arrives in the environment, so it is not trusted. The open is
+// non-blocking: a plain open of a FIFO waits for a writer, which would hang
+// `dir2mcp up` before it starts. The type check below then rejects every
+// non-regular file the non-blocking open let through.
+func readDaemonChildHandshake(path string) (string, bool) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return "", false
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, daemonChildHandshakeMaxBytes))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(raw)), true
+}
+
+// prepareDaemonChildHandshake creates the single-use handshake for one spawn
+// and returns the environment entries the child must receive, plus a cleanup
+// that removes the handshake file.
+//
+// The caller must run the cleanup before it returns. The child normally
+// consumes the file itself; the cleanup covers a child that died before it
+// got that far, so a nonce never outlives the launch it belongs to.
+func prepareDaemonChildHandshake(stateDir string) (env []string, cleanup func(), err error) {
+	nonce, err := generateDaemonNonce()
+	if err != nil {
+		return nil, nil, err
+	}
+	// The file lives in the state directory: it is owner-only, it is on the
+	// same volume the daemon already writes, and `rm -rf .dir2mcp` clears it.
+	f, err := os.CreateTemp(stateDir, "daemon-handshake-*.nonce")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create daemon handshake file: %w", err)
+	}
+	path := f.Name()
+	cleanup = func() { _ = os.Remove(path) }
+	// CreateTemp asks for 0600, but the process umask can strip owner bits from
+	// that mode, and the child rejects a file it cannot read. Set the mode
+	// explicitly so the handshake never depends on the umask of the shell.
+	if cerr := f.Chmod(daemonChildHandshakeMode); cerr != nil {
+		_ = f.Close()
+		cleanup()
+		return nil, nil, fmt.Errorf("harden daemon handshake file: %w", cerr)
+	}
+	if _, werr := f.WriteString(nonce + "\n"); werr != nil {
+		_ = f.Close()
+		cleanup()
+		return nil, nil, fmt.Errorf("write daemon handshake file: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("close daemon handshake file: %w", cerr)
+	}
+	return []string{
+		daemonChildEnv + "=" + nonce,
+		daemonChildHandshakeEnv + "=" + path,
+	}, cleanup, nil
+}
+
+// DaemonChildHandshakeEnvForTest prepares a real parent-side handshake in
+// stateDir and returns the environment entries a spawned child receives, plus
+// a cleanup that removes the handshake file. It lets external tests reproduce
+// the launch handshake exactly, rather than assert that a long-enough marker
+// selects daemon-child mode. Test-only surface; not used by production code.
+func DaemonChildHandshakeEnvForTest(stateDir string) ([]string, func(), error) {
+	return prepareDaemonChildHandshake(stateDir)
+}

--- a/internal/cli/server_log_tee_internal_test.go
+++ b/internal/cli/server_log_tee_internal_test.go
@@ -132,12 +132,42 @@ func TestTeeServerLog_WritesToServerLogInForeground(t *testing.T) {
 // TestTeeServerLog_NoopInDaemonChild verifies the tee is a no-op in the daemon
 // child, whose stderr the parent already redirects to server.log — teeing again
 // would double-write every line.
+// The daemon child is identified by a verified launch handshake, so the test
+// builds a real one (a marker that merely "looks long" is rejected, #671).
 func TestTeeServerLog_NoopInDaemonChild(t *testing.T) {
-	t.Setenv(daemonChildEnv, strings.Repeat("a", 64)) // looks like a daemon child
+	stateDir := t.TempDir()
+	childEnv, cleanup, err := prepareDaemonChildHandshake(stateDir)
+	if err != nil {
+		t.Fatalf("prepare daemon handshake: %v", err)
+	}
+	defer cleanup()
+	for _, entry := range childEnv {
+		name, value, _ := strings.Cut(entry, "=")
+		t.Setenv(name, value)
+	}
 	app := NewAppWithIO(io.Discard, &bytes.Buffer{})
-	if restore := app.teeServerLog(t.TempDir()); restore != nil {
+	if restore := app.teeServerLog(stateDir); restore != nil {
 		restore()
 		t.Fatal("teeServerLog must be a no-op in the daemon child (stderr already → server.log)")
+	}
+}
+
+// TestTeeServerLog_ActiveWhenMarkerDoesNotVerify pins the other half of #671: a
+// marker that is present but has no matching handshake must not select
+// daemon-child behaviour, so the foreground server.log tee stays active.
+func TestTeeServerLog_ActiveWhenMarkerDoesNotVerify(t *testing.T) {
+	t.Setenv(daemonChildEnv, strings.Repeat("a", 64)) // long, but proves nothing
+	t.Setenv(daemonChildHandshakeEnv, "")
+	stateDir := t.TempDir()
+	var stderr bytes.Buffer
+	app := NewAppWithIO(io.Discard, &stderr)
+	restore := app.teeServerLog(stateDir)
+	if restore == nil {
+		t.Fatal("an unverified marker must not disable the foreground tee")
+	}
+	restore()
+	if !strings.Contains(stderr.String(), daemonChildEnv) {
+		t.Errorf("an unverified marker should be reported once on stderr; got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1961,7 +1962,9 @@ func (a *App) publishConnection(cfg config.Config, mcpURL string, auth authMater
 // divergent in-memory state corrupt the index (#434). The daemon child
 // relies on its parent having reconciled a stale pid file first; the
 // foreground/service path has no parent, so acquireSingleInstanceLock
-// reconciles a dead owner itself before its O_EXCL claim.
+// reconciles the record itself before its O_EXCL claim. That
+// reconciliation is token-aware (issue #665): only a pid file that still
+// names our live server refuses the start; a recycled pid does not.
 //
 // Returns the deferred cleanup closure (removes the pid file on exit)
 // and an exit code; runUp returns immediately when the code is non-zero
@@ -1999,31 +2002,15 @@ var errAlreadyRunning = errors.New("dir2mcp is already running")
 
 // acquireSingleInstanceLock claims the per-state-dir pid file so at most
 // one server process ever writes a given corpus's sqlite + index. It
-// reconciles a stale pid file (owner process dead) so a clean restart is
-// not blocked by a crash, then claims with O_EXCL so two live starters
-// racing the same directory cannot both win. A live owner — or losing
-// the O_EXCL race — returns an "already running" error the caller
+// reconciles a pid file that no longer names our live server so a clean
+// restart is not blocked by a crash, then claims with O_EXCL so two live
+// starters racing the same directory cannot both win. A live owner — or
+// losing the O_EXCL race — returns an "already running" error the caller
 // surfaces; the returned release removes the pid file on shutdown.
 func acquireSingleInstanceLock(stateDir string) (release func(), err error) {
 	pidPath := pidFilePath(stateDir)
-	// Reconcile a stale pid file whose owner is gone so the O_EXCL claim
-	// below has a clear field; a LIVE owner means a second writer, which
-	// we must refuse.
-	if existing, rerr := readPIDFile(pidPath); rerr == nil {
-		if processIsAlive(existing) {
-			return nil, fmt.Errorf("%w for %s (pid %d)", errAlreadyRunning, stateDir, existing)
-		}
-		_ = removePIDFile(pidPath)
-	} else if !errors.Is(rerr, os.ErrNotExist) {
-		// The pid file exists but is empty/corrupt/unparseable
-		// (readPIDFile errored with something other than "not exist").
-		// Its content names no live process, so treat it as a dead owner
-		// and clear it — otherwise a single malformed pid file would
-		// permanently brick startup: the O_EXCL claim below would fail
-		// and every run would report a bogus "already running" (#434). A
-		// live owner is never removed here because a live owner yields a
-		// parseable pid (the rerr == nil branch above), not an error.
-		_ = removePIDFile(pidPath)
+	if rerr := reconcilePIDFileOwner(pidPath, stateDir); rerr != nil {
+		return nil, rerr
 	}
 	if cerr := claimPIDFile(pidPath, os.Getpid()); cerr != nil {
 		if errors.Is(cerr, os.ErrExist) {
@@ -2037,6 +2024,97 @@ func acquireSingleInstanceLock(stateDir string) (release func(), err error) {
 		return nil, fmt.Errorf("claim pid file %s: %w", pidPath, cerr)
 	}
 	return func() { _ = removePIDFile(pidPath) }, nil
+}
+
+// pidReconcileAttempts bounds how often the startup lock re-reads a pid file
+// that another starter rewrote under it. Two attempts already cover the case;
+// the third is slack, and the bound guarantees the loop ends.
+const pidReconcileAttempts = 3
+
+// reconcilePIDFileOwner decides whether the startup lock may claim the pid
+// file at pidPath, and clears the record when it does not name our live
+// server. It returns errAlreadyRunning only for a positively identified live
+// owner, so the O_EXCL claim that follows has a clear field in every other
+// case.
+//
+// The ownership decision uses classifyPIDFile, the same token-aware check
+// `down`, `status` and `reindex` already use, so every command agrees on what
+// "our live daemon" means (issue #665). A bare liveness check is not an
+// identity check: after a crash without cleanup the OS can recycle the
+// recorded pid to an unrelated process, and that process would block every
+// later start with a false "already running" (issue #418).
+//
+// The three non-live classes are all cleared:
+//
+//   - pidDead: the owner exited, the normal post-crash restart.
+//   - pidRecycled: alive, but its start-time token no longer matches, so it
+//     is a bystander and not our server (issue #665).
+//   - pidMalformed: empty/corrupt/unparseable, so it names no live process.
+//     Clearing it keeps one bad file from bricking startup forever, because
+//     the O_EXCL claim over a surviving file would fail and report a bogus
+//     "already running" (issue #434).
+//
+// The record is only cleared while it still holds the bytes the ownership
+// decision read. A second starter can reconcile and claim the same pid file
+// between our read and our unlink, and an unconditional unlink would then
+// delete a live claim and let both servers serve one corpus. When the bytes
+// changed we re-read instead, and the record we find is either that live claim
+// (refused) or another stale record (cleared on the next attempt). A window of
+// a few instructions remains between the compare and the unlink; closing it
+// completely needs an advisory lock over the whole state directory, which is
+// more than this fix carries.
+func reconcilePIDFileOwner(pidPath, stateDir string) error {
+	for attempt := 0; attempt < pidReconcileAttempts; attempt++ {
+		snapshot, serr := os.ReadFile(pidPath)
+		if serr != nil && errors.Is(serr, os.ErrNotExist) {
+			return nil
+		}
+		existing, ownership := classifyPIDFile(pidPath)
+		switch ownership {
+		case pidNoFile:
+			return nil
+		case pidLive:
+			return fmt.Errorf("%w for %s (pid %d)", errAlreadyRunning, stateDir, existing)
+		}
+		cleared, cerr := clearPIDRecordIfUnchanged(pidPath, snapshot)
+		if cerr != nil {
+			// A removal we are not allowed to perform is an environment
+			// failure, not an already-running server. Report it as itself so
+			// the hint about `dir2mcp down` does not mislead (#434).
+			return fmt.Errorf("clear stale pid file %s: %w", pidPath, cerr)
+		}
+		if cleared {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w for %s (pid file %s keeps changing under concurrent starts)",
+		errAlreadyRunning, stateDir, pidPath)
+}
+
+// clearPIDRecordIfUnchanged removes pidPath only while its content still
+// equals snapshot, the bytes the ownership decision was made on. It reports
+// whether the record is gone. A record that changed under us is left alone and
+// reported as not cleared, so the caller re-reads it rather than unlink a
+// claim it never inspected.
+func clearPIDRecordIfUnchanged(pidPath string, snapshot []byte) (bool, error) {
+	current, err := os.ReadFile(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Another starter cleared the same stale record, which is the
+			// outcome we wanted.
+			return true, nil
+		}
+		// We cannot tell what we would be deleting, so delete nothing and let
+		// the caller report the real error.
+		return false, err
+	}
+	if !bytes.Equal(current, snapshot) {
+		return false, nil
+	}
+	if rerr := removePIDFile(pidPath); rerr != nil {
+		return false, rerr
+	}
+	return true, nil
 }
 
 // installInteractionForUp picks the right termination interaction for

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1971,7 +1971,7 @@ func (a *App) publishConnection(cfg config.Config, mcpURL string, auth authMater
 // (the helper has already written the error).
 func (a *App) setupServerSingleInstance(stateDir string, opts upOptions, cancel context.CancelFunc) (cleanup func(), code int) {
 	cleanup = func() {}
-	if isRunningAsDaemonChild() {
+	if a.isDaemonChild() {
 		installDaemonChildSignalHandler(cancel)
 	}
 	release, err := acquireSingleInstanceLock(stateDir)
@@ -2138,7 +2138,7 @@ func (a *App) installInteractionForUp(
 	opts upOptions,
 	nonInteractiveMode bool,
 ) <-chan struct{} {
-	if isRunningAsDaemonChild() {
+	if a.isDaemonChild() {
 		installDaemonChildSignalHandler(cancel)
 		return startStdinQuitListener(true, opts.jsonOutput)
 	}
@@ -2154,8 +2154,11 @@ func (a *App) installInteractionForUp(
 //   - --foreground / -f: explicit caller request
 //   - --json: NDJSON event stream callers (smoke tests, automation) need
 //     events on stdout in real time, which detaching breaks
-//   - daemon child: we're already inside the forked process; fall through
-//     to the in-process server body
+//   - daemon marker present in the environment: we are already inside the
+//     forked process; fall through to the in-process server body. The test
+//     is the presence of the marker, not the verified handshake (#671): a
+//     marker that fails to verify must degrade to one in-process run, never
+//     to a chain of spawns, so a broken handshake can never fork-bomb.
 //   - non-unix platforms: setsid isn't available, so degrade gracefully
 //   - stdout not a TTY: piped, redirected, or being scraped by a test
 //     harness — the caller wants to see real-time output (and any
@@ -2170,7 +2173,7 @@ func shouldDaemonize(a *App, opts upOptions) bool {
 	if opts.foreground || opts.jsonOutput {
 		return false
 	}
-	if isRunningAsDaemonChild() {
+	if os.Getenv(daemonChildEnv) != "" {
 		return false
 	}
 	if !isDaemonSupported() {

--- a/internal/cli/up_daemon.go
+++ b/internal/cli/up_daemon.go
@@ -77,19 +77,24 @@ func (a *App) runUpAsDaemonParent(_ context.Context, opts upOptions) int {
 		return exitGeneric
 	}
 
-	// Pass the original argv through verbatim. The child re-enters
-	// runUp; the daemonChildEnv marker (set on Env below) takes the
-	// in-process branch instead of recursing into the daemon parent.
-	// The marker value is a per-spawn random nonce rather than a
-	// constant "1" so a manually-exported env var in the user's shell
-	// can't accidentally trip the daemon-child code paths.
-	nonce, err := generateDaemonNonce()
+	// Pass the original argv through verbatim. The child re-enters runUp; the
+	// daemon marker (set on Env below) takes the in-process branch instead of
+	// recursing into the daemon parent.
+	//
+	// The marker is one half of a launch handshake: the nonce travels in the
+	// environment, and the same nonce sits in an owner-only file the child
+	// consumes (#671). Only the process this parent spawned can match it, so an
+	// exported or inherited environment value cannot claim the role. The
+	// cleanup removes the file when this parent returns, which bounds the
+	// nonce's life to this launch even if the child died before it read it.
+	childEnv, cleanupHandshake, err := prepareDaemonChildHandshake(stateDir)
 	if err != nil {
-		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("generate daemon nonce: %v", err))
+		writeCLIError(a.stderr, opts.jsonOutput, exitGeneric, fmt.Sprintf("prepare daemon handshake: %v", err))
 		return exitGeneric
 	}
+	defer cleanupHandshake()
 	cmd := exec.Command(selfPath, os.Args[1:]...)
-	cmd.Env = append(os.Environ(), daemonChildEnv+"="+nonce)
+	cmd.Env = append(os.Environ(), childEnv...)
 	cmd.Stdin = nil
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
@@ -281,9 +286,9 @@ func (a *App) preflightDaemonParentConfig(cfg *config.Config, opts upOptions) in
 	return a.checkMistralAPIKey(cfg, opts, upNonInteractiveMode(opts))
 }
 
-// generateDaemonNonce returns a 32-character hex string drawn from the
-// system CSPRNG. Used as the daemonChildEnv value so isRunningAsDaemonChild
-// can distinguish a parent-spawned child from a manually-exported env var.
+// generateDaemonNonce returns a 32-character hex string drawn from the system
+// CSPRNG. It is the secret half of the daemon launch handshake, so the child
+// can tell a parent-spawned launch from any other environment value (#671).
 func generateDaemonNonce() (string, error) {
 	var buf [16]byte
 	if _, err := rand.Read(buf[:]); err != nil {

--- a/tests/cli/daemon_child_fifo_671_test.go
+++ b/tests/cli/daemon_child_fifo_671_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// TestDaemonHandshakePathCannotHangStartup guards the handshake read (#671).
+// The handshake path arrives in the environment, so it is untrusted. A plain
+// open of a FIFO waits for a writer, so a marker plus a FIFO path would hang
+// `dir2mcp up` before it starts. The read must not block, and the FIFO must
+// not pass as a handshake, so the run takes the foreground path and creates
+// <state_dir>/server.log.
+func TestDaemonHandshakePathCannotHangStartup(t *testing.T) {
+	tmp := t.TempDir()
+	fifo := filepath.Join(tmp, "handshake.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable here: %v", err)
+	}
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+	t.Setenv(daemonChildEnvName, "0123456789abcdef0123456789abcdef")
+	t.Setenv(daemonHandshakeEnvName, fifo)
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	done := make(chan int, 1)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		go func() { done <- app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"}) }()
+		select {
+		case code := <-done:
+			if code != 0 {
+				t.Fatalf("foreground up failed: code=%d stderr=%s", code, stderr.String())
+			}
+		case <-time.After(raceScaled(30 * time.Second)):
+			// Deliberately bounded here rather than left to the package
+			// timeout: a blocking read on the FIFO never returns.
+			t.Fatal("startup blocked on the handshake path; the read must not wait for a FIFO writer")
+		}
+	})
+
+	logPath := filepath.Join(tmp, ".dir2mcp", "server.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("a FIFO must not pass as a handshake: %s missing (%v)", logPath, err)
+	}
+}

--- a/tests/cli/daemon_child_marker_671_test.go
+++ b/tests/cli/daemon_child_marker_671_test.go
@@ -1,0 +1,166 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// daemonChildEnvName is the marker the daemon parent sets on the child it
+// spawns. The tests below drive it from the outside, the way a leaked shell
+// export or a CI runner variable would.
+const daemonChildEnvName = "DIR2MCP_DAEMON_CHILD"
+
+// daemonHandshakeEnvName carries the path of the file that holds the same
+// nonce as the marker. Both halves must agree for a process to hold the
+// daemon-child role.
+const daemonHandshakeEnvName = "DIR2MCP_DAEMON_HANDSHAKE"
+
+// TestForegroundIgnoresUnverifiedDaemonMarker pins the issue #671 fix: the
+// daemon-child role was granted on marker length alone, so any value of 16 or
+// more characters turned a plain `dir2mcp up` into a process that behaves like
+// the daemon body. The operator gets a foreground process that prints no
+// banner, does not answer q+Enter, and writes no <state_dir>/server.log,
+// because the log tee is skipped for a child whose stderr the parent has
+// already pointed at that file.
+//
+// server.log is the observable: the foreground tee creates it, and the daemon
+// child never does. A run that produces the file took the foreground path.
+func TestForegroundIgnoresUnverifiedDaemonMarker(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+	// A marker of exactly the real nonce length, with no handshake behind it.
+	// Length must not be evidence.
+	t.Setenv(daemonChildEnvName, strings.Repeat("a", 32))
+	t.Setenv(daemonHandshakeEnvName, "")
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		if code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("foreground up failed: code=%d stderr=%s", code, stderr.String())
+		}
+	})
+
+	logPath := filepath.Join(tmp, ".dir2mcp", "server.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("an unverified marker selected daemon-child behaviour: %s missing (%v); stderr=%s",
+			logPath, err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), daemonChildEnvName) {
+		t.Errorf("an unverified marker should be reported to the operator; stderr=%s", stderr.String())
+	}
+}
+
+// TestForegroundHonoursVerifiedDaemonHandshake is the counterpart: a process
+// that holds a genuine handshake, the one the daemon parent prepares before it
+// spawns the child, must still take the daemon-child path. The handshake is
+// built with the production helper, so the test cannot pass by accident.
+//
+// The daemon child skips the server.log tee, so the absence of the file is the
+// evidence here.
+func TestForegroundHonoursVerifiedDaemonHandshake(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	childEnv, cleanup, err := cli.DaemonChildHandshakeEnvForTest(stateDir)
+	if err != nil {
+		t.Fatalf("prepare daemon handshake: %v", err)
+	}
+	defer cleanup()
+	for _, entry := range childEnv {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			t.Fatalf("malformed child env entry %q", entry)
+		}
+		t.Setenv(name, value)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		if code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("foreground up failed: code=%d stderr=%s", code, stderr.String())
+		}
+	})
+
+	logPath := filepath.Join(stateDir, "server.log")
+	if _, err := os.Stat(logPath); err == nil {
+		t.Fatalf("a verified daemon child must not tee %s (its stderr is already that file)", logPath)
+	}
+	if strings.Contains(stderr.String(), "did not verify") {
+		t.Errorf("a genuine handshake must not warn; stderr=%s", stderr.String())
+	}
+}
+
+// TestDaemonHandshakeIsSingleUse verifies the nonce admits one process once.
+// The first verified run consumes the handshake file, so a second process that
+// inherits the same environment (a grandchild, or a replay) is not the daemon
+// child any more. Before the fix the marker was reusable for ever, because
+// nothing was consumed and nothing was compared.
+func TestDaemonHandshakeIsSingleUse(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	childEnv, cleanup, err := cli.DaemonChildHandshakeEnvForTest(stateDir)
+	if err != nil {
+		t.Fatalf("prepare daemon handshake: %v", err)
+	}
+	defer cleanup()
+	var handshakePath string
+	for _, entry := range childEnv {
+		name, value, _ := strings.Cut(entry, "=")
+		t.Setenv(name, value)
+		if name == daemonHandshakeEnvName {
+			handshakePath = value
+		}
+	}
+
+	// First run: a real daemon child, which consumes the handshake.
+	firstApp := cli.NewAppWithIO(&bytes.Buffer{}, &bytes.Buffer{})
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		if code := firstApp.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("first foreground up failed")
+		}
+	})
+	if _, err := os.Stat(handshakePath); err == nil {
+		t.Fatal("a verified handshake must be consumed")
+	}
+
+	// Second run with the very same environment: the role is gone.
+	var stderr bytes.Buffer
+	secondApp := cli.NewAppWithIO(&bytes.Buffer{}, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		if code := secondApp.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"}); code != 0 {
+			t.Fatalf("second foreground up failed: stderr=%s", stderr.String())
+		}
+	})
+	if _, err := os.Stat(filepath.Join(stateDir, "server.log")); err != nil {
+		t.Fatalf("a replayed marker must fall back to the foreground path: %v; stderr=%s", err, stderr.String())
+	}
+}

--- a/tests/cli/single_instance_recycled_pid_665_test.go
+++ b/tests/cli/single_instance_recycled_pid_665_test.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+)
+
+// TestForegroundStartsOverRecycledPid pins the issue #665 fix: the
+// single-instance lock that every `up` mode takes must use the same
+// token-aware ownership check as `down`, `status` and `reindex`.
+//
+// A pid file left by a crash can name a pid the OS has since recycled to an
+// unrelated process. A bare liveness check reads that as the live server, so
+// `up --foreground` (the launchd/systemd service target) refuses to start and
+// the operator is locked out of the corpus until the pid file is deleted by
+// hand.
+//
+// The recycled pid is built deterministically instead of waiting for the OS to
+// reuse one: the record names this live test process but carries a start-time
+// token that does not match it, which is exactly what classifyPIDFile reports
+// as pidRecycled.
+func TestForegroundStartsOverRecycledPid(t *testing.T) {
+	realToken := requireStartTokens(t)
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	pidPath := filepath.Join(stateDir, "server.pid")
+	if err := cli.WritePIDRecordForTest(pidPath, os.Getpid(), realToken+"-stale"); err != nil {
+		t.Fatalf("seed recycled pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(2*time.Second))
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		if code != 0 {
+			t.Fatalf("foreground up refused to start over a recycled pid: code=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if strings.Contains(stderr.String(), "already running") {
+		t.Fatalf("a recycled pid was mistaken for the live server: %s", stderr.String())
+	}
+}
+
+// TestForegroundRefusesLiveOwnerWithMatchingToken is the counterpart guard: the
+// token-aware reconciliation must not clear a pid file that still names our
+// live server. The record here carries this process's real start-time token, so
+// classifyPIDFile reports pidLive and the start must be refused with the pid
+// file left intact (issue #665 must not weaken the #434 single-instance rule).
+func TestForegroundRefusesLiveOwnerWithMatchingToken(t *testing.T) {
+	realToken := requireStartTokens(t)
+	tmp := t.TempDir()
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	t.Setenv("DIR2MCP_AUTH_TOKEN", "test-token")
+
+	stateDir := filepath.Join(tmp, ".dir2mcp")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	pidPath := filepath.Join(stateDir, "server.pid")
+	if err := cli.WritePIDRecordForTest(pidPath, os.Getpid(), realToken); err != nil {
+		t.Fatalf("seed live pid file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIO(&stdout, &stderr)
+	withWorkingDir(t, tmp, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), raceScaled(10*time.Second))
+		defer cancel()
+		code := app.RunWithContext(ctx, []string{"up", "--foreground", "--listen", "127.0.0.1:0"})
+		if code == 0 {
+			t.Fatalf("foreground up served a corpus a live owner holds; stderr=%s", stderr.String())
+		}
+	})
+	if !strings.Contains(stderr.String(), "already running") {
+		t.Fatalf("expected an 'already running' refusal, got stderr=%s", stderr.String())
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Errorf("a live owner's pid file must survive the refusal; stat err=%v", err)
+	}
+}

--- a/tests/security/cli_boundary_test.go
+++ b/tests/security/cli_boundary_test.go
@@ -170,6 +170,7 @@ func TestRepoSplitBoundary_InternalCLIFileOwnership(t *testing.T) {
 		"corpus_snapshot_test.go":                {},
 		"corpus_writer_test.go":                  {},
 		"daemon.go":                              {},
+		"daemon_child.go":                        {},
 		"daemon_other.go":                        {},
 		"daemon_unix.go":                         {},
 		"down.go":                                {},


### PR DESCRIPTION
## Summary

Two places identified a process by something too weak to identify it. Each one
is a separate commit.

1. `36d9a23` #665: the foreground single-instance lock asked only whether the
   recorded pid was alive.
2. `5bacccad` #671: the daemon-child marker was accepted on its length.

## #665: a recycled pid blocks every start

**What the operator sees.** After a crash that leaves `server.pid` behind, the
OS can give that pid to any unrelated process. `dir2mcp up --foreground` and
the supervised launchd/systemd service then exit non-zero with:

```
dir2mcp is already running for /path/.dir2mcp (pid 40321)
Another dir2mcp server is already running for this state directory; check with `dir2mcp status` or stop it with `dir2mcp down`.
```

No server is running. `dir2mcp down` reports nothing to stop, because `down` is
token-aware and sees the same record as recycled. The corpus stays unusable
until the operator deletes the pid file by hand.

**Mechanism.** `acquireSingleInstanceLock` used `readPIDFile` plus
`processIsAlive`. It never consulted the start-time token, so a live bystander
read as our server. The lock is the one every `up` mode takes, so foreground,
service and daemon-child starts were all affected.

**Fix.** The lock now reconciles the record with `classifyPIDFile`, the same
token-aware check `down`, `status` and `reindex` already use (see
`refuseReindexIfDaemonRunning`, which documents the recycled case). Only
`pidLive` refuses the start. `pidDead`, `pidRecycled` and `pidMalformed` are
cleared. The `O_EXCL` claim still decides the winner between two starters, so
the claim race stays atomic. The decision lives in one new helper,
`reconcilePIDFileOwner`, so no command grows a second notion of ownership.

The reconciliation also stops unlinking a record it did not inspect: it deletes
the pid file only while the file still holds the bytes the decision read, and
re-reads when a second starter rewrote it. An unconditional unlink could delete
a fresh live claim and let two servers serve one corpus. A removal the OS
refuses is now reported as itself instead of surfacing as a false "already
running".

## #671: any 16-character marker takes the daemon role

**What the value causes.** With `DIR2MCP_DAEMON_CHILD` set to any 16 or more
characters, a plain `dir2mcp up` runs the server body as if a daemon parent had
spawned it:

- no startup banner;
- no `q`+Enter quit listener, so the terminal cannot stop it;
- a SIGTERM/SIGINT handler the operator did not ask for;
- no `<state_dir>/server.log`, because the log tee is skipped for a child whose
  stderr the parent already points at that file. Recovered-panic stacks and
  embed-worker logs then reach no file, and the support bundle collects nothing.

Reproduction from the issue: `DIR2MCP_DAEMON_CHILD=aaaaaaaaaaaaaaaa dir2mcp up`.

**Exposure.** The check was `len(os.Getenv("DIR2MCP_DAEMON_CHILD")) >= 16`. A
length check is not an identity check, and the code comments claimed a match
against a nonce in the parent's memory that no line performed. So:

- Any process that can set an environment variable for a `dir2mcp` launch
  selects the daemon role with 16 arbitrary characters. That includes a wrapper
  script, a service unit, a CI runner variable and a stale shell export. No
  guessing is needed, because there is no secret to guess.
- A grandchild inherited the marker from a real daemon child and claimed the
  role too.
- The observable result is a server whose logging is diverted and whose
  interactive stop path is removed. That is a self-inflicted denial of the log
  trail, not a privilege boundary, but a marker documented as unforgeable was
  in fact free to forge.

**Fix.** The marker is now one half of a launch handshake. The parent draws a 32
hex-character CSPRNG nonce, writes it to an owner-only file inside the state
directory, and hands the child the nonce plus the file path. The child compares
the two with `crypto/subtle.ConstantTimeCompare` and consumes the file. So an
arbitrary value never verifies, the nonce admits one process once, and an
inherited environment finds the file gone.

The nonce, the marker and the file contents are never logged. An unverified
marker produces one warning that names the variable only.

Hardening around the same read, from review:

- The handshake path arrives in the environment, so the open is non-blocking. A
  plain open of a FIFO waits for a writer, which would hang `dir2mcp up` before
  it starts. The file must then prove to be regular with no group or world
  access.
- The verdict is cached per process. The parent removes the handshake file once
  the child is ready, so a later re-check would flip the role while the server
  runs.
- `shouldDaemonize` bails on the presence of the marker, not on the verified
  verdict, so a handshake that fails degrades to one in-process run and never
  to a chain of spawns.

## Tests

New, and failing on `main`:

| Test | On `main` |
| --- | --- |
| `TestForegroundStartsOverRecycledPid` | FAIL: `foreground up refused to start over a recycled pid: code=1 stderr=dir2mcp is already running` |
| `TestForegroundIgnoresUnverifiedDaemonMarker` | FAIL: `an unverified marker selected daemon-child behaviour: .../server.log missing` |
| `TestDaemonHandshakePathCannotHangStartup` | FAIL: `a FIFO must not pass as a handshake: .../server.log missing` |

Also added, passing before and after, to prove the fixes do not overshoot:
`TestForegroundRefusesLiveOwnerWithMatchingToken` (a live owner with a matching
token is still refused and its pid file survives),
`TestForegroundHonoursVerifiedDaemonHandshake` (a genuine handshake still
selects the daemon body) and `TestDaemonHandshakeIsSingleUse` (the nonce admits
one process once).

The recycled pid is built deterministically: the record names the live test
process and carries a start-time token that does not match it, which is exactly
what `classifyPIDFile` reports as `pidRecycled`. No test waits for the OS to
reuse a pid.

`internal/cli/daemon_child.go` is added to the allowlist in
`tests/security/cli_boundary_test.go`.

## Checks

- `make check` passes.
- `coderabbit review --committed --base main` ran and reported 3 findings, all
  addressed in this branch: serialize the pid-file reconciliation against a
  concurrent claim and report removal errors as themselves; do not ignore the
  handshake consumption failure silently; do not block on a FIFO handshake
  path. The verification pass is rate limited on this account, so the second
  review is a line-by-line self-review.

## Not done

- A full advisory lock over the state directory. The compare-before-unlink above
  narrows the reconcile-then-claim window to a few instructions but does not
  close it. Closing it needs `flock` and per-platform files, which is wider than
  these two issues.
- The end-to-end spawn test for the handshake stays in the existing
  integration-gated daemon lifecycle suite. The new tests drive the production
  handshake helper in-process instead, so they run by default.

Closes #665
Closes #671
