### PR TITLE
fix(mcp): stop emitting the stats `sessions` object the canonical schema forbids (#850)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -129,7 +129,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # submodules: true because the suite now validates a whole tool payload
+      # against the CANONICAL schema in dirstral-spec (#850), not against a copy
+      # kept in this repo. Without the submodule that assertion cannot run, and
+      # a conformance guard that silently skips is worse than no guard.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          submodules: true
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/google/jsonschema-go v0.4.2
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/pdfcpu/pdfcpu v0.12.1
@@ -58,7 +59,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hhrutter/lzw v1.0.0 // indirect

--- a/internal/mcp/output_schema_conformance_test.go
+++ b/internal/mcp/output_schema_conformance_test.go
@@ -499,12 +499,8 @@ func TestStatsOutputSchemaConformance(t *testing.T) {
 			"stt_model":    "voxtral-mini-latest",
 			"chat":         "mistral-large-latest",
 		},
-		"sessions": map[string]interface{}{
-			"active": 1,
-			"items": []map[string]interface{}{
-				{"id": "abc***", "created_unix": int64(1700000000), "last_seen_unix": int64(1700000100)},
-			},
-		},
+		// No "sessions" key: the transport session roster is not part of the
+		// §15.6 output (#850), and the schema closes the object.
 		"recent_failures": []map[string]interface{}{
 			{"rel_path": "docs/bad.pdf", "doc_type": "pdf", "mtime_unix": int64(1700000050), "error_message": "ocr failed"},
 		},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -445,25 +445,10 @@ func (s *Server) handleStatsTool(ctx context.Context, args map[string]interface{
 		structured["skip_reasons"] = reasons
 	}
 
-	s.sessionMu.RLock()
-	sessionItems := make([]map[string]interface{}, 0, len(s.sessions))
-	for id, si := range s.sessions {
-		sessionItems = append(sessionItems, map[string]interface{}{
-			"id":             maskSessionID(id),
-			"created_unix":   si.created.Unix(),
-			"last_seen_unix": si.lastSeen.Unix(),
-		})
-	}
-	s.sessionMu.RUnlock()
-	sort.Slice(sessionItems, func(i, j int) bool {
-		left, _ := sessionItems[i]["id"].(string)
-		right, _ := sessionItems[j]["id"].(string)
-		return left < right
-	})
-	structured["sessions"] = map[string]interface{}{
-		"active": len(sessionItems),
-		"items":  sessionItems,
-	}
+	// No `sessions` block here on purpose (#850). See statsOutputSchema for the
+	// full reasoning: the transport session roster is not part of the §15.6
+	// contract, and the canonical stats.json closes the output object, so
+	// emitting it made a canonically-validating client reject every response.
 
 	text := fmt.Sprintf(
 		"indexing running=%t scanned=%d indexed=%d errors=%d",
@@ -4387,6 +4372,22 @@ func statsInputSchema() map[string]interface{} {
 	}
 }
 
+// statsOutputSchema is the schema dir2mcp advertises for dir2mcp_stats. It must
+// stay the same contract as the canonical
+// dirstral-spec/spec/tools/schemas/stats.json for the pinned spec version,
+// because SPEC §1.3 treats "the server-advertised schema" and "the schema for
+// the payload's declared format_version" as one schema, and the canonical output
+// object is closed (additionalProperties: false).
+//
+// It therefore declares no `sessions` block (#850). The transport session roster
+// used to be published here and emitted on every call, so a client that
+// validated against the canonical schema rejected EVERY stats response. Sessions
+// are transport state, not corpus state: §15.6 scopes this tool to
+// "status/progress/health for indexing and models", session state has its own
+// normative home in spec/sessions/lifecycle.md, and that document gives a client
+// only its own session, through headers. It defines no roster. On the stdio
+// transport a session id does not exist at all, so a required roster field
+// cannot mean anything for a stdio implementation.
 func statsOutputSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":                 "object",
@@ -4446,27 +4447,6 @@ func statsOutputSchema() map[string]interface{} {
 				},
 				"required": []string{"embed_text", "embed_code", "ocr", "stt_provider", "stt_model", "chat"},
 			},
-			"sessions": map[string]interface{}{
-				"type":                 "object",
-				"additionalProperties": false,
-				"properties": map[string]interface{}{
-					"active": map[string]interface{}{"type": "integer"},
-					"items": map[string]interface{}{
-						"type": "array",
-						"items": map[string]interface{}{
-							"type":                 "object",
-							"additionalProperties": false,
-							"properties": map[string]interface{}{
-								"id":             map[string]interface{}{"type": "string"},
-								"created_unix":   map[string]interface{}{"type": "integer"},
-								"last_seen_unix": map[string]interface{}{"type": "integer"},
-							},
-							"required": []string{"id", "created_unix", "last_seen_unix"},
-						},
-					},
-				},
-				"required": []string{"active", "items"},
-			},
 			// recent_failures: optional per SPEC §15.6 — implementations
 			// MAY omit when no failures are recorded; clients MUST treat
 			// omission as "no recent failures". additionalProperties:false
@@ -4517,6 +4497,6 @@ func statsOutputSchema() map[string]interface{} {
 				},
 			},
 		},
-		"required": []string{"root", "state_dir", "protocol_version", "doc_counts", "total_docs", "doc_counts_available", "indexing", "models", "sessions"},
+		"required": []string{"root", "state_dir", "protocol_version", "doc_counts", "total_docs", "doc_counts_available", "indexing", "models"},
 	}
 }

--- a/tests/conformance/helpers_test.go
+++ b/tests/conformance/helpers_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/protocol"
 	"github.com/dirstral/dir2mcp/internal/x402"
 )
@@ -144,7 +145,15 @@ const serverCloseTimeout = 15 * time.Second
 // handler on purpose.
 func newServer(t *testing.T, cfg config.Config, opts ...mcp.ServerOption) *runningServer {
 	t.Helper()
-	server := mcp.NewServer(cfg, nil, opts...)
+	return newServerWithRetriever(t, cfg, nil, opts...)
+}
+
+// newServerWithRetriever is newServer with a live retriever behind the tools, so
+// a test can read a payload that travelled the production chain (store aggregate
+// -> retrieval service -> tool serialization) instead of the no-corpus fallback.
+func newServerWithRetriever(t *testing.T, cfg config.Config, retriever model.Retriever, opts ...mcp.ServerOption) *runningServer {
+	t.Helper()
+	server := mcp.NewServer(cfg, retriever, opts...)
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)

--- a/tests/conformance/stats_canonical_schema_850_test.go
+++ b/tests/conformance/stats_canonical_schema_850_test.go
@@ -1,0 +1,293 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// Whole-payload conformance for dir2mcp_stats (issue #850).
+//
+// SPEC §1.3 treats "the schema the server advertises" and "the schema for the
+// payload's declared format_version" as ONE schema, and the canonical stats
+// output object is closed (additionalProperties: false). So a payload that
+// carries a field the canonical schema does not declare is invalid for every
+// client that validates against the canonical copy, on every single call.
+//
+// dir2mcp used to emit a `sessions` object and to mark it required in the served
+// schema. The canonical schema declares no such field, so a canonically
+// validating client rejected EVERY stats response. #849 could only validate the
+// skip_reasons subtree for that reason. These tests validate the WHOLE object,
+// which is what makes the drift impossible to reintroduce quietly.
+
+// canonicalStatsSchemaPath is the pinned canonical schema inside the
+// dirstral-spec submodule. The suite reads THAT file, not a copy, so a
+// spec-side change reaches this test through the submodule pin.
+var canonicalStatsSchemaPath = filepath.Join("..", "..", "dirstral-spec", "spec", "tools", "schemas", "stats.json")
+
+// canonicalStatsOutputRaw returns the raw `definitions.output` subschema of the
+// canonical stats.json. That subschema, not the file's root, is the contract for
+// a dir2mcp_stats structuredContent payload.
+func canonicalStatsOutputRaw(t *testing.T) json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(canonicalStatsSchemaPath)
+	if err != nil {
+		t.Fatalf("read canonical stats.json (run: git submodule update --init): %v", err)
+	}
+	var doc struct {
+		Definitions map[string]json.RawMessage `json:"definitions"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode canonical stats.json: %v", err)
+	}
+	output, ok := doc.Definitions["output"]
+	if !ok {
+		t.Fatal("canonical stats.json declares no definitions.output")
+	}
+	return output
+}
+
+// canonicalStatsValidator compiles the canonical output subschema into a
+// validator.
+func canonicalStatsValidator(t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(canonicalStatsOutputRaw(t), &schema); err != nil {
+		t.Fatalf("decode canonical stats output subschema: %v", err)
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("resolve canonical stats output subschema: %v", err)
+	}
+	return resolved
+}
+
+// canonicalStatsTree returns the canonical output subschema as a generic tree,
+// for the property-set and required-list comparison.
+func canonicalStatsTree(t *testing.T) map[string]interface{} {
+	t.Helper()
+	var tree map[string]interface{}
+	if err := json.Unmarshal(canonicalStatsOutputRaw(t), &tree); err != nil {
+		t.Fatalf("decode canonical stats output subschema as a tree: %v", err)
+	}
+	return tree
+}
+
+// callStatsStructured calls dir2mcp_stats over the production transport and
+// returns the structuredContent a real client validates.
+func callStatsStructured(t *testing.T, srv *runningServer, cfg config.Config) map[string]interface{} {
+	t.Helper()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+	resp := sendRPC(t, mcpURL, sid, statsCallBody(2), nil)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stats: status=%d want=200 body=%s", resp.StatusCode, body)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("stats: decode response: %v body=%s", err, body)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("stats: isError=true body=%s", body)
+	}
+	if envelope.Result.StructuredContent == nil {
+		t.Fatalf("stats: missing structuredContent body=%s", body)
+	}
+	return envelope.Result.StructuredContent
+}
+
+// assertCanonicalStats validates a whole stats payload against the canonical
+// schema and reports the offending payload on failure.
+func assertCanonicalStats(t *testing.T, structured map[string]interface{}) {
+	t.Helper()
+	if err := canonicalStatsValidator(t).Validate(structured); err != nil {
+		pretty, _ := json.MarshalIndent(structured, "", "  ")
+		t.Fatalf("dir2mcp_stats payload is invalid against the canonical stats.json: %v\npayload:\n%s", err, pretty)
+	}
+}
+
+// TestStats_PayloadValidatesAgainstCanonicalSchema pins the whole payload of a
+// plain server against the canonical schema.
+//
+// It fails on main with `unexpected additional properties ["sessions"]`, which
+// is exactly what a strict client saw on every call.
+func TestStats_PayloadValidatesAgainstCanonicalSchema(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.StateDir = t.TempDir()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+
+	assertCanonicalStats(t, callStatsStructured(t, srv, cfg))
+}
+
+// statsStoreWithGaps seeds a store whose corpus exercises the optional halves of
+// the §15.6 output: skipped documents (skip_reasons) and a failed one
+// (recent_failures). Without them a whole-payload check would never reach those
+// subtrees.
+func statsStoreWithGaps(t *testing.T) (model.Store, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	seeded := []model.Document{
+		{RelPath: "a.odt", DocType: "document", Status: "skipped", SkipReason: model.SkipReasonUnsupportedFormat},
+		{RelPath: "b.rtf", DocType: "document", Status: "skipped", SkipReason: model.SkipReasonUnsupportedFormat},
+		{RelPath: "c.zip", DocType: "archive", Status: "skipped", SkipReason: model.SkipReasonArchive},
+		{RelPath: "d.md", DocType: "md", Status: "ok"},
+		{RelPath: "e.pdf", DocType: "pdf", Status: "error", ErrorMessage: "extract failed"},
+	}
+	for _, doc := range seeded {
+		if err := st.UpsertDocument(context.Background(), doc); err != nil {
+			t.Fatalf("seed %s: %v", doc.RelPath, err)
+		}
+	}
+	return st, tmp
+}
+
+// TestStats_PopulatedPayloadValidatesAgainstCanonicalSchema validates the whole
+// payload of a corpus that actually has coverage gaps, so skip_reasons and
+// recent_failures are present and get validated too. This is the check #849
+// could not write: it had to look at the skip_reasons subtree alone, because a
+// whole-payload validation failed on `sessions` no matter what the subtree said.
+func TestStats_PopulatedPayloadValidatesAgainstCanonicalSchema(t *testing.T) {
+	t.Parallel()
+	st, tmp := statsStoreWithGaps(t)
+
+	cfg := defaultConfig()
+	cfg.StateDir = tmp
+	retriever := retrieval.NewService(st, nil, nil, nil)
+	srv := newServerWithRetriever(t, cfg, retriever, mcp.WithStore(st))
+	defer srv.Close()
+
+	structured := callStatsStructured(t, srv, cfg)
+
+	// Guard against a vacuous pass: the optional subtrees must really be there.
+	for _, field := range []string{"skip_reasons", "recent_failures"} {
+		if _, present := structured[field]; !present {
+			t.Fatalf("seeded corpus produced no %s, so the whole-payload check would not cover it: %v", field, sortedKeys(structured))
+		}
+	}
+	assertCanonicalStats(t, structured)
+}
+
+// sortedKeys returns the sorted key set of a decoded JSON object.
+func sortedKeys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// schemaPropertyNames reads a schema node's `properties` key set.
+func schemaPropertyNames(t *testing.T, schema map[string]interface{}, label string) []string {
+	t.Helper()
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s schema declares no properties object: %#v", label, schema["properties"])
+	}
+	return sortedKeys(properties)
+}
+
+// schemaRequired reads a schema node's `required` list as sorted strings.
+func schemaRequired(t *testing.T, schema map[string]interface{}, label string) []string {
+	t.Helper()
+	raw, ok := schema["required"].([]interface{})
+	if !ok {
+		t.Fatalf("%s schema declares no required array: %#v", label, schema["required"])
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		name, ok := item.(string)
+		if !ok {
+			t.Fatalf("%s schema has a non-string entry in required: %#v", label, item)
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestStats_AdvertisedSchemaMatchesCanonical pins the other direction of the
+// same contract. The payload check above only sees what this deployment happens
+// to emit. This one reads the schema the server publishes through tools/list and
+// requires the same top-level property set and the same required list as the
+// canonical file.
+//
+// It matters on its own: `required` in a served schema is a promise about the
+// ecosystem shape, not about this deployment's extras. A served schema that
+// required `sessions` made a client refuse a conforming response from another
+// implementation that correctly omits it.
+//
+// It fails on main, where `sessions` is both advertised and required.
+//
+// It compares the top level only. The nested shape stays with the payload
+// checks above, which validate real payloads against the whole canonical schema,
+// and with the deliberate served/canonical divergence #849 documented for the
+// skip_reasons `reason` enum.
+func TestStats_AdvertisedSchemaMatchesCanonical(t *testing.T) {
+	t.Parallel()
+	served, ok := toolsListSchemas(t)[protocol.ToolNameStats].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tools/list advertises no outputSchema for %s", protocol.ToolNameStats)
+	}
+	canonical := canonicalStatsTree(t)
+
+	assertSameStrings(t, "top-level property",
+		schemaPropertyNames(t, canonical, "canonical"),
+		schemaPropertyNames(t, served, "served"))
+	assertSameStrings(t, "required field",
+		schemaRequired(t, canonical, "canonical"),
+		schemaRequired(t, served, "served"))
+}
+
+// assertSameStrings reports each name present on one side only. It names the
+// direction, because the two directions are different defects: served-only means
+// the server publishes a field outside the contract, canonical-only means it
+// fails to publish a field the contract defines.
+func assertSameStrings(t *testing.T, label string, canonical, served []string) {
+	t.Helper()
+	inCanonical := make(map[string]bool, len(canonical))
+	for _, name := range canonical {
+		inCanonical[name] = true
+	}
+	inServed := make(map[string]bool, len(served))
+	for _, name := range served {
+		inServed[name] = true
+	}
+	for _, name := range served {
+		if !inCanonical[name] {
+			t.Errorf("served stats schema declares %s %q, which the canonical stats.json does not: served=%v canonical=%v", label, name, served, canonical)
+		}
+	}
+	for _, name := range canonical {
+		if !inServed[name] {
+			t.Errorf("canonical stats.json declares %s %q, which the served stats schema does not: served=%v canonical=%v", label, name, served, canonical)
+		}
+	}
+}

--- a/tests/mcp/tools_test.go
+++ b/tests/mcp/tools_test.go
@@ -880,7 +880,7 @@ func TestMCPToolsCallStats_ReturnsStructuredContent(t *testing.T) {
 	assertStatsDocCountsUnavailable(t, envelope.Result.StructuredContent)
 	assertStatsIndexingHasMode(t, envelope.Result.StructuredContent)
 	assertStatsModelsSTTProvider(t, envelope.Result.StructuredContent)
-	assertStatsSessionsActiveAndItems(t, envelope.Result.StructuredContent)
+	assertStatsOmitsSessions(t, envelope.Result.StructuredContent)
 }
 
 func assertStatsDocCountsUnavailable(t *testing.T, sc map[string]interface{}) {
@@ -917,18 +917,15 @@ func assertStatsModelsSTTProvider(t *testing.T, sc map[string]interface{}) {
 	}
 }
 
-func assertStatsSessionsActiveAndItems(t *testing.T, sc map[string]interface{}) {
+// assertStatsOmitsSessions pins issue #850: dir2mcp_stats MUST NOT carry a
+// `sessions` object. The canonical stats.json closes the output object and
+// declares no such field, so emitting it made a client that validates against
+// the canonical schema reject every stats response. It also published the
+// transport session roster of one client to every other client.
+func assertStatsOmitsSessions(t *testing.T, sc map[string]interface{}) {
 	t.Helper()
-	sessionsRaw, ok := sc["sessions"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected sessions object, got %#v", sc["sessions"])
-	}
-	if active, ok := sessionsRaw["active"].(float64); !ok || active < 1 {
-		t.Fatalf("expected sessions.active >= 1, got %#v", sessionsRaw["active"])
-	}
-	items, ok := sessionsRaw["items"].([]interface{})
-	if !ok || len(items) == 0 {
-		t.Fatalf("expected non-empty sessions.items, got %#v", sessionsRaw["items"])
+	if got, present := sc["sessions"]; present {
+		t.Fatalf("stats must not emit sessions (canonical stats.json is additionalProperties:false and declares no such field), got %#v", got)
 	}
 }
 
@@ -986,7 +983,7 @@ func TestMCPToolsCallStats_UsesRetrieverStats(t *testing.T) {
 	if !retriever.statsCalled.Load() {
 		t.Fatal("expected retriever.Stats to be called")
 	}
-	assertRetrieverStatsSessionsActive(t, envelope.Result.StructuredContent)
+	assertStatsOmitsSessions(t, envelope.Result.StructuredContent)
 }
 
 func assertRetrieverStatsTopLevel(t *testing.T, sc map[string]interface{}) {
@@ -1028,17 +1025,6 @@ func assertRetrieverStatsIndexing(t *testing.T, sc map[string]interface{}) {
 	}
 	if indexingRaw["scanned"] != float64(4) || indexingRaw["representations"] != float64(6) || indexingRaw["chunks_total"] != float64(8) {
 		t.Fatalf("unexpected indexing payload: %#v", indexingRaw)
-	}
-}
-
-func assertRetrieverStatsSessionsActive(t *testing.T, sc map[string]interface{}) {
-	t.Helper()
-	sessionsRaw, ok := sc["sessions"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected sessions object, got %#v", sc["sessions"])
-	}
-	if active, ok := sessionsRaw["active"].(float64); !ok || active < 1 {
-		t.Fatalf("expected sessions.active >= 1, got %#v", sessionsRaw["active"])
 	}
 }
 


### PR DESCRIPTION
Sixth instance of the class PR #849 fixed five times: the schema a tool publishes disagrees with what its handler does. This one is not an edge case. It broke every single `dir2mcp_stats` response.

## What a client does, and what it gets

- **Does:** validates `structuredContent` against the canonical `dirstral-spec/spec/tools/schemas/stats.json`, which is what a cross-implementation client validates against.
- **Gets:** `validating root: unexpected additional properties ["sessions"]`. Every call. Every deployment. The canonical output object is closed (`additionalProperties: false`) and declares no `sessions`.

The mirror problem existed too. A client that read the SERVED schema learned that `sessions` is **required**, so it refused a conforming response from any other implementation that correctly omits it.

## Both premises verified before the fix

Two issues this session had wrong premises, so both halves were checked first.

- Canonical `stats.json` sets `"additionalProperties": false` on `definitions.output` and its `required` list is `[root, state_dir, protocol_version, doc_counts, total_docs, doc_counts_available, indexing, models]`. No `sessions` anywhere in the file.
- `handleStatsTool` set `structured["sessions"]` unconditionally, and `statsOutputSchema()` declared it and named it in `required`.

SPEC §15.6 and bs-007 do not mention `sessions` either.

## The decision: the field goes, the canonical schema stays

The issue offered two honest fixes. This PR takes the second, and the first is wrong.

**Why the canonical schema must NOT gain `sessions`:**

1. **Wrong tool.** §15.6 scopes `dir2mcp_stats` to "status/progress/health for indexing and models". A session roster is neither indexing nor models. Every other field in the canonical output describes the corpus or the pinned protocol.
2. **Session state already has a normative home,** `spec/sessions/lifecycle.md`. That document gives a client its own session, through headers (`MCP-Session-Id`, `X-MCP-Session-Expired`). It defines no roster and no way to list sessions. A roster in a tool output is a new observability surface, not a schema repair.
3. **It is not implementable everywhere.** The same document defines stdio as a supported transport: "No session ID is issued or required." A canonical `sessions` field would mean nothing for a stdio implementation, and the served schema made it **required**.
4. **It crossed a client boundary.** Any caller read how many other clients were connected, plus a stable pseudonymous id, a creation time and a last-seen time for each. dir2mcp supports `--public` with x402 gating, so that caller can be a paying stranger, and `internal/elevenlabsbridge` forwards the whole structured payload to an external agent. A canonical field would push that on every implementation.

**Why removal needs no deprecation window.** No conforming client can be reading it. The field was never in the contract, and a client that validated against the canonical schema was already rejecting every stats response, so it could never consume the field it rejected. Nothing in this repo reads it either: no CLI command, no `docs/`, no `README.md`, no `make release-smoke` check. The only readers were this tool's own tests, and they now assert absence.

One honest residual risk: a client that cached a copy of dir2mcp's OLD served schema, where `sessions` was required, will reject the new payload. SPEC §1.3 already tells a client not to do that. It requires validation against the schema read from `tools/list`, "never a copy of an older schema pinned out of band". Leaving a contract violation in place to protect a client that ignores that rule is the worse trade.

**No dirstral-spec PR is needed.** The issue's first acceptance criterion asks dirstral-spec to decide whether stats carries `sessions`. The canonical schema already answers: it closes the object and omits the field. Nothing changes in the submodule, so there is no re-pin.

## The change

- `handleStatsTool` no longer builds the `sessions` block.
- `statsOutputSchema()` drops it from `properties` **and** from `required`. That is the issue's third acceptance criterion: `required` in a served schema is a promise about the ecosystem shape, not about this deployment's extras.

## The tests, and the #849 limitation they end

PR #849 could only validate the `skip_reasons` subtree, because a whole-payload check failed on `sessions` no matter what the subtree said. That limitation ends here. Three tests in `tests/conformance` run on the production SDK transport (#827) and read the canonical schema from the **pinned submodule**, so a spec-side change reaches them through the pin:

- `TestStats_PayloadValidatesAgainstCanonicalSchema`: validates the WHOLE payload of a plain server.
- `TestStats_PopulatedPayloadValidatesAgainstCanonicalSchema`: seeds a corpus with skipped and failed documents so `skip_reasons` and `recent_failures` are present, then validates the WHOLE payload. It fails first if either field is missing, so it cannot pass vacuously.
- `TestStats_AdvertisedSchemaMatchesCanonical`: reads `tools/list` and requires the served top-level property set and required list to equal the canonical ones. It names the direction of any mismatch, because served-only and canonical-only are different defects.

## Proof each test fails on main

Run with main's `internal/mcp/tools.go` restored and the new tests in place:

```
--- FAIL: TestStats_PayloadValidatesAgainstCanonicalSchema
    dir2mcp_stats payload is invalid against the canonical stats.json:
    validating root: unexpected additional properties ["sessions"]
    payload: { ... "sessions": {"active": 1, "items": [
      {"created_unix": 1786571452, "id": "43bb300d", "last_seen_unix": 1786571452}]} ... }

--- FAIL: TestStats_PopulatedPayloadValidatesAgainstCanonicalSchema
    validating root: unexpected additional properties ["sessions"]

--- FAIL: TestStats_AdvertisedSchemaMatchesCanonical
    served stats schema declares top-level property "sessions", which the canonical stats.json does not
    served stats schema declares required field "sessions", which the canonical stats.json does not
```

All three pass with the change.

## One CI change, in the second commit

The `conformance` job was the only Go job in `.github/workflows/go.yml` that checked out **without** submodules. The suite now reads the canonical schema from `dirstral-spec`, so the job needs it. The test reports a missing checkout instead of skipping, because a conformance guard that silently skips is worse than no guard. Every other Go job in that workflow already sets `submodules: true`.

## Notes

- `go.mod`: `github.com/google/jsonschema-go` moves from indirect to direct. No new module enters the graph. It is already there at the same version through the MCP Go SDK, and it is the validator the SDK itself uses, so the test validates with the engine a real client gets.
- `newServerWithRetriever` is added to the conformance helpers, and `newServer` now delegates to it. A conformance test can now read a payload that travelled the production chain (store aggregate, retrieval service, tool serialization) instead of the no-corpus fallback.
- Two existing assertions changed sides. `tests/mcp/tools_test.go` asserted `sessions.active >= 1` in two places; one helper now asserts absence and pins #850 at the tool layer. The `internal/mcp` output-schema fixture drops its `sessions` sample.
- No documentation change: `README.md` and `docs/` never described the field.
- `coderabbit review --committed --base main` ran and returned one minor finding: gate the two TCP transport tests behind `RUN_INTEGRATION_TESTS`. **Not applied, on purpose.** The existing `tests/conformance` suite already calls the same `newServer` helper from 53 call sites, every one of which binds a loopback port, and not one is gated. In this repo `RUN_INTEGRATION_TESTS` gates tests that need an external service or spawn a daemon, not loopback listeners. Gating these would make a CI anti-drift guard that never runs in CI. A second and third CodeRabbit pass returned no findings.
- `make check` passes, gocyclo `-over 15` included.

Closes #850
