### PR TITLE
fix(mcp): make five tool schemas agree with their handlers (#644, #645, #646, #647, #648)

### DIFF
--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -1378,6 +1378,22 @@ func ResolveSTTProviderModel(cfg config.Config) (providerName, sttModel string, 
 	return strings.TrimSpace(prof.Name), strings.TrimSpace(prof.STTModel), true
 }
 
+// ResolveOCRProviderModel returns the resolved bespoke-OCR provider profile name
+// and its OCR model for cfg (SPEC 8.1.3), mirroring the exact selection
+// mistralExtractor performs: the explicit `model.ocr.provider` binding when set,
+// otherwise the built-in `mistral-ocr` profile. It is the OCR twin of
+// ResolveSTTProviderModel, and it exists so the MCP stats tool can report the OCR
+// model an operator actually configured instead of the built-in Mistral constant
+// (issue #647). ok=false when no OCR-capable profile resolves, in which case the
+// caller keeps its own fallback.
+func ResolveOCRProviderModel(cfg config.Config) (providerName, ocrModel string, ok bool) {
+	prof, err := cfg.Providers().ResolveExplicit(provider.CapOCR, ocrProviderName(cfg), true)
+	if err != nil {
+		return "", "", false
+	}
+	return strings.TrimSpace(prof.Name), strings.TrimSpace(prof.OCRModel), true
+}
+
 // translatorFromConfig resolves the chat-capability binding used to translate
 // transcripts (SPEC §8.6.2: "uses the chat capability unless a dedicated
 // binding is configured") and builds a model.Generator from it. A dedicated

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -51,12 +51,18 @@ const (
 	paymentOutcomeMaxEntries      = 5000
 )
 
-// DefaultSearchK is used when tools/call search arguments omit k or provide
-// a non-positive value.
+// DefaultSearchK is the k a tools/call uses when the arguments OMIT k. A
+// supplied k is never replaced by it: an out-of-bound value is INVALID_RANGE
+// (see parseKArg, issue #648).
 const DefaultSearchK = 15
 
-// MaxSearchK is the highest allowed k value for search/ask requests.
-const MaxSearchK = 50
+// MinSearchK and MaxSearchK are the inclusive bounds the advertised input
+// schemas publish for k (SPEC §15.2/§15.3, canonical search.json/ask.json:
+// "minimum": 1, "maximum": 50). A supplied k outside them is INVALID_RANGE.
+const (
+	MinSearchK = 1
+	MaxSearchK = 50
+)
 
 // sessionInfo holds metadata tracked for each active session.  `created` is the
 // time the session was started; `lastSeen` is updated on each successful

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -460,6 +460,9 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 	if failures := loadRecentFailuresForStats(ctx, s.store); len(failures) > 0 {
 		structured["recent_failures"] = failures
 	}
+	if reasons := skipReasonsForStats(retrievedStats.SkipSummary); len(reasons) > 0 {
+		structured["skip_reasons"] = reasons
+	}
 
 	s.sessionMu.RLock()
 	sessionItems := make([]map[string]interface{}, 0, len(s.sessions))
@@ -495,6 +498,55 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		},
 		StructuredContent: structured,
 	}, nil
+}
+
+// skipReasonsForStats projects the store's durable skip aggregate onto the
+// canonical skip_reasons array: one {reason, count} entry per distinct reason a
+// document was recorded as status="skipped" (SPEC §15.6 / stats.json).
+//
+// It is the honest-coverage half of the stats payload. doc_counts groups every
+// non-deleted document by doc_type regardless of status, so it OVERSTATES what
+// is retrievable: a skipped .odt and an extracted .docx both count as
+// "document". skip_reasons is what says otherwise. The aggregate was populated
+// and then dropped before serialization (#646), so a corpus with unindexable
+// files looked fully covered to every MCP client.
+//
+// Zero-or-negative counts are omitted (the spec pins count >= 1), as is a blank
+// reason. Ordering is deterministic (count descending, then reason ascending), so
+// repeated calls and independent stores produce the same array. Returns nil when
+// nothing was skipped, so the caller omits the field entirely: the spec's "MAY
+// omit when nothing was skipped", which clients MUST read as "nothing skipped"
+// rather than "unsupported".
+func skipReasonsForStats(summary *model.SkipSummary) []map[string]interface{} {
+	if summary == nil || len(summary.Categories) == 0 {
+		return nil
+	}
+	type skipReasonCount struct {
+		reason string
+		count  int64
+	}
+	entries := make([]skipReasonCount, 0, len(summary.Categories))
+	for reason, count := range summary.Categories {
+		reason = strings.TrimSpace(reason)
+		if reason == "" || count < 1 {
+			continue
+		}
+		entries = append(entries, skipReasonCount{reason: reason, count: count})
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count != entries[j].count {
+			return entries[i].count > entries[j].count
+		}
+		return entries[i].reason < entries[j].reason
+	})
+	out := make([]map[string]interface{}, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, map[string]interface{}{"reason": entry.reason, "count": entry.count})
+	}
+	return out
 }
 
 // statsRecentFailuresLimit caps the recent_failures array per the spec
@@ -4351,6 +4403,36 @@ func statsOutputSchema() map[string]interface{} {
 						"error_message": map[string]interface{}{"type": "string"},
 					},
 					"required": []string{"rel_path", "doc_type", "mtime_unix", "error_message"},
+				},
+			},
+			// skip_reasons: optional per SPEC §15.6. It is the honest-coverage
+			// breakdown of what was NOT indexed and why. Omitted when nothing
+			// was skipped; clients MUST read omission as "nothing skipped",
+			// not "unsupported".
+			//
+			// `reason` is advertised as a plain string, not the canonical
+			// closed enum. The spec's enum is the vocabulary for one spec
+			// minor and the same section tells clients they MAY receive an
+			// unrecognized value from a newer server and SHOULD render it
+			// verbatim. A served enum would therefore publish a schema that
+			// rejects a payload this server can legitimately emit, the very
+			// defect skip_reasons is being added to fix. The canonical values
+			// are named in the description so a client can still branch on
+			// them.
+			"skip_reasons": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]interface{}{
+						"reason": map[string]interface{}{
+							"type":        "string",
+							"minLength":   1,
+							"description": "Why these documents were not indexed. Canonical values for this spec minor: unsupported_format, binary_ignored, archive, ignore_rule, secret_excluded, path_excluded, size_cap, language_uncovered, symlink_ignored. Render an unrecognized value verbatim.",
+						},
+						"count": map[string]interface{}{"type": "integer", "minimum": 1},
+					},
+					"required": []string{"reason", "count"},
 				},
 			},
 		},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1159,62 +1159,113 @@ func mapRelatedError(err error) *toolExecutionError {
 	}
 }
 
-func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
-	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "language_match": {}, "date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
+// askFamilyArguments is the argument set dir2mcp_ask accepts, and therefore the
+// set askInputSchema advertises. dir2mcp_ask_audio "inherits all dir2mcp_ask
+// fields" (bs-007 / SPEC §15.10) and its schema is a clone of ask's, so the two
+// handlers MUST allow the same names. extra names the additive, tool-specific
+// arguments the caller adds on top (ask_audio's voice_id).
+//
+// Sharing one list is the fix for the first half of issue #644: ask_audio kept a
+// shorter hand-written list, so every filter its own schema advertised came
+// back INVALID_FIELD: languages, language_match, date_from, date_to,
+// time_from_ms, time_to_ms, entities and events.
+func askFamilyArguments(extra ...string) map[string]struct{} {
+	allowed := map[string]struct{}{
+		"question": {}, "k": {}, "mode": {}, "index": {},
+		"path_prefix": {}, "file_glob": {}, "doc_types": {},
+		"languages": {}, "language_match": {},
+		"date_from": {}, "date_to": {}, "time_from_ms": {}, "time_to_ms": {},
 		"entities": {}, "events": {},
-	}); err != nil {
-		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+	}
+	for _, name := range extra {
+		allowed[name] = struct{}{}
+	}
+	return allowed
+}
+
+// askRequest is a parsed dir2mcp_ask (or dir2mcp_ask_audio) request: the
+// question, the resolved mode, and the retrieval query carrying every filter the
+// caller supplied.
+type askRequest struct {
+	question string
+	mode     string
+	query    model.SearchQuery
+}
+
+// parseAskArgs validates an ask-family argument map and projects it into an
+// askRequest. allowed is the tool's argument allowlist (see askFamilyArguments),
+// so a tool-specific additive argument passes the unknown-argument gate while
+// every shared field is parsed the one way.
+//
+// Both ask-family tools funnel through here, so a filter cannot be advertised on
+// one and rejected on the other, and a filter cannot be accepted yet dropped
+// before it reaches retrieval.
+func parseAskArgs(args map[string]interface{}, allowed map[string]struct{}) (askRequest, *toolExecutionError) {
+	if err := assertNoUnknownArguments(args, allowed); err != nil {
+		return askRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
 	question, ok, err := parseRequiredString(args, "question")
 	if err != nil {
-		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
+		return askRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
 	if !ok {
-		return toolCallResult{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "question is required", Retryable: false}
+		return askRequest{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "question is required", Retryable: false}
 	}
 	k, toolErr := parseKArg(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
 	mode, toolErr := parseModeArg(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
 	indexName, toolErr := parseIndexArg(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
 	pathPrefix, fileGlob, docTypes, toolErr := parseSearchFilters(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
 	languages, toolErr := parseLanguagesArg(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
 	languageMatch, toolErr := parseLanguageMatchArg(args)
 	if toolErr != nil {
-		return toolCallResult{}, toolErr
+		return askRequest{}, toolErr
 	}
-	tw, toolErr := parseTemporalFilters(args)
+	tw, entities, events, toolErr := parseSearchScopeFilters(args)
+	if toolErr != nil {
+		return askRequest{}, toolErr
+	}
+	return askRequest{
+		question: question,
+		mode:     mode,
+		query: model.SearchQuery{
+			Query: question, K: k, Index: indexName,
+			PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes,
+			Languages: languages, LanguageMatch: languageMatch,
+			DateFrom: tw.dateFrom, DateTo: tw.dateTo,
+			HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS,
+			HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS,
+			Entities: entities, Events: events,
+		},
+	}, nil
+}
+
+func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
+	req, toolErr := parseAskArgs(args, askFamilyArguments())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	askEntities, askEvents, toolErr := parseAnnotationFilters(args)
-	if toolErr != nil {
-		return toolCallResult{}, toolErr
+	if req.mode == "search_only" {
+		return s.runSearchOnlyMode(ctx, req.question, req.query)
 	}
-	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes, Languages: languages, LanguageMatch: languageMatch, DateFrom: tw.dateFrom, DateTo: tw.dateTo,
-		HasTimeFrom: tw.hasTimeFrom, TimeFromMS: tw.timeFromMS, HasTimeTo: tw.hasTimeTo, TimeToMS: tw.timeToMS,
-		Entities: askEntities, Events: askEvents}
-	if mode == "search_only" {
-		return s.runSearchOnlyMode(ctx, question, sq)
-	}
-	askResult, askErr := s.retriever.Ask(ctx, question, sq)
+	askResult, askErr := s.retriever.Ask(ctx, req.question, req.query)
 	if askErr != nil {
 		return toolCallResult{}, mapSearchError(askErr)
 	}
@@ -1225,31 +1276,7 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 }
 
 func (s *Server) handleAskAudioTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
-	if err := assertNoUnknownArguments(args, map[string]struct{}{
-		"question": {}, "k": {}, "mode": {}, "index": {}, "path_prefix": {}, "file_glob": {}, "doc_types": {}, "voice_id": {},
-	}); err != nil {
-		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
-	}
-	question, ok, err := parseRequiredString(args, "question")
-	if err != nil {
-		return toolCallResult{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
-	}
-	if !ok {
-		return toolCallResult{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "question is required", Retryable: false}
-	}
-	k, toolErr := parseKArg(args)
-	if toolErr != nil {
-		return toolCallResult{}, toolErr
-	}
-	mode, toolErr := parseModeArg(args)
-	if toolErr != nil {
-		return toolCallResult{}, toolErr
-	}
-	indexName, toolErr := parseIndexArg(args)
-	if toolErr != nil {
-		return toolCallResult{}, toolErr
-	}
-	pathPrefix, fileGlob, docTypes, toolErr := parseSearchFilters(args)
+	req, toolErr := parseAskArgs(args, askFamilyArguments("voice_id"))
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1260,11 +1287,10 @@ func (s *Server) handleAskAudioTool(ctx context.Context, args map[string]interfa
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	sq := model.SearchQuery{Query: question, K: k, Index: indexName, PathPrefix: pathPrefix, FileGlob: fileGlob, DocTypes: docTypes}
-	if mode == "search_only" {
-		return s.runSearchOnlyMode(ctx, question, sq)
+	if req.mode == "search_only" {
+		return s.runSearchOnlyMode(ctx, req.question, req.query)
 	}
-	return s.runAskAudioAnswer(ctx, question, voiceID, sq)
+	return s.runAskAudioAnswer(ctx, req.question, voiceID, req.query)
 }
 
 func (s *Server) runAskAudioAnswer(ctx context.Context, question, voiceID string, sq model.SearchQuery) (toolCallResult, *toolExecutionError) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2083,20 +2083,37 @@ func parseListFilesArgs(args map[string]interface{}) (pathPrefix, glob string, l
 	return pathPrefix, glob, limit, offset, includeHidden, nil
 }
 
-// parseKArg parses the "k" argument with default and range validation.
+// parseKArg resolves the shared k argument for search, ask, related, ask_audio
+// and transcribe_and_ask.
+//
+// An OMITTED k resolves to the shipped default (DefaultSearchK). A SUPPLIED k
+// must satisfy the bound the input schema advertises, 1..50 (SPEC §15.2/§15.3,
+// canonical search.json/ask.json), and anything outside it is INVALID_RANGE.
+//
+// This distinction is the fix for issue #648: k=0 and k=-1 used to be replaced
+// by the default, so a caller that asked for a k the schema forbids got a
+// silent, different retrieval instead of the machine-parseable error every
+// other out-of-bound value produced. Absent and present-but-invalid are
+// different requests and answer differently now.
+//
+// Resolving an omitted k against `rag.k_default` is deliberately NOT done here:
+// that precedence is dirstral-spec PR #90 / dir2mcp #654 and it changes what the
+// served schema must advertise as well.
 func parseKArg(args map[string]interface{}) (int, *toolExecutionError) {
-	k := DefaultSearchK
-	if rawK, exists := args["k"]; exists {
-		parsedK, parseErr := parseInteger(rawK, "k")
-		if parseErr != nil {
-			return 0, &toolExecutionError{Code: "INVALID_FIELD", Message: parseErr.Error(), Retryable: false}
-		}
-		if parsedK > 0 {
-			k = parsedK
-		}
+	rawK, exists := args["k"]
+	if !exists {
+		return DefaultSearchK, nil
 	}
-	if k > 50 {
-		return 0, &toolExecutionError{Code: "INVALID_RANGE", Message: "k must be between 1 and 50", Retryable: false}
+	k, parseErr := parseInteger(rawK, "k")
+	if parseErr != nil {
+		return 0, &toolExecutionError{Code: "INVALID_FIELD", Message: parseErr.Error(), Retryable: false}
+	}
+	if k < MinSearchK || k > MaxSearchK {
+		return 0, &toolExecutionError{
+			Code:      "INVALID_RANGE",
+			Message:   fmt.Sprintf("k must be between %d and %d", MinSearchK, MaxSearchK),
+			Retryable: false,
+		}
 	}
 	return k, nil
 }
@@ -3696,7 +3713,7 @@ func searchInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"query":       map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},
@@ -3785,7 +3802,7 @@ func relatedInputSchema() map[string]interface{} {
 				"minLength":   1,
 				"description": "The source document (corpus-relative, normalized '/'): neighbours are ranked against the document's own chunk vectors. Chunks belonging to this document are always excluded from hits.",
 			},
-			"k":     map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":     map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
 			"index": map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto", "description": "Which logical vector axis to search (SPEC §6.1). 'auto' matches the source segment's own index_kind."},
 			"exclude_same_document": map[string]interface{}{
 				"type":        "boolean",
@@ -3835,7 +3852,7 @@ func askInputSchema() map[string]interface{} {
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"question":    map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
 			"mode":        map[string]interface{}{"type": "string", "enum": []string{"answer", "search_only"}, "default": "answer"},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
@@ -4029,7 +4046,7 @@ func transcribeAndAskInputSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"rel_path": map[string]interface{}{"type": "string", "minLength": 1},
 			"question": map[string]interface{}{"type": "string", "minLength": 1},
-			"k":        map[string]interface{}{"type": "integer", "minimum": 1, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":        map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
 		},
 		"required": []string{"rel_path", "question"},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -436,26 +436,7 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 			}
 			return idx
 		}(),
-		"models": map[string]interface{}{
-			"embed_text":   defaultEmbedTextModel,
-			"embed_code":   defaultEmbedCodeModel,
-			"ocr":          defaultOCRModel,
-			"stt_provider": defaultSTTProvider,
-			"stt_model":    defaultSTTModel,
-			"chat": func() string {
-				cp, err := s.cfg.Providers().Resolve(provider.CapChat)
-				if err != nil {
-					// No chat provider resolves; report the built-in default.
-					return defaultChatModel
-				}
-				if m := strings.TrimSpace(cp.ChatModel); m != "" {
-					return m
-				}
-				// Resolved but no explicit model: the adapter uses its
-				// own provider-kind default — don't misreport Mistral's.
-				return "(" + cp.Name + " provider default)"
-			}(),
-		},
+		"models": resolvedStatsModels(s.cfg),
 	}
 	if failures := loadRecentFailuresForStats(ctx, s.store); len(failures) > 0 {
 		structured["recent_failures"] = failures
@@ -498,6 +479,100 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		},
 		StructuredContent: structured,
 	}, nil
+}
+
+// resolvedStatsModels reports the models.* block of dir2mcp_stats: the provider
+// and model identities THIS deployment actually resolves for each pipeline
+// (SPEC §15.6).
+//
+// It used to emit the built-in Mistral constants for embeddings, OCR and STT and
+// resolve only the chat model (issue #647). An operator who pointed embeddings at
+// Gemini or STT at a self-hosted Whisper endpoint still read "mistral-embed" and
+// "mistral" here, so the one surface that answers "what produced these vectors
+// and this transcript" named a backend the deployment does not use. Provenance
+// that reports a default instead of the configuration is worse than no
+// provenance: it looks authoritative.
+//
+// Every field resolves through the same provider model the pipelines use, so the
+// reported identity cannot drift from the identity on the wire:
+//
+//   - embed_text / embed_code: provider.EffectiveEmbedModels of the resolved
+//     embed profile, the same resolution the embed identity (SPEC 8.1.4) and both
+//     embed call sites use.
+//   - ocr: ingest.ResolveOCRProviderModel, which mirrors the extractor's own
+//     `model.ocr.provider` binding.
+//   - stt_provider / stt_model: resolvedSTTProvenance, already shared with the
+//     transcribe tools.
+//   - chat: the resolved chat profile's model.
+//
+// A capability with no eligible profile keeps the shipped default, because that
+// is what a later `up` with a credential present would use. A profile that
+// resolves but names no model reports "(<profile> provider default)" rather than
+// another provider's constant: the adapter picks its own default there, and
+// naming a model would be a guess.
+func resolvedStatsModels(cfg config.Config) map[string]interface{} {
+	embedText, embedCode := resolvedEmbedProvenance(cfg)
+	sttProvider, sttModel := resolvedSTTProvenance(cfg)
+	return map[string]interface{}{
+		"embed_text":   embedText,
+		"embed_code":   embedCode,
+		"ocr":          resolvedOCRProvenance(cfg),
+		"stt_provider": sttProvider,
+		"stt_model":    sttModel,
+		"chat":         resolvedChatProvenance(cfg),
+	}
+}
+
+// providerDefaultLabel names the adapter-chosen model for a profile that
+// resolves without an explicit model id. It is deliberately not a model id: the
+// adapter substitutes its own kind default there, and printing another provider's
+// constant would misreport provenance.
+func providerDefaultLabel(profileName string) string {
+	return "(" + profileName + " provider default)"
+}
+
+// resolvedEmbedProvenance reports the text/code embed models the resolved embed
+// profile puts on the wire, falling back to the shipped defaults when no embed
+// profile is eligible.
+func resolvedEmbedProvenance(cfg config.Config) (embedText, embedCode string) {
+	prof, err := cfg.Providers().Resolve(provider.CapEmbed)
+	if err != nil {
+		return defaultEmbedTextModel, defaultEmbedCodeModel
+	}
+	text, code := provider.EffectiveEmbedModels(prof)
+	if strings.TrimSpace(text) == "" {
+		text = providerDefaultLabel(prof.Name)
+	}
+	if strings.TrimSpace(code) == "" {
+		code = providerDefaultLabel(prof.Name)
+	}
+	return text, code
+}
+
+// resolvedOCRProvenance reports the OCR model of the profile the extractor binds,
+// falling back to the shipped default when no OCR-capable profile resolves.
+func resolvedOCRProvenance(cfg config.Config) string {
+	name, ocrModel, ok := ingest.ResolveOCRProviderModel(cfg)
+	if !ok {
+		return defaultOCRModel
+	}
+	if strings.TrimSpace(ocrModel) == "" {
+		return providerDefaultLabel(name)
+	}
+	return ocrModel
+}
+
+// resolvedChatProvenance reports the chat model of the resolved chat profile,
+// falling back to the shipped default when no chat profile is eligible.
+func resolvedChatProvenance(cfg config.Config) string {
+	prof, err := cfg.Providers().Resolve(provider.CapChat)
+	if err != nil {
+		return defaultChatModel
+	}
+	if m := strings.TrimSpace(prof.ChatModel); m != "" {
+		return m
+	}
+	return providerDefaultLabel(prof.Name)
 }
 
 // skipReasonsForStats projects the store's durable skip aggregate onto the
@@ -4356,10 +4431,16 @@ func statsOutputSchema() map[string]interface{} {
 				"type":                 "object",
 				"additionalProperties": false,
 				"properties": map[string]interface{}{
-					"embed_text":   map[string]interface{}{"type": "string"},
-					"embed_code":   map[string]interface{}{"type": "string"},
-					"ocr":          map[string]interface{}{"type": "string"},
-					"stt_provider": map[string]interface{}{"type": "string", "enum": []string{"mistral", "elevenlabs"}},
+					"embed_text": map[string]interface{}{"type": "string"},
+					"embed_code": map[string]interface{}{"type": "string"},
+					"ocr":        map[string]interface{}{"type": "string"},
+					// stt_provider is NOT a closed enum (bs-007 and stats.json:
+					// "any STT-capable provider ... is valid"). The old
+					// mistral|elevenlabs enum made a strict client reject the
+					// stats of a deployment that transcribes with whisper,
+					// openai, gemini or an operator-named profile, all of which
+					// the provider model already supports (#647).
+					"stt_provider": map[string]interface{}{"type": "string", "minLength": 1},
 					"stt_model":    map[string]interface{}{"type": "string"},
 					"chat":         map[string]interface{}{"type": "string"},
 				},

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2613,6 +2613,11 @@ func applyCorpusStats(base model.Stats, corpus model.CorpusStats) model.Stats {
 	base.EmbeddedPending = corpus.EmbeddedPending
 	base.Errors = corpus.Errors
 	base.TotalDocs = corpus.TotalDocs
+	// SkipSummary is the honest-coverage aggregate the store persists (#414/#395).
+	// It has to travel with the counters, because dir2mcp_stats reports it as the
+	// canonical skip_reasons field (SPEC §15.6). Dropping it here made a corpus
+	// with skipped documents look fully covered to every MCP client (#646).
+	base.SkipSummary = corpus.SkipSummary
 	if len(corpus.DocCounts) == 0 {
 		base.DocCounts = map[string]int64{}
 	} else {

--- a/tests/conformance/input_schema_contract_644_test.go
+++ b/tests/conformance/input_schema_contract_644_test.go
@@ -1,0 +1,177 @@
+package conformance
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// toolInputSchemas fetches tools/list and returns each tool's inputSchema as a
+// decoded generic tree keyed by tool name.
+func toolInputSchemas(t *testing.T, mcpURL, sessionID string) map[string]map[string]interface{} {
+	t.Helper()
+	resp := sendRPC(t, mcpURL, sessionID, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`, nil)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/list: status=%d want=200 body=%s", resp.StatusCode, body)
+	}
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name        string                 `json:"name"`
+				InputSchema map[string]interface{} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("tools/list: decode: %v body=%s", err, body)
+	}
+	out := make(map[string]map[string]interface{}, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		out[tool.Name] = tool.InputSchema
+	}
+	if len(out) == 0 {
+		t.Fatal("tools/list advertised no tools")
+	}
+	return out
+}
+
+// sampleValueForSchema returns a value that satisfies the given property schema
+// well enough to reach the handler's unknown-argument gate. It does not have to
+// be semantically meaningful: the assertion below is only that the server does
+// not answer "unknown argument", so a malformed date or an unknown path is a
+// perfectly good sample.
+func sampleValueForSchema(prop map[string]interface{}) interface{} {
+	if enum, ok := prop["enum"].([]interface{}); ok && len(enum) > 0 {
+		return enum[0]
+	}
+	switch prop["type"] {
+	case "integer", "number":
+		if min, ok := prop["minimum"].(float64); ok {
+			return min
+		}
+		return 1
+	case "boolean":
+		return true
+	case "array":
+		return []interface{}{"x"}
+	case "object":
+		return map[string]interface{}{}
+	default:
+		return "x"
+	}
+}
+
+// requiredPropertyNames returns the names a request must carry: the schema's own
+// "required" list, plus the first "oneOf" branch's required list when the schema
+// uses one (dir2mcp_related's chunk_id / rel_path choice).
+func requiredPropertyNames(schema map[string]interface{}) []string {
+	names := stringSliceFromJSON(schema["required"])
+	if branches, ok := schema["oneOf"].([]interface{}); ok {
+		for _, raw := range branches {
+			branch, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if extra := stringSliceFromJSON(branch["required"]); len(extra) > 0 {
+				names = append(names, extra...)
+				break
+			}
+		}
+	}
+	return names
+}
+
+func stringSliceFromJSON(raw interface{}) []string {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestInputSchema_EveryAdvertisedPropertyIsAccepted is the anti-drift guard for
+// the whole "the schema says one thing, the handler does another" defect class
+// (issues #644 and #645).
+//
+// A schema-driven client reads inputSchema from tools/list and builds requests
+// from it. Every property a tool advertises MUST therefore reach the handler:
+// answering "unknown argument" to a field the server itself published leaves the
+// client no way to use the contract it was given.
+//
+// The test walks every tool, sends one request per advertised property (plus the
+// tool's required fields), and asserts the server never reports that property as
+// unknown. Any other failure is fine: a conformance server has no retriever or
+// corpus, so most calls fail for a reason that is not the contract.
+//
+// It fails on the pre-fix tree because dir2mcp_ask_audio advertised the whole
+// inherited dir2mcp_ask filter set while its handler allowed only eight names.
+func TestInputSchema_EveryAdvertisedPropertyIsAccepted(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	schemas := toolInputSchemas(t, mcpURL, sid)
+	names := make([]string, 0, len(schemas))
+	for name := range schemas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, toolName := range names {
+		schema := schemas[toolName]
+		properties, ok := schema["properties"].(map[string]interface{})
+		if !ok {
+			// A tool with no input properties (dir2mcp_stats) has nothing to check.
+			continue
+		}
+		required := requiredPropertyNames(schema)
+		propNames := make([]string, 0, len(properties))
+		for prop := range properties {
+			propNames = append(propNames, prop)
+		}
+		sort.Strings(propNames)
+
+		for _, propName := range propNames {
+			t.Run(toolName+"/"+propName, func(t *testing.T) {
+				args := map[string]interface{}{}
+				for _, name := range required {
+					prop, ok := properties[name].(map[string]interface{})
+					if !ok {
+						continue
+					}
+					args[name] = sampleValueForSchema(prop)
+				}
+				prop, ok := properties[propName].(map[string]interface{})
+				if !ok {
+					t.Fatalf("%s: property %q is not an object schema: %#v", toolName, propName, properties[propName])
+				}
+				args[propName] = sampleValueForSchema(prop)
+
+				encoded, err := json.Marshal(args)
+				if err != nil {
+					t.Fatalf("encode arguments: %v", err)
+				}
+				envelope := callToolRaw(t, mcpURL, sid, toolName, string(encoded))
+				if envelope.Result.StructuredContent.Error == nil {
+					return
+				}
+				message := envelope.Result.StructuredContent.Error.Message
+				if strings.Contains(message, "unknown argument: "+propName) {
+					t.Fatalf("%s advertises %q but its handler rejects it: %s", toolName, propName, message)
+				}
+			})
+		}
+	}
+}

--- a/tests/conformance/input_schema_undeclared_645_test.go
+++ b/tests/conformance/input_schema_undeclared_645_test.go
@@ -1,0 +1,131 @@
+package conformance
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+)
+
+// propertySchemas returns the "properties" object of an input schema, or nil when
+// the tool takes no arguments.
+func propertySchemas(schema map[string]interface{}) map[string]interface{} {
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return properties
+}
+
+// probeVocabulary collects every property name any tool advertises, with one
+// sample schema per name so a probe value is type-plausible for that name.
+func probeVocabulary(schemas map[string]map[string]interface{}) map[string]map[string]interface{} {
+	out := map[string]map[string]interface{}{}
+	for _, schema := range schemas {
+		for name, raw := range propertySchemas(schema) {
+			prop, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if _, seen := out[name]; !seen {
+				out[name] = prop
+			}
+		}
+	}
+	return out
+}
+
+// undeclaredProbes returns the probe names a tool does NOT advertise, sorted.
+func undeclaredProbes(schema map[string]interface{}, vocabulary map[string]map[string]interface{}) []string {
+	declared := propertySchemas(schema)
+	probes := make([]string, 0, len(vocabulary))
+	for name := range vocabulary {
+		if _, ok := declared[name]; !ok {
+			probes = append(probes, name)
+		}
+	}
+	sort.Strings(probes)
+	return probes
+}
+
+// requiredSampleArgs builds the minimal valid argument object for a tool: one
+// sample value per required property (including a oneOf branch's requirements).
+func requiredSampleArgs(schema map[string]interface{}) map[string]interface{} {
+	args := map[string]interface{}{}
+	declared := propertySchemas(schema)
+	for _, name := range requiredPropertyNames(schema) {
+		if prop, ok := declared[name].(map[string]interface{}); ok {
+			args[name] = sampleValueForSchema(prop)
+		}
+	}
+	return args
+}
+
+// sortedToolNames returns the advertised tool names in a stable order.
+func sortedToolNames(schemas map[string]map[string]interface{}) []string {
+	names := make([]string, 0, len(schemas))
+	for name := range schemas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestInputSchema_UndeclaredPropertyIsRejected is the reverse guard of
+// TestInputSchema_EveryAdvertisedPropertyIsAccepted, and the contract test issue
+// #645 asks for.
+//
+// Every tool's advertised schema sets additionalProperties:false, so a strict
+// client refuses to send a field the schema does not declare. A handler that
+// nevertheless honors such a field creates a hidden feature: the server and its
+// own tests treat it as supported while no schema-driven client can ever reach
+// it. #645 reported exactly that for dir2mcp_related and language_match.
+//
+// A conformance test cannot enumerate every possible name, so it probes with the
+// names the OTHER tools advertise: a tool must report any property outside its
+// own schema as an unknown argument. That covers the reported case (related does
+// not advertise language_match, so it must refuse it) and every future one where
+// two sibling tools drift apart.
+func TestInputSchema_UndeclaredPropertyIsRejected(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	schemas := toolInputSchemas(t, mcpURL, sid)
+	vocabulary := probeVocabulary(schemas)
+	if len(vocabulary) == 0 {
+		t.Fatal("no advertised input properties to probe with")
+	}
+
+	for _, toolName := range sortedToolNames(schemas) {
+		schema := schemas[toolName]
+		for _, probe := range undeclaredProbes(schema, vocabulary) {
+			t.Run(toolName+"/"+probe, func(t *testing.T) {
+				args := requiredSampleArgs(schema)
+				args[probe] = sampleValueForSchema(vocabulary[probe])
+				encoded, err := json.Marshal(args)
+				if err != nil {
+					t.Fatalf("encode arguments: %v", err)
+				}
+				envelope := callToolRaw(t, mcpURL, sid, toolName, string(encoded))
+				assertUnknownArgument(t, toolName, probe, envelope)
+			})
+		}
+	}
+}
+
+// assertUnknownArgument requires that a tools/call rejected the named property as
+// an unknown argument (INVALID_FIELD, df-008).
+func assertUnknownArgument(t *testing.T, toolName, property string, envelope toolCallResultEnvelope) {
+	t.Helper()
+	errObj := envelope.Result.StructuredContent.Error
+	if errObj == nil {
+		t.Fatalf("%s does not advertise %q but accepted it: a schema-driven client can never use it", toolName, property)
+	}
+	if errObj.Code != "INVALID_FIELD" || errObj.Message != "unknown argument: "+property {
+		t.Fatalf("%s does not advertise %q; want INVALID_FIELD 'unknown argument', got code=%q message=%q",
+			toolName, property, errObj.Code, errObj.Message)
+	}
+}

--- a/tests/conformance/tool_k_bound_648_test.go
+++ b/tests/conformance/tool_k_bound_648_test.go
@@ -1,0 +1,162 @@
+package conformance
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+// toolCallResultEnvelope is the decoded shape of a tools/call response: the
+// tool-level isError flag plus structuredContent, which carries the canonical
+// error object (df-008) when the call failed.
+type toolCallResultEnvelope struct {
+	Result struct {
+		IsError           bool `json:"isError"`
+		StructuredContent struct {
+			Error *struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"structuredContent"`
+	} `json:"result"`
+	Error interface{} `json:"error"`
+}
+
+// callToolRaw posts one tools/call with a raw JSON arguments object and returns
+// the decoded tool-level envelope.
+func callToolRaw(t *testing.T, mcpURL, sessionID, tool, argsJSON string) toolCallResultEnvelope {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"` + tool +
+		`","arguments":` + argsJSON + `}}`
+	resp := sendRPC(t, mcpURL, sessionID, body, nil)
+	payload := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status=%d want=200 body=%s", tool, resp.StatusCode, payload)
+	}
+	var envelope toolCallResultEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("%s: decode: %v body=%s", tool, err, payload)
+	}
+	if envelope.Error != nil {
+		t.Fatalf("%s: expected a tool-level result, got a JSON-RPC error: %s", tool, payload)
+	}
+	return envelope
+}
+
+// envelopeErrorCode returns the canonical error code of a failed tools/call, or
+// "" when the call did not fail. Unlike toolErrorCode it never fails the test
+// on a SUCCESSFUL call, so a caller can assert "this code did not occur".
+func envelopeErrorCode(envelope toolCallResultEnvelope) string {
+	if !envelope.Result.IsError || envelope.Result.StructuredContent.Error == nil {
+		return ""
+	}
+	return envelope.Result.StructuredContent.Error.Code
+}
+
+// kBearingTools are every tool whose advertised input schema carries k with the
+// "minimum": 1 / "maximum": 50 bound (SPEC §15.2/§15.3, canonical
+// search.json/ask.json/related.json/ask_audio.json/transcribe_and_ask.json).
+// argsWithK renders a minimal, otherwise-valid argument object for the tool
+// with the given k, so the k check is the only thing under test.
+var kBearingTools = []struct {
+	name      string
+	argsWithK func(k int) string
+}{
+	{
+		name:      "dir2mcp_search",
+		argsWithK: func(k int) string { return `{"query":"q","k":` + strconv.Itoa(k) + `}` },
+	},
+	{
+		name:      "dir2mcp_ask",
+		argsWithK: func(k int) string { return `{"question":"q","k":` + strconv.Itoa(k) + `}` },
+	},
+	{
+		name:      "dir2mcp_related",
+		argsWithK: func(k int) string { return `{"chunk_id":1,"k":` + strconv.Itoa(k) + `}` },
+	},
+	{
+		name:      "dir2mcp_ask_audio",
+		argsWithK: func(k int) string { return `{"question":"q","k":` + strconv.Itoa(k) + `}` },
+	},
+	{
+		name: "dir2mcp_transcribe_and_ask",
+		argsWithK: func(k int) string {
+			return `{"rel_path":"a.mp3","question":"q","k":` + strconv.Itoa(k) + `}`
+		},
+	},
+}
+
+// TestToolK_SuppliedOutOfBoundIsInvalidRange pins issue #648 across the shared
+// k parser: every tool advertises "minimum": 1 / "maximum": 50 for k, so a
+// SUPPLIED value outside that bound MUST be the machine-parseable INVALID_RANGE
+// error. k=0 and k=-1 previously became the default k silently, so a caller got
+// a retrieval it did not request and no way to detect the substitution.
+//
+// The in-bound rows (1 and 50) assert the converse: a valid k is never turned
+// into a range error. They may still fail for another reason (no retriever is
+// wired in a conformance server), which is why the assertion is on the code.
+func TestToolK_SuppliedOutOfBoundIsInvalidRange(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	for _, tool := range kBearingTools {
+		for _, tc := range []struct {
+			k         int
+			wantRange bool
+		}{
+			{k: -1, wantRange: true},
+			{k: 0, wantRange: true},
+			{k: 1, wantRange: false},
+			{k: 50, wantRange: false},
+			{k: 51, wantRange: true},
+		} {
+			t.Run(tool.name+"/k="+strconv.Itoa(tc.k), func(t *testing.T) {
+				envelope := callToolRaw(t, mcpURL, sid, tool.name, tool.argsWithK(tc.k))
+				code := envelopeErrorCode(envelope)
+				if tc.wantRange && code != "INVALID_RANGE" {
+					t.Fatalf("%s with k=%d: code=%q want INVALID_RANGE", tool.name, tc.k, code)
+				}
+				if !tc.wantRange && code == "INVALID_RANGE" {
+					t.Fatalf("%s with in-bound k=%d must not be INVALID_RANGE", tool.name, tc.k)
+				}
+			})
+		}
+	}
+}
+
+// TestToolK_OmittedStillResolvesToDefault pins the other half of #648: making a
+// supplied out-of-bound k an error must not make an OMITTED k an error. An
+// absent k stays the shipped default, so an existing caller sees no change.
+func TestToolK_OmittedStillResolvesToDefault(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	for _, tool := range kBearingTools {
+		t.Run(tool.name, func(t *testing.T) {
+			args := tool.argsWithK(1)
+			// Drop the k member so the tool sees an omitted field.
+			var decoded map[string]interface{}
+			if err := json.Unmarshal([]byte(args), &decoded); err != nil {
+				t.Fatalf("decode fixture args: %v", err)
+			}
+			delete(decoded, "k")
+			withoutK, err := json.Marshal(decoded)
+			if err != nil {
+				t.Fatalf("encode fixture args: %v", err)
+			}
+			envelope := callToolRaw(t, mcpURL, sid, tool.name, string(withoutK))
+			if code := envelopeErrorCode(envelope); code == "INVALID_RANGE" {
+				t.Fatalf("%s with omitted k must not be INVALID_RANGE", tool.name)
+			}
+		})
+	}
+}

--- a/tests/mcp/ask_audio_filters_644_test.go
+++ b/tests/mcp/ask_audio_filters_644_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// TestMCPAskAudio_InheritedFiltersReachRetrieval pins issue #644: dir2mcp_ask_audio
+// "inherits all dir2mcp_ask fields" (bs-007 / SPEC §15.10) and its advertised
+// schema is a clone of ask's, so every filter it publishes must reach the
+// retrieval query.
+//
+// Before the fix the handler allowed only eight names, so languages,
+// language_match, date_from/date_to, time_from_ms/time_to_ms, entities and
+// events came back INVALID_FIELD. A schema-driven client could not narrow an
+// ask_audio question at all.
+func TestMCPAskAudio_InheritedFiltersReachRetrieval(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	var got model.SearchQuery
+	retriever := &askAudioRetrieverStub{
+		indexingComplete: true,
+		askResult:        model.AskResult{Answer: "ok"},
+		OnAskQuery:       func(q model.SearchQuery) { got = q },
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{`+
+			`"question":"q","k":7,"index":"text","path_prefix":"docs/","file_glob":"*.md","doc_types":["document"],`+
+			`"languages":["pt-BR"],"language_match":"strict","date_from":"2026-01-01","date_to":"2026-02-01",`+
+			`"time_from_ms":1000,"time_to_ms":5000,"entities":["ent-1"],"events":["goal"],"voice_id":"v1"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	assertAskAudioFiltersForwarded(t, got)
+}
+
+// assertAskAudioFiltersForwarded checks every advertised ask_audio filter arrived
+// in the retrieval query. One table row per advertised field, so a newly
+// advertised filter that never reaches retrieval shows up as its own failure.
+func assertAskAudioFiltersForwarded(t *testing.T, got model.SearchQuery) {
+	t.Helper()
+	for _, check := range []struct {
+		field string
+		ok    bool
+		got   interface{}
+	}{
+		{"k", got.K == 7, got.K},
+		{"index", got.Index == "text", got.Index},
+		{"path_prefix", got.PathPrefix == "docs/", got.PathPrefix},
+		{"file_glob", got.FileGlob == "*.md", got.FileGlob},
+		{"doc_types", reflect.DeepEqual(got.DocTypes, []string{"document"}), got.DocTypes},
+		{"languages", reflect.DeepEqual(got.Languages, []string{"pt-BR"}), got.Languages},
+		{"language_match", got.LanguageMatch == "strict", got.LanguageMatch},
+		{"date_from", got.DateFrom != 0, got.DateFrom},
+		{"date_to", got.DateTo != 0, got.DateTo},
+		{"time_from_ms", got.HasTimeFrom && got.TimeFromMS == 1000, got.TimeFromMS},
+		{"time_to_ms", got.HasTimeTo && got.TimeToMS == 5000, got.TimeToMS},
+		{"entities", reflect.DeepEqual(got.Entities, []string{"ent-1"}), got.Entities},
+		{"events", reflect.DeepEqual(got.Events, []string{"goal"}), got.Events},
+	} {
+		if !check.ok {
+			t.Errorf("ask_audio advertises %s but it did not reach retrieval: got %#v", check.field, check.got)
+		}
+	}
+}
+
+// TestMCPAskAudio_InvalidInheritedFilterIsRejected pins the other direction: now
+// that ask_audio accepts the inherited filters, it must also apply their
+// validation rather than pass a malformed value down. An unrecognized
+// language_match is INVALID_FIELD (SPEC §9.5/§14) on ask_audio exactly as it is
+// on ask and search.
+func TestMCPAskAudio_InvalidInheritedFilterIsRejected(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &askAudioRetrieverStub{indexingComplete: true, askResult: model.AskResult{Answer: "ok"}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask_audio","arguments":{"question":"q","languages":["en"],"language_match":"loose"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	assertToolCallErrorCode(t, resp, "INVALID_FIELD")
+	if retriever.askCalled.Load() {
+		t.Fatal("retriever.Ask must not run when an inherited filter is invalid")
+	}
+}

--- a/tests/mcp/stats_models_647_test.go
+++ b/tests/mcp/stats_models_647_test.go
@@ -1,0 +1,148 @@
+package tests
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+)
+
+// loadStatsModelsConfig writes a .dir2mcp.yaml, loads it, and returns a config
+// ready to serve MCP. The providers subtree is only reachable through
+// config.LoadFile, so a models-provenance test has to go through a file.
+func loadStatsModelsConfig(t *testing.T, body string) config.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile: %v", err)
+	}
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+	return cfg
+}
+
+// statsModelsFromServer calls dir2mcp_stats and returns the models block.
+func statsModelsFromServer(t *testing.T, cfg config.Config) map[string]interface{} {
+	t.Helper()
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	t.Cleanup(srv.Close)
+	sc := callStatsTool(t, srv.URL+cfg.MCPPath)
+	models, ok := sc["models"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models missing from stats payload: %#v", sc["models"])
+	}
+	return models
+}
+
+// TestMCPToolsCallStats_ModelsReportConfiguredIdentities pins issue #647: the
+// models block MUST name the provider and model identities this deployment
+// resolves, not the built-in Mistral constants.
+//
+// An operator who moves embeddings, OCR and STT onto other providers asks stats
+// what produced the vectors and transcripts. The old handler answered
+// "mistral-embed", "codestral-embed", "mistral-ocr-latest" and "mistral" for
+// every deployment, so the provenance surface named a backend that is not in use.
+func TestMCPToolsCallStats_ModelsReportConfiguredIdentities(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "gemini-test-key")
+	t.Setenv("WHISPER_BASE_URL", "http://127.0.0.1:9/v1")
+	t.Setenv("MISTRAL_API_KEY", "")
+
+	cfg := loadStatsModelsConfig(t, ""+
+		"stt_provider: whisper\n"+
+		"providers:\n"+
+		"  gemini:\n"+
+		"    embed_text_model: gemini-embedding-001\n"+
+		"    embed_code_model: gemini-embedding-001\n"+
+		"    chat_model: gemini-2.5-pro\n"+
+		"  house-ocr:\n"+
+		"    kind: mistral\n"+
+		"    base_url: http://127.0.0.1:9\n"+
+		"    ocr_model: house-ocr-v3\n"+
+		"  whisper:\n"+
+		"    kind: whisper\n"+
+		"    base_url: http://127.0.0.1:9/v1\n"+
+		"    stt_model: large-v3-turbo\n"+
+		"model:\n"+
+		"  embed:\n"+
+		"    provider: gemini\n"+
+		"  chat:\n"+
+		"    provider: gemini\n"+
+		"  ocr:\n"+
+		"    provider: house-ocr\n")
+
+	models := statsModelsFromServer(t, cfg)
+	for field, want := range map[string]string{
+		"embed_text":   "gemini-embedding-001",
+		"embed_code":   "gemini-embedding-001",
+		"ocr":          "house-ocr-v3",
+		"chat":         "gemini-2.5-pro",
+		"stt_provider": "whisper",
+		"stt_model":    "large-v3-turbo",
+	} {
+		if got, _ := models[field].(string); got != want {
+			t.Errorf("models.%s = %q, want the configured %q", field, got, want)
+		}
+	}
+}
+
+// TestMCPToolsCallStats_ModelsFallBackWhenNothingResolves pins the other branch:
+// with no eligible provider the block keeps the shipped defaults, so an
+// unconfigured server still reports a full, required models object.
+func TestMCPToolsCallStats_ModelsFallBackWhenNothingResolves(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("COHERE_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ELEVENLABS_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+
+	cfg := loadStatsModelsConfig(t, "root_dir: .\n")
+	models := statsModelsFromServer(t, cfg)
+	for _, field := range []string{"embed_text", "embed_code", "ocr", "stt_provider", "stt_model", "chat"} {
+		if got, _ := models[field].(string); got == "" {
+			t.Errorf("models.%s must stay populated when no provider resolves, got %#v", field, models[field])
+		}
+	}
+}
+
+// TestMCPToolsCallStats_STTProviderIsNotAClosedEnum pins the advertised half of
+// #647. bs-007 and the canonical stats.json say stt_provider is "not a closed
+// enum", and that any STT-capable provider is valid. The served schema pinned it
+// to mistral|elevenlabs, so a strict client rejected the stats of a deployment
+// that transcribes with whisper, openai, gemini or an operator-named profile.
+func TestMCPToolsCallStats_STTProviderIsNotAClosedEnum(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	defer srv.Close()
+
+	schema := toolOutputSchemaFromList(t, srv.URL+cfg.MCPPath, protocol.ToolNameStats)
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stats outputSchema has no properties: %#v", schema)
+	}
+	models, ok := properties["models"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stats outputSchema declares no models object: %v", keysOf(properties))
+	}
+	modelProps, ok := models["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models schema has no properties: %#v", models)
+	}
+	sttProvider, ok := modelProps["stt_provider"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("models schema declares no stt_provider: %v", keysOf(modelProps))
+	}
+	if enum, present := sttProvider["enum"]; present {
+		t.Fatalf("stt_provider must not be a closed enum, got %#v", enum)
+	}
+}

--- a/tests/mcp/stats_skip_reasons_646_test.go
+++ b/tests/mcp/stats_skip_reasons_646_test.go
@@ -1,0 +1,273 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// canonicalSkipReasons is the closed skip-reason vocabulary the canonical
+// stats.json pins for this spec minor. The test reads it from the pinned
+// dirstral-spec submodule when the checkout is present, so a spec-side change
+// cannot pass unnoticed, and falls back to the model constants otherwise (a
+// shallow clone without submodules still runs the rest of the assertions).
+func canonicalSkipReasons(t *testing.T) map[string]bool {
+	t.Helper()
+	fallback := map[string]bool{}
+	for _, reason := range []string{
+		model.SkipReasonUnsupportedFormat, model.SkipReasonBinaryIgnored,
+		model.SkipReasonArchive, model.SkipReasonIgnoreRule,
+		model.SkipReasonSecretExcluded, model.SkipReasonPathExcluded,
+		model.SkipReasonSizeCap, model.SkipReasonLanguageUncovered,
+		model.SkipReasonSymlinkIgnored,
+	} {
+		fallback[reason] = true
+	}
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "dirstral-spec", "spec", "tools", "schemas", "stats.json"))
+	if err != nil {
+		t.Logf("canonical stats.json unavailable (%v); using the model skip-reason constants", err)
+		return fallback
+	}
+	var doc struct {
+		Definitions struct {
+			Output struct {
+				Properties struct {
+					SkipReasons struct {
+						Items struct {
+							Properties struct {
+								Reason struct {
+									Enum []string `json:"enum"`
+								} `json:"reason"`
+							} `json:"properties"`
+						} `json:"items"`
+					} `json:"skip_reasons"`
+				} `json:"properties"`
+			} `json:"output"`
+		} `json:"definitions"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode canonical stats.json: %v", err)
+	}
+	enum := doc.Definitions.Output.Properties.SkipReasons.Items.Properties.Reason.Enum
+	if len(enum) == 0 {
+		t.Fatal("canonical stats.json declares no skip_reasons reason enum")
+	}
+	out := make(map[string]bool, len(enum))
+	for _, reason := range enum {
+		out[reason] = true
+	}
+	return out
+}
+
+// statsServerOverStore boots an MCP server whose retriever is a real retrieval
+// service over st, so the stats payload travels the production chain: store
+// aggregate -> retrieval.Stats -> tool serialization.
+func statsServerOverStore(t *testing.T, tmp string, st model.Store) (*httptest.Server, config.Config) {
+	t.Helper()
+	cfg := config.Default()
+	cfg.StateDir = tmp
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+
+	retriever := retrieval.NewService(st, nil, nil, nil)
+	srv := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
+	t.Cleanup(srv.Close)
+	return srv, cfg
+}
+
+func newSkipReasonStore(t *testing.T) (*store.SQLiteStore, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st, tmp
+}
+
+// toolOutputSchemaFromList returns the outputSchema the server advertises for
+// one tool, which is the schema a strict client validates responses against.
+func toolOutputSchemaFromList(t *testing.T, mcpURL, toolName string) map[string]interface{} {
+	t.Helper()
+	sessionID := initializeSession(t, mcpURL)
+	resp := postRPC(t, mcpURL, sessionID, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+	defer func() { _ = resp.Body.Close() }()
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name         string                 `json:"name"`
+				OutputSchema map[string]interface{} `json:"outputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode tools/list: %v", err)
+	}
+	for _, tool := range envelope.Result.Tools {
+		if tool.Name == toolName {
+			return tool.OutputSchema
+		}
+	}
+	t.Fatalf("tool %q not advertised", toolName)
+	return nil
+}
+
+// keysOf returns the sorted key set of a decoded JSON object, for readable
+// failure messages.
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// decodeSkipReasons validates the emitted skip_reasons array against the
+// canonical item contract (reason in the closed enum, count >= 1, no extra keys)
+// and returns the per-reason counts.
+func decodeSkipReasons(t *testing.T, raw interface{}) map[string]float64 {
+	t.Helper()
+	entries, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("skip_reasons missing or not an array: %#v", raw)
+	}
+	allowed := canonicalSkipReasons(t)
+	counts := map[string]float64{}
+	for _, item := range entries {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("skip_reasons entry is not an object: %#v", item)
+		}
+		if len(entry) != 2 {
+			t.Errorf("skip_reasons entry carries extra keys (canonical items are additionalProperties:false): %#v", entry)
+		}
+		reason, _ := entry["reason"].(string)
+		if reason == "" {
+			t.Fatalf("skip_reasons entry has no reason string: %#v", entry)
+		}
+		if !allowed[reason] {
+			t.Errorf("reason %q is outside the canonical enum %v", reason, allowed)
+		}
+		count, ok := entry["count"].(float64)
+		if !ok || count < 1 {
+			t.Fatalf("skip_reasons %q count must be an integer >= 1, got %#v", reason, entry["count"])
+		}
+		counts[reason] = count
+	}
+	return counts
+}
+
+// TestMCPToolsCallStats_SkipReasonsReportedFromStore pins issue #646: the store
+// persists a durable skip aggregate, so dir2mcp_stats MUST serialize it as the
+// canonical skip_reasons array (SPEC §15.6 / stats.json).
+//
+// A client that trusts doc_counts alone reads a corpus with unindexable files as
+// fully covered, then answers over evidence that was never indexed. skip_reasons
+// is the field that says what is missing and why.
+func TestMCPToolsCallStats_SkipReasonsReportedFromStore(t *testing.T) {
+	st, tmp := newSkipReasonStore(t)
+
+	seeded := []model.Document{
+		{RelPath: "a.odt", DocType: "document", Status: "skipped", SkipReason: model.SkipReasonUnsupportedFormat},
+		{RelPath: "b.rtf", DocType: "document", Status: "skipped", SkipReason: model.SkipReasonUnsupportedFormat},
+		{RelPath: "c.zip", DocType: "archive", Status: "skipped", SkipReason: model.SkipReasonArchive},
+		{RelPath: "d.md", DocType: "md", Status: "ok"},
+		{RelPath: "e.pdf", DocType: "pdf", Status: "error", ErrorMessage: "extract failed"},
+	}
+	for _, doc := range seeded {
+		if err := st.UpsertDocument(context.Background(), doc); err != nil {
+			t.Fatalf("seed %s: %v", doc.RelPath, err)
+		}
+	}
+
+	srv, cfg := statsServerOverStore(t, tmp, st)
+	sc := callStatsTool(t, srv.URL+cfg.MCPPath)
+
+	counts := decodeSkipReasons(t, sc["skip_reasons"])
+	if counts[model.SkipReasonUnsupportedFormat] != 2 {
+		t.Errorf("unsupported_format count = %v, want 2", counts[model.SkipReasonUnsupportedFormat])
+	}
+	if counts[model.SkipReasonArchive] != 1 {
+		t.Errorf("archive count = %v, want 1", counts[model.SkipReasonArchive])
+	}
+
+	// SPEC §15.6: indexing.skipped equals the sum of skip_reasons[].count.
+	indexing, ok := sc["indexing"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("indexing missing: %#v", sc["indexing"])
+	}
+	var total float64
+	for _, count := range counts {
+		total += count
+	}
+	if skipped, _ := indexing["skipped"].(float64); skipped != total {
+		t.Errorf("indexing.skipped = %v, want the skip_reasons total %v", indexing["skipped"], total)
+	}
+}
+
+// TestMCPToolsCallStats_SkipReasonsOmittedWhenNothingSkipped pins the other
+// branch of SPEC §15.6: a corpus with nothing skipped omits the field, so
+// "present" always means real coverage gaps exist.
+func TestMCPToolsCallStats_SkipReasonsOmittedWhenNothingSkipped(t *testing.T) {
+	st, tmp := newSkipReasonStore(t)
+	if err := st.UpsertDocument(context.Background(), model.Document{
+		RelPath: "ok.md", DocType: "md", Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	srv, cfg := statsServerOverStore(t, tmp, st)
+	sc := callStatsTool(t, srv.URL+cfg.MCPPath)
+	if _, present := sc["skip_reasons"]; present {
+		t.Errorf("skip_reasons must be omitted when nothing was skipped, got %#v", sc["skip_reasons"])
+	}
+}
+
+// TestMCPToolsCallStats_SkipReasonsAdvertisedInOutputSchema pins the advertised
+// half of the contract: a strict client validates structuredContent against the
+// outputSchema it read from tools/list, and that schema sets
+// additionalProperties:false. An emitted-but-undeclared skip_reasons would make
+// every response with coverage gaps invalid.
+func TestMCPToolsCallStats_SkipReasonsAdvertisedInOutputSchema(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+	srv := httptest.NewServer(mcp.NewServer(cfg, nil).Handler())
+	defer srv.Close()
+
+	schema := toolOutputSchemaFromList(t, srv.URL+cfg.MCPPath, protocol.ToolNameStats)
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stats outputSchema has no properties: %#v", schema)
+	}
+	skipReasons, ok := properties["skip_reasons"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("stats outputSchema does not declare skip_reasons: %v", keysOf(properties))
+	}
+	items, ok := skipReasons["items"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skip_reasons declares no item schema: %#v", skipReasons)
+	}
+	itemProps, ok := items["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skip_reasons item schema has no properties: %#v", items)
+	}
+	for _, field := range []string{"reason", "count"} {
+		if _, ok := itemProps[field]; !ok {
+			t.Errorf("skip_reasons item schema omits %q: %v", field, keysOf(itemProps))
+		}
+	}
+}


### PR DESCRIPTION
One defect class in five issues: the schema a tool ADVERTISES disagrees with what its handler DOES. A client reads `tools/list`, trusts the contract, and gets a surprise. Each issue is its own commit so each reads on its own.

## What a client that trusts the schema does, and what it gets

### #648: `k=0` and negative `k` become the default (commit 1)

Every tool that takes `k` advertises `"minimum": 1` and `"maximum": 50`. The shared parser rejected only values above 50.

- **Does:** sends `k: 0`, a value the schema forbids, and expects the error the schema implies.
- **Gets:** 15 hits and no signal. The substitution is indistinguishable from omitting the field, so a caller cannot detect that its request was not the request served.

`parseKArg` now tells an omitted `k` from a supplied one. An omitted `k` still resolves to `DefaultSearchK`. A supplied `k` outside 1..50 returns `INVALID_RANGE`, the code 51 already returned.

**Direction:** the SPEC bound is `1..50` in prose (§15.2/§15.3, bs-007) and in the canonical `search.json`/`ask.json` (`"minimum": 1`). Nothing in the SPEC clamps, so 0 is invalid, not clamped to 1.

**Not done here, on purpose:** resolving an omitted `k` against `rag.k_default`. dirstral-spec PR #90 is OPEN and decides that precedence (request, then `rag.k_default`, then the shipped fallback), requires `rag.k_default` itself to satisfy 1..50 at load, and requires the SERVED schema to publish the EFFECTIVE default. That is dir2mcp #654. This PR does not touch default resolution or the advertised `default`, so it cannot contradict #90. The new `MinSearchK` const is the low bound #90 also applies to `rag.k_default`, in one place.

### #644: `ask_audio` advertises filters its handler rejects (commit 2)

`askAudioInputSchema` clones `askInputSchema`, so `tools/list` publishes the whole inherited `ask` filter set. The handler kept a shorter hand-written allowlist of eight names.

- **Does:** narrows an `ask_audio` question by language, document date or media time window, exactly as the published schema describes.
- **Gets:** `INVALID_FIELD` for `languages`, `language_match`, `date_from`, `date_to`, `time_from_ms`, `time_to_ms`, `entities` and `events`. The advertised contract was unusable.

**Direction:** bs-007 and SPEC §15.10 say the input "**inherits all** `dir2mcp_ask` fields", naming `languages`, `date_from` and `date_to`. So the fix accepts them rather than shrinking the schema. Both ask-family handlers now share one allowlist (`askFamilyArguments`) and one parser (`parseAskArgs`), so a field cannot be advertised on one tool and refused on the other, and an accepted filter cannot be dropped before retrieval.

**Minor contract change worth naming:** `dir2mcp_ask` used to check `retriever == nil` before validating `entities`/`events`. Validation now runs first, so a bad `entities` value on a server with no retriever answers `INVALID_FIELD` instead of `INDEX_NOT_READY`. Input validation before availability is what every other field already did.

**STOPPED, so #644 stays open:** the canonical `format` option (`mp3 | wav`, default `mp3`). Advertising it without honoring it would recreate this exact defect, and honoring it needs per-provider TTS output-format plumbing: ElevenLabs emits raw PCM rather than a WAV container, so `format: wav` means wrapping PCM or transcoding, and OpenAI and Gemini each need their own mapping. That is a feature, not a contract repair. Filed as the remaining half of #644.

### #645: `related` and `language_match` (commit 3, test only)

The report says the handler accepts `language_match` while the schema omits it. **On main the two agree.** The `related` allowlist has never carried `language_match` (it has not since the tool landed in #607), and `relatedInputSchema` does not declare it. The cited evidence, `tests/mcp/related_test.go:244`, is `TestMCPRelated_UnknownArgumentRejected`, which uses `language_match` as its example of an UNDECLARED argument, so it asserts the opposite of the report.

**STOPPED, so #645 stays open.** Adding `language_match` to `related` is a SPEC decision: canonical `related.json` sets `additionalProperties: false` and omits it, and SPEC §9.5 scopes the companion argument to `dir2mcp_search` (§15.2) and `dir2mcp_ask` (§15.3). §15.12 enumerates the filters `related` reuses and `language_match` is not among them. This repo is spec-first, so that starts in dirstral-spec.

What was missing is the guard the issue's last acceptance criterion asks for, so this commit adds it. See the anti-drift section below.

### #646: `stats` drops populated skip-reason coverage (commit 4)

The store aggregates every `status="skipped"` document by `skip_reason`. Two layers dropped it: `retrieval.applyCorpusStats` did not copy `SkipSummary` while copying the counters, and the stats handler never serialized `skip_reasons`.

- **Does:** reads `doc_counts` plus `skip_reasons` to learn which part of a corpus is retrievable, because §15.6 says `doc_counts` overstates coverage on purpose.
- **Gets:** `doc_counts` only. A corpus of unindexable `.odt` files looks fully covered, so a downstream agent claims evidence that was never indexed. `skip_reasons` is the field that says otherwise, and it was silently absent.

Both layers are fixed. Serialization follows §15.6: `[{reason, count}]`, deterministic order (count descending, then reason), no zero counts, and the field omitted when nothing was skipped so "present" always means real gaps. The test also asserts the §15.6 invariant that `indexing.skipped` equals the sum of `skip_reasons[].count`.

**One deliberate divergence from the canonical schema.** The served item declares `reason` as a string, not the canonical closed `enum`. §15.6 says the enum is the vocabulary for ONE spec minor and, in the same paragraph, that a client MAY receive an unrecognized value from a newer server and SHOULD render it verbatim. A served closed enum would therefore publish a schema that rejects a payload this server can legitimately emit (a legacy row with no recorded reason aggregates as `unknown`), which is the very defect this PR exists to remove. The canonical values are named in the description, and the test validates emitted reasons against the enum read from the pinned `dirstral-spec/spec/tools/schemas/stats.json`, so a spec-side change is still caught.

### #647: `stats` reports hardcoded Mistral identities and closes the STT enum (commit 5)

- **Does (operator):** points embeddings at Gemini and STT at a self-hosted Whisper endpoint, then asks stats what produced the vectors and the transcripts.
- **Gets:** `mistral-embed`, `codestral-embed`, `mistral-ocr-latest` and `mistral`, for every deployment. Provenance that reports a default instead of the configuration is worse than none, because it looks authoritative.
- **Does (strict client):** validates `structuredContent` against the advertised `outputSchema`.
- **Gets:** a rejected response whenever the deployment transcribes with `whisper`, `openai`, `gemini` or an operator-named profile, because the served `stt_provider` enum was `mistral | elevenlabs`.

**Shape of the fix: report what is configured, do not widen a hardcoded list.** Every field resolves through the same provider model the pipelines use, so the reported identity cannot drift from the identity on the wire:

- `embed_text` / `embed_code`: `provider.EffectiveEmbedModels` of the resolved embed profile, the resolution the embed identity (SPEC 8.1.4) and both embed call sites already share.
- `ocr`: the new `ingest.ResolveOCRProviderModel`, the OCR twin of `ResolveSTTProviderModel`, mirroring the extractor's own `model.ocr.provider` binding.
- `stt_provider` / `stt_model`: `resolvedSTTProvenance`, already shared with the transcribe tools.
- `chat`: unchanged, it was already resolved.

A capability with no eligible profile keeps the shipped default, which is what a later `up` with a credential present would use. A profile that resolves but names no model reports `(<profile> provider default)` rather than another provider's constant, because the adapter picks its own default there and naming a model would be a guess.

`stt_provider` is now an open string, as bs-007 and `stats.json` require.

**Scope boundary:** `models.ocr` reports the resolved OCR provider profile's model. It does not resolve the docling/pandoc extractor cascade, because `DescribeDocumentExtractor` runs an `exec` probe and an HTTP reachability probe, which a status call must not do on every request. So with `ingest.extractor=docling` the field still names the OCR profile rather than the local extractor. Worth a follow-up issue; it needs a cached extractor decision, not a hardcoded constant.

## The anti-drift guard

Two conformance tests read `tools/list` and pin the contract in both directions, so the class cannot come back on a tool nobody thought about:

- `TestInputSchema_EveryAdvertisedPropertyIsAccepted`: every advertised property must reach its handler. Fails on main for the eight `ask_audio` filters.
- `TestInputSchema_UndeclaredPropertyIsRejected` (#645): a tool must refuse a property it does not advertise, probed with the names its sibling tools publish. Passes on main, which is the evidence that #645's reported divergence does not exist.

Both run against the production SDK transport (#827), so they read the contract a real client gets.

## Proof each test fails on main

Run against main's `internal/` with the new tests in place.

`TestToolK_SuppliedOutOfBoundIsInvalidRange` (#648), 10 of 25 subtests:

```
--- FAIL: .../dir2mcp_search/k=-1  code="INDEX_NOT_READY" want INVALID_RANGE
--- FAIL: .../dir2mcp_search/k=0   code="INDEX_NOT_READY" want INVALID_RANGE
--- FAIL: .../dir2mcp_ask/k=-1 ... /dir2mcp_ask/k=0
--- FAIL: .../dir2mcp_related/k=-1 ... /dir2mcp_related/k=0
--- FAIL: .../dir2mcp_ask_audio/k=-1 ... /dir2mcp_ask_audio/k=0
--- FAIL: .../dir2mcp_transcribe_and_ask/k=-1 ... /k=0
```

`TestInputSchema_EveryAdvertisedPropertyIsAccepted` (#644):

```
dir2mcp_ask_audio advertises "date_from" but its handler rejects it: unknown argument: date_from
dir2mcp_ask_audio advertises "date_to" ... "entities" ... "events" ... "language_match"
dir2mcp_ask_audio advertises "languages" ... "time_from_ms" ... "time_to_ms"
```

`TestMCPAskAudio_InheritedFiltersReachRetrieval` (#644): 13 of 13 advertised filters absent from the retrieval query (`k=0 index=""`, nil `DocTypes`, nil `Languages`, `DateFrom=0`, `HasTimeFrom=false`, nil `Entities`).

`TestMCPToolsCallStats_SkipReasons*` (#646):

```
skip_reasons missing or not an array: <nil>
stats outputSchema does not declare skip_reasons: [doc_counts ... recent_failures root sessions state_dir total_docs]
```

Also verified that the retrieval-layer half is load-bearing: with the tool-layer fix applied but `applyCorpusStats` at main, `skip_reasons` is still `<nil>`.

`TestMCPToolsCallStats_Models*` / `_STTProviderIsNotAClosedEnum` (#647):

```
models.stt_provider = "mistral", want the configured "whisper"
models.stt_model = "voxtral-mini-latest", want the configured "large-v3-turbo"
models.embed_text = "mistral-embed", want the configured "gemini-embedding-001"
models.embed_code = "codestral-embed", want the configured "gemini-embedding-001"
models.ocr = "mistral-ocr-latest", want the configured "house-ocr-v3"
stt_provider must not be a closed enum, got []interface{}{"mistral", "elevenlabs"}
```

Each commit was also checked out in a scratch worktree and built and tested on its own, so the series has no commit that only compiles with a later one.

## Found while reading, NOT fixed

`dir2mcp_stats` emits a `sessions` object and marks it required in the served output schema. Canonical `stats.json` sets `additionalProperties: false` and does not declare `sessions`, so a client validating against the canonical schema rejects EVERY dir2mcp stats response. Same defect class, sixth instance, and spec-pinned in both directions: either the canonical schema adds `sessions` or dir2mcp drops a field clients may already read. Not touched here. Worth its own issue.

## Notes

- `coderabbit review --committed --base main` refused: "Review limit reached ... this Git provider account isn't linked to an assigned seat". A line-by-line self-review replaced it and found four things, all fixed before this PR: a duplicated `parseKArg` doc comment left by the rewrite, an untyped `interface{}` sort comparator in `skipReasonsForStats` (now a typed slice, so a wrong-type count can no longer sort as 0), the review touch-ups landing in the wrong commits (series rebuilt so each commit is self-contained), and em dashes in new comments and one commit message.
- `make check` and `make ci` both pass, gocyclo `-over 15` included. Two test helpers were extracted to stay under the gate.
- No documentation change needed: `README.md` and `docs/` do not state the `k` bound, the stats `models` identities, or `skip_reasons`.

Closes #646
Closes #647
Closes #648
