### PR TITLE
fix(retrieval): make rag.k_default and rag.generate_answer do what they say (#654)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,33 @@ strategy selector. The key is now unrecognized, so a config that still carries i
 with the warning above and no longer publishes the key back into the saved config or the
 effective snapshot.
 
+#### Retrieval answer keys
+
+```yaml
+rag:
+  generate_answer: true   # false serves every ask as search-only
+  k_default: 15           # hits for a request that sends no k (1..50)
+```
+
+`rag.k_default` sets how many hits a request that omits `k` gets. It applies to every
+tool that takes a `k`: `search`, `ask`, `related`, `ask_audio` and `transcribe_and_ask`,
+plus the `ask` and `search` CLI commands. Precedence is fixed: the `k` on the request,
+then `rag.k_default`, then the shipped default of 15.
+
+The value carries the same `1..50` bound as the request field. A value outside it fails
+at startup with `CONFIG_INVALID`, because a default that asks for a `k` the tools forbid
+would otherwise only fail later, on a request the operator never wrote.
+
+The served tool schemas advertise the **effective** value. `tools/list` reports
+`"default": <your k_default>` for `k`, so a client that reads the schema and sends the
+advertised number explicitly gets the same result as a client that omits the field.
+
+`rag.generate_answer: false` turns answer generation off for the whole server. Every
+`ask`, `ask_audio` and `transcribe_and_ask` request then behaves as `mode=search_only`:
+the response shape is unchanged, `answer` is `""`, `citations` is `[]`, and the retrieval
+hits are still returned. No chat provider is called. A request cannot switch generation
+back on, so `mode=answer` is served as search-only rather than refused.
+
 ### Environment variables (overrides / secrets)
 
 Sensitive keys and temporary runtime overrides are supplied via environment variables. They take

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -258,7 +258,11 @@ func (o *optionalBoolFlag) IsBoolFlag() bool {
 }
 
 type askOptions struct {
-	question   string
+	question string
+	// k is the requested number of hits, or 0 when the caller supplied none.
+	// 0 means "resolve it against rag.k_default" (SPEC §9.1): the local path
+	// reads the corpus config, and the remote path OMITS k from the tool
+	// arguments so the daemon that owns the configuration resolves it.
 	k          int
 	mode       string
 	index      string
@@ -937,6 +941,9 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
+	// The local ask path reads the same rag.k_default the served tools do
+	// (SPEC §9.1), so one corpus answers with one default k on both surfaces.
+	ret.SetDefaultK(cfg.EffectiveKDefault())
 	a.configureReranker(ret, cfg)
 	ret.SetMinScore(cfg.RetrievalMinScore)
 	ret.SetRecencyHalfLife(cfg.RetrievalRecencyHalfLife)
@@ -992,7 +999,6 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 // applying defaults and validating k, mode, index, and the doc-types filter.
 func parseAskOptions(args []string) (askOptions, error) {
 	opts := askOptions{
-		k:     mcp.DefaultSearchK,
 		mode:  "answer",
 		index: "auto",
 	}
@@ -1004,7 +1010,7 @@ func parseAskOptions(args []string) (askOptions, error) {
 		&opts.k,
 		"k",
 		opts.k,
-		fmt.Sprintf("number of results (<=0 defaults to %d, max %d)", mcp.DefaultSearchK, mcp.MaxSearchK),
+		fmt.Sprintf("number of results (<=0 uses the configured rag.k_default, currently %d by default; max %d)", mcp.DefaultSearchK, mcp.MaxSearchK),
 	)
 	fs.StringVar(&opts.mode, "mode", opts.mode, "answer|search_only")
 	fs.StringVar(&opts.index, "index", opts.index, "auto|text|code|both")
@@ -1019,8 +1025,12 @@ func parseAskOptions(args []string) (askOptions, error) {
 	if opts.question == "" {
 		return askOptions{}, errors.New("ask command requires a question argument")
 	}
-	if opts.k <= 0 {
-		opts.k = mcp.DefaultSearchK
+	// <=0 keeps the historical "I did not choose a k" meaning, but the number it
+	// resolves to is now the corpus's rag.k_default rather than a constant baked
+	// into the client (SPEC §9.1). Both forms normalize to 0, the value the ask
+	// and search paths read as "unset".
+	if opts.k < 0 {
+		opts.k = 0
 	}
 	if opts.k > mcp.MaxSearchK {
 		return askOptions{}, fmt.Errorf("k must be <= %d", mcp.MaxSearchK)

--- a/internal/cli/ask.go
+++ b/internal/cli/ask.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/provider"
 )
@@ -48,27 +49,7 @@ func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOpt
 	// SPEC 8.1.3 preflight: an embed provider must resolve (generalized
 	// from the legacy MISTRAL_API_KEY-specific check; mirrors `up`).
 	if _, embErr := cfg.Providers().Resolve(provider.CapEmbed); embErr != nil {
-		msg := "CONFIG_INVALID: no embedding provider configured"
-		hint := "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
-		var ce *provider.ConfigError
-		if errors.As(embErr, &ce) {
-			msg = ce.Error()
-		}
-		if global.jsonOutput {
-			writeCLIError(a.stderr, true, exitConfigInvalid, msg, hint, "Or run: dir2mcp config init")
-			return exitConfigInvalid
-		}
-		se := a.sty(global.jsonOutput)
-		nonInteractiveMode := global.nonInteractive || !isTerminal(os.Stdin) || !isTerminal(os.Stdout)
-		if nonInteractiveMode {
-			writef(a.stderr, "%s %s\n", se.errPrefix(), msg)
-			writeln(a.stderr, hint)
-			writeln(a.stderr, "Or run: dir2mcp config init")
-		} else {
-			writef(a.stderr, "%s %s\n", se.errPrefix(), strings.TrimPrefix(msg, "CONFIG_INVALID: "))
-			writeln(a.stderr, "Run: dir2mcp config init")
-		}
-		return exitConfigInvalid
+		return a.reportMissingEmbedProvider(global, embErr)
 	}
 	st := a.storeForConfig(cfg)
 	defer func() { _ = st.Close() }()
@@ -88,14 +69,18 @@ func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOpt
 
 	query := model.SearchQuery{
 		Query:      opts.question,
-		K:          opts.k,
+		K:          resolveAskK(cfg, opts.k),
 		Index:      opts.index,
 		PathPrefix: opts.pathPrefix,
 		FileGlob:   opts.fileGlob,
 		DocTypes:   opts.docTypes,
 	}
 
-	if opts.mode == "search_only" {
+	// Either condition withholds generation (SPEC §9.4): the request's own
+	// mode, or the operator's rag.generate_answer. A request cannot turn
+	// generation back on, so `--mode answer` on a corpus with generation off
+	// returns the same hits with an empty answer instead of failing.
+	if opts.mode == "search_only" || !cfg.RAGGenerateAnswer {
 		return a.runAskSearchOnly(ctx, global, opts.question, retriever, query)
 	}
 
@@ -105,6 +90,45 @@ func (a *App) runAskLocal(ctx context.Context, global globalOptions, opts askOpt
 		return exitGeneric
 	}
 	return a.renderAskResult(global, askResult)
+}
+
+// reportMissingEmbedProvider writes the "no embedding provider" preflight
+// failure in the shape the caller's output mode expects, and returns the exit
+// code. It is split out of runAskLocal so that function stays inside the
+// cyclomatic-complexity gate; the text and the exit code are unchanged.
+func (a *App) reportMissingEmbedProvider(global globalOptions, embErr error) int {
+	msg := "CONFIG_INVALID: no embedding provider configured"
+	hint := "Set a provider credential (e.g. MISTRAL_API_KEY / OPENAI_API_KEY) or configure providers: in .dir2mcp.yaml"
+	var ce *provider.ConfigError
+	if errors.As(embErr, &ce) {
+		msg = ce.Error()
+	}
+	if global.jsonOutput {
+		writeCLIError(a.stderr, true, exitConfigInvalid, msg, hint, "Or run: dir2mcp config init")
+		return exitConfigInvalid
+	}
+	se := a.sty(global.jsonOutput)
+	nonInteractiveMode := global.nonInteractive || !isTerminal(os.Stdin) || !isTerminal(os.Stdout)
+	if nonInteractiveMode {
+		writef(a.stderr, "%s %s\n", se.errPrefix(), msg)
+		writeln(a.stderr, hint)
+		writeln(a.stderr, "Or run: dir2mcp config init")
+	} else {
+		writef(a.stderr, "%s %s\n", se.errPrefix(), strings.TrimPrefix(msg, "CONFIG_INVALID: "))
+		writeln(a.stderr, "Run: dir2mcp config init")
+	}
+	return exitConfigInvalid
+}
+
+// resolveAskK resolves the number of hits a LOCAL ask/search runs with (SPEC
+// §9.1): the -k flag when the caller supplied one, else the corpus's configured
+// rag.k_default. The remote path does not use it: it omits k from the tool
+// arguments so the daemon resolves the default against ITS configuration.
+func resolveAskK(cfg config.Config, k int) int {
+	if k > 0 {
+		return k
+	}
+	return cfg.EffectiveKDefault()
 }
 
 func (a *App) runAskSearchOnly(ctx context.Context, global globalOptions, question string, retriever model.Retriever, query model.SearchQuery) int {

--- a/internal/cli/remote_commands.go
+++ b/internal/cli/remote_commands.go
@@ -341,14 +341,15 @@ func (a *App) runSearchRemote(ctx context.Context, global globalOptions, args []
 		return exitGeneric
 	}
 
-	payload, err := client.CallTool(ctx, protocol.ToolNameSearch, map[string]interface{}{
+	toolArgs := map[string]interface{}{
 		"query":       opts.question,
-		"k":           opts.k,
 		"index":       opts.index,
 		"path_prefix": opts.pathPrefix,
 		"file_glob":   opts.fileGlob,
 		"doc_types":   opts.docTypes,
-	})
+	}
+	withRemoteK(toolArgs, opts.k)
+	payload, err := client.CallTool(ctx, protocol.ToolNameSearch, toolArgs)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("search failed: %v", err))
 		return exitGeneric
@@ -360,16 +361,27 @@ func (a *App) runSearchRemote(ctx context.Context, global globalOptions, args []
 	return exitSuccess
 }
 
+// withRemoteK adds the k argument to a remote tool call, and adds NOTHING when
+// the caller supplied no k. An omitted field is what makes the daemon resolve
+// its own rag.k_default (SPEC §9.1); sending a client-side constant instead
+// would override the server's configured default on every call.
+func withRemoteK(args map[string]interface{}, k int) {
+	if k > 0 {
+		args["k"] = k
+	}
+}
+
 func (a *App) runAskRemote(ctx context.Context, global globalOptions, opts askOptions, client *remoteMCPClient) int {
-	payload, err := client.CallTool(ctx, protocol.ToolNameAsk, map[string]interface{}{
+	args := map[string]interface{}{
 		"question":    opts.question,
 		"mode":        opts.mode,
-		"k":           opts.k,
 		"index":       opts.index,
 		"path_prefix": opts.pathPrefix,
 		"file_glob":   opts.fileGlob,
 		"doc_types":   opts.docTypes,
-	})
+	}
+	withRemoteK(args, opts.k)
+	payload, err := client.CallTool(ctx, protocol.ToolNameAsk, args)
 	if err != nil {
 		writeCLIError(a.stderr, global.jsonOutput, exitGeneric, fmt.Sprintf("ask failed: %v", err))
 		return exitGeneric

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -103,6 +103,9 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
 	ret.SetOversampleFactor(cfg.RAGOversampleFactor)
+	// One effective rag.k_default for the whole deployment (SPEC §9.1): the tool
+	// layer resolves an omitted k to the same number this service falls back to.
+	ret.SetDefaultK(cfg.EffectiveKDefault())
 	a.configureReranker(ret, cfg)
 	ret.SetCrossFileDedupEnabled(cfg.DedupRetrieval)
 	ret.SetMinScore(cfg.RetrievalMinScore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,28 @@ const (
 // evidence threshold in internal/retrieval/evidence.go. `0` disables the floor.
 const defaultRetrievalMinScore = 0.05
 
+// RAGKMin, RAGKMax and RAGKFallback resolve the number of hits a retrieval
+// request asks for (SPEC §9.1).
+//
+// RAGKMin/RAGKMax are the inclusive bound the `k` request field advertises on
+// every tool that takes one, and `rag.k_default` MUST satisfy the SAME bound: a
+// default that asks for a k the schema forbids can only fail later, at a request
+// the operator did not write, so a configured value outside it is CONFIG_INVALID
+// at load.
+//
+// RAGKFallback is the shipped fallback, used when the operator configured no
+// `rag.k_default`. Default() ships it, so the config template, the served schema
+// and the runtime all state the same number.
+//
+// They live here, not in internal/mcp, because config validation needs the bound
+// and internal/mcp imports this package (mcp.MinSearchK/MaxSearchK/DefaultSearchK
+// alias them, so there is still one definition).
+const (
+	RAGKMin      = 1
+	RAGKMax      = 50
+	RAGKFallback = 15
+)
+
 // DefaultMediaSubtitlesAlignToleranceMS is the bilingual cross-language cue
 // alignment tolerance (SPEC §8.6.10, media.subtitles.ttml.align_tolerance_ms):
 // a secondary segment whose start is within this many milliseconds of a primary
@@ -257,8 +279,19 @@ type Config struct {
 	// field is intentionally not persisted to disk.
 	Warnings []error
 
-	RAGSystemPrompt     string
-	RAGGenerateAnswer   bool
+	RAGSystemPrompt string
+	// RAGGenerateAnswer is `rag.generate_answer` (SPEC §16). false withholds
+	// answer generation on every ask-family surface: the server returns the
+	// retrieval hits with `answer: ""` and `citations: []`, the same shape
+	// `mode=search_only` returns (SPEC §9.4). The setting and the request field
+	// form a disjunction, so a request cannot turn generation back on, and
+	// `mode=answer` against false is SERVED as search_only rather than refused.
+	RAGGenerateAnswer bool
+	// RAGKDefault is `rag.k_default` (SPEC §16): the number of hits a request
+	// that OMITS `k` resolves to. It MUST satisfy the same RAGKMin..RAGKMax
+	// bound the request field does; a configured value outside it is
+	// CONFIG_INVALID at load. Read it through EffectiveKDefault, which applies
+	// the shipped fallback for a Config that never went through Default().
 	RAGKDefault         int
 	RAGMaxContextChars  int
 	RAGOversampleFactor int
@@ -1538,7 +1571,7 @@ func Default() Config {
 		},
 		RAGSystemPrompt:        "",
 		RAGGenerateAnswer:      true,
-		RAGKDefault:            10,
+		RAGKDefault:            RAGKFallback,
 		RAGMaxContextChars:     20000,
 		RAGOversampleFactor:    5,
 		RetrievalHybridEnabled: true,
@@ -1562,7 +1595,7 @@ func Default() Config {
 		RetrievalAdaptiveEnabled: false,
 		// RetrievalAdaptiveKMin / RetrievalAdaptiveKMax bound the dynamic k the
 		// gate may choose. These defaults give the heuristic room to narrow easy
-		// queries and widen hard ones around the typical rag.k_default (10).
+		// queries and widen hard ones around the shipped rag.k_default (15).
 		RetrievalAdaptiveKMin: 4,
 		RetrievalAdaptiveKMax: 30,
 		// MMR diversity re-ordering defaults to OFF (issue #340): candidate order
@@ -4595,6 +4628,26 @@ func applyX402RouteEnvOverrides(cfg *Config, env map[string]string) {
 	}
 }
 
+// EffectiveKDefault returns the number of hits a request that OMITS `k`
+// resolves to (SPEC §9.1, step 2 then step 3): `rag.k_default` when it is
+// configured and in bound, and the shipped RAGKFallback otherwise.
+//
+// Every surface that takes a `k` reads it through this one method: the tool
+// handlers, the `default` the served tool schemas advertise, the retrieval
+// service and the CLI. One corpus therefore has ONE default, and the value a
+// client reads from the schema is the value an omitted field produces.
+//
+// Validate rejects an out-of-bound configured value, so the fallback branch is
+// reached only by a Config that never went through Default()/Load (a test or an
+// embedder constructing a Config literal). It resolves such a Config to the
+// shipped default rather than to 0, which would retrieve nothing.
+func (c Config) EffectiveKDefault() int {
+	if c.RAGKDefault >= RAGKMin && c.RAGKDefault <= RAGKMax {
+		return c.RAGKDefault
+	}
+	return RAGKFallback
+}
+
 // Validate checks configuration consistency and applies normalization
 // or defaults.  It currently enforces rules around session durations:
 //
@@ -5207,14 +5260,8 @@ func (c *Config) validateNumericBounds() error {
 	if err := c.validateMediaSTTNumericBounds(); err != nil {
 		return err
 	}
-	if c.RAGMaxContextChars < 0 {
-		return fmt.Errorf("rag.max_context_chars must be non-negative: %d", c.RAGMaxContextChars)
-	}
-	if c.RAGKDefault < 0 {
-		return fmt.Errorf("rag.k_default must be non-negative: %d", c.RAGKDefault)
-	}
-	if c.RAGOversampleFactor < 0 {
-		return fmt.Errorf("rag.oversample_factor must be non-negative: %d", c.RAGOversampleFactor)
+	if err := c.validateRAGNumericBounds(); err != nil {
+		return err
 	}
 	if c.ChunkingMaxTokens < 0 {
 		return fmt.Errorf("chunking.max_tokens must be non-negative: %d", c.ChunkingMaxTokens)
@@ -5234,6 +5281,24 @@ func (c *Config) validateNumericBounds() error {
 	}
 	if err := c.validateRetrievalNumericBounds(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateRAGNumericBounds validates the rag.* numeric knobs.
+func (c *Config) validateRAGNumericBounds() error {
+	if c.RAGMaxContextChars < 0 {
+		return fmt.Errorf("rag.max_context_chars must be non-negative: %d", c.RAGMaxContextChars)
+	}
+	// rag.k_default carries the same bound as the `k` request field (SPEC 9.1),
+	// and it fails HERE rather than at a later request: an operator who asks for
+	// a k the tool schemas forbid must learn it at load, not from a request they
+	// did not write.
+	if c.RAGKDefault < RAGKMin || c.RAGKDefault > RAGKMax {
+		return fmt.Errorf("rag.k_default must be between %d and %d: %d", RAGKMin, RAGKMax, c.RAGKDefault)
+	}
+	if c.RAGOversampleFactor < 0 {
+		return fmt.Errorf("rag.oversample_factor must be non-negative: %d", c.RAGOversampleFactor)
 	}
 	return nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -51,18 +51,41 @@ const (
 	paymentOutcomeMaxEntries      = 5000
 )
 
-// DefaultSearchK is the k a tools/call uses when the arguments OMIT k. A
-// supplied k is never replaced by it: an out-of-bound value is INVALID_RANGE
+// DefaultSearchK is the SHIPPED fallback k, used when the arguments omit k and
+// the operator configured no rag.k_default (SPEC §9.1, step 3). A deployment
+// that configures rag.k_default resolves an omitted k to THAT value instead;
+// read the resolved number with Server.effectiveK, never this constant. A
+// supplied k is never replaced by either: an out-of-bound value is INVALID_RANGE
 // (see parseKArg, issue #648).
-const DefaultSearchK = 15
+const DefaultSearchK = config.RAGKFallback
 
 // MinSearchK and MaxSearchK are the inclusive bounds the advertised input
 // schemas publish for k (SPEC §15.2/§15.3, canonical search.json/ask.json:
-// "minimum": 1, "maximum": 50). A supplied k outside them is INVALID_RANGE.
+// "minimum": 1, "maximum": 50). A supplied k outside them is INVALID_RANGE, and
+// rag.k_default carries the same bound at load (SPEC §9.1).
 const (
-	MinSearchK = 1
-	MaxSearchK = 50
+	MinSearchK = config.RAGKMin
+	MaxSearchK = config.RAGKMax
 )
+
+// effectiveK is the k this deployment resolves an OMITTED k to: rag.k_default
+// when the operator set one, else the shipped fallback (SPEC §9.1). Every k
+// surface reads it here: the shared argument parser, and the `default` the
+// served input schemas advertise. The advertised default is therefore, by
+// construction, the value an omitted field produces.
+func (s *Server) effectiveK() int {
+	return s.cfg.EffectiveKDefault()
+}
+
+// generatesAnswers reports whether this deployment generates answers at all
+// (`rag.generate_answer`, SPEC §16). false is equivalent to `mode=search_only`
+// on every ask-family request: hits are returned with an empty answer and empty
+// citations, no prompt is assembled and no chat provider is called (SPEC §9.4).
+// The condition is a disjunction with the request's own mode, so a request
+// cannot turn generation back on against the operator's setting.
+func (s *Server) generatesAnswers() bool {
+	return s.cfg.RAGGenerateAnswer
+}
 
 // sessionInfo holds metadata tracked for each active session.  `created` is the
 // time the session was started; `lastSeen` is updated on each successful

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -129,28 +129,28 @@ func (s *Server) buildToolRegistry() map[string]toolDefinition {
 		protocol.ToolNameSearch: {
 			Name:         protocol.ToolNameSearch,
 			Description:  "Semantic retrieval across indexed content.",
-			InputSchema:  searchInputSchema(),
+			InputSchema:  searchInputSchema(s.effectiveK()),
 			OutputSchema: searchOutputSchema(),
 			handler:      s.handleSearchTool,
 		},
 		protocol.ToolNameRelated: {
 			Name:         protocol.ToolNameRelated,
 			Description:  "Nearest-neighbour segments for a given chunk or document ('more like this').",
-			InputSchema:  relatedInputSchema(),
+			InputSchema:  relatedInputSchema(s.effectiveK()),
 			OutputSchema: relatedOutputSchema(),
 			handler:      s.handleRelatedTool,
 		},
 		protocol.ToolNameAsk: {
 			Name:         protocol.ToolNameAsk,
 			Description:  "RAG answer with citations; can run search-only mode.",
-			InputSchema:  askInputSchema(),
+			InputSchema:  askInputSchema(s.effectiveK()),
 			OutputSchema: askOutputSchema(),
 			handler:      s.handleAskTool,
 		},
 		protocol.ToolNameAskAudio: {
 			Name:         protocol.ToolNameAskAudio,
 			Description:  "RAG answer with optional ElevenLabs audio synthesis.",
-			InputSchema:  askAudioInputSchema(),
+			InputSchema:  askAudioInputSchema(s.effectiveK()),
 			OutputSchema: askAudioOutputSchema(),
 			handler:      s.handleAskAudioTool,
 		},
@@ -171,7 +171,7 @@ func (s *Server) buildToolRegistry() map[string]toolDefinition {
 		protocol.ToolNameTranscribeAndAsk: {
 			Name:         protocol.ToolNameTranscribeAndAsk,
 			Description:  "Ensure transcript exists for audio file, then answer a question with citations.",
-			InputSchema:  transcribeAndAskInputSchema(),
+			InputSchema:  transcribeAndAskInputSchema(s.effectiveK()),
 			OutputSchema: transcribeAndAskOutputSchema(),
 			handler:      s.handleTranscribeAndAskTool,
 		},
@@ -1055,7 +1055,7 @@ func (s *Server) handleSearchTool(ctx context.Context, args map[string]interface
 	if !ok {
 		return toolCallResult{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "query is required", Retryable: false}
 	}
-	k, toolErr := parseKArg(args)
+	k, toolErr := parseKArg(args, s.effectiveK())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1158,7 +1158,7 @@ func normalizeIndexAxis(axis string) string {
 // nearest-neighbour retrieval. Exactly one of chunk_id / rel_path identifies the
 // seed; the same §9.5/§9.6 filters as dir2mcp_search narrow the neighbours.
 func (s *Server) handleRelatedTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
-	rq, toolErr := parseRelatedArgs(args)
+	rq, toolErr := parseRelatedArgs(args, s.effectiveK())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1192,8 +1192,9 @@ func (s *Server) handleRelatedTool(ctx context.Context, args map[string]interfac
 // parseRelatedArgs validates and projects the dir2mcp_related arguments into a
 // model.RelatedQuery. It enforces the chunk_id/rel_path oneOf and reuses the
 // shared k/index/filter/date parsers so dir2mcp_related and dir2mcp_search stay
-// in lockstep on those semantics.
-func parseRelatedArgs(args map[string]interface{}) (model.RelatedQuery, *toolExecutionError) {
+// in lockstep on those semantics. defaultK is the deployment's effective default
+// k (Server.effectiveK); related is one of the five tools rag.k_default covers.
+func parseRelatedArgs(args map[string]interface{}, defaultK int) (model.RelatedQuery, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, map[string]struct{}{
 		"chunk_id": {}, "rel_path": {}, "k": {}, "index": {}, "exclude_same_document": {},
 		"path_prefix": {}, "file_glob": {}, "doc_types": {}, "languages": {}, "date_from": {}, "date_to": {},
@@ -1215,7 +1216,7 @@ func parseRelatedArgs(args map[string]interface{}) (model.RelatedQuery, *toolExe
 	if chunkPresent && chunkID < 1 {
 		return model.RelatedQuery{}, &toolExecutionError{Code: "INVALID_FIELD", Message: "chunk_id must be >= 1", Retryable: false}
 	}
-	k, toolErr := parseKArg(args)
+	k, toolErr := parseKArg(args, defaultK)
 	if toolErr != nil {
 		return model.RelatedQuery{}, toolErr
 	}
@@ -1326,8 +1327,9 @@ type askRequest struct {
 //
 // Both ask-family tools funnel through here, so a filter cannot be advertised on
 // one and rejected on the other, and a filter cannot be accepted yet dropped
-// before it reaches retrieval.
-func parseAskArgs(args map[string]interface{}, allowed map[string]struct{}) (askRequest, *toolExecutionError) {
+// before it reaches retrieval. defaultK is the deployment's effective default k
+// (Server.effectiveK), applied when the request omits the field.
+func parseAskArgs(args map[string]interface{}, allowed map[string]struct{}, defaultK int) (askRequest, *toolExecutionError) {
 	if err := assertNoUnknownArguments(args, allowed); err != nil {
 		return askRequest{}, &toolExecutionError{Code: "INVALID_FIELD", Message: err.Error(), Retryable: false}
 	}
@@ -1338,7 +1340,7 @@ func parseAskArgs(args map[string]interface{}, allowed map[string]struct{}) (ask
 	if !ok {
 		return askRequest{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "question is required", Retryable: false}
 	}
-	k, toolErr := parseKArg(args)
+	k, toolErr := parseKArg(args, defaultK)
 	if toolErr != nil {
 		return askRequest{}, toolErr
 	}
@@ -1382,14 +1384,14 @@ func parseAskArgs(args map[string]interface{}, allowed map[string]struct{}) (ask
 }
 
 func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
-	req, toolErr := parseAskArgs(args, askFamilyArguments())
+	req, toolErr := parseAskArgs(args, askFamilyArguments(), s.effectiveK())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	if req.mode == "search_only" {
+	if s.withholdsAnswer(req.mode) {
 		return s.runSearchOnlyMode(ctx, req.question, req.query)
 	}
 	askResult, askErr := s.retriever.Ask(ctx, req.question, req.query)
@@ -1403,7 +1405,7 @@ func (s *Server) handleAskTool(ctx context.Context, args map[string]interface{})
 }
 
 func (s *Server) handleAskAudioTool(ctx context.Context, args map[string]interface{}) (toolCallResult, *toolExecutionError) {
-	req, toolErr := parseAskArgs(args, askFamilyArguments("voice_id"))
+	req, toolErr := parseAskArgs(args, askFamilyArguments("voice_id"), s.effectiveK())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1414,10 +1416,22 @@ func (s *Server) handleAskAudioTool(ctx context.Context, args map[string]interfa
 	if s.retriever == nil {
 		return toolCallResult{}, &toolExecutionError{Code: protocol.ErrorCodeIndexNotReady, Message: "retriever not configured", Retryable: false}
 	}
-	if req.mode == "search_only" {
+	if s.withholdsAnswer(req.mode) {
 		return s.runSearchOnlyMode(ctx, req.question, req.query)
 	}
 	return s.runAskAudioAnswer(ctx, req.question, voiceID, req.query)
+}
+
+// withholdsAnswer reports whether this request returns hits without an answer.
+// SPEC §9.4 states the condition as a disjunction: EITHER the server disabled
+// generation (`rag.generate_answer: false`) OR the request asked for
+// `mode=search_only`. Either one is sufficient, so `mode=answer` against a
+// server with generation off is SERVED as search_only rather than refused: the
+// response shape is identical, and a refusal would leave the caller no way to
+// use the corpus at all. A request therefore cannot turn generation back on
+// against the operator's decision about provider cost and data flow.
+func (s *Server) withholdsAnswer(mode string) bool {
+	return mode == "search_only" || !s.generatesAnswers()
 }
 
 func (s *Server) runAskAudioAnswer(ctx context.Context, question, voiceID string, sq model.SearchQuery) (toolCallResult, *toolExecutionError) {
@@ -1779,7 +1793,7 @@ func (s *Server) handleTranscribeAndAskTool(ctx context.Context, args map[string
 	if !ok {
 		return toolCallResult{}, &toolExecutionError{Code: "MISSING_FIELD", Message: "question is required", Retryable: false}
 	}
-	k, toolErr := parseKArg(args)
+	k, toolErr := parseKArg(args, s.effectiveK())
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
@@ -1794,27 +1808,49 @@ func (s *Server) handleTranscribeAndAskTool(ctx context.Context, args map[string
 	if toolErr != nil {
 		return toolCallResult{}, toolErr
 	}
-	askResult, askErr := s.retriever.Ask(ctx, question, model.SearchQuery{
+	query := model.SearchQuery{
 		Query: question, K: k, Index: "text", FileGlob: escapeGlobLiteral(relPath),
-	})
-	if askErr != nil {
-		return toolCallResult{}, mapSearchError(askErr)
+	}
+	result, toolErr := s.transcriptAnswer(ctx, question, query)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
 	}
 
 	sttProvider, sttModel := resolvedSTTProvenance(s.cfg)
-	structured := buildAskStructuredContent(askResult)
+	structured, ok := result.StructuredContent.(map[string]interface{})
+	if !ok {
+		structured = map[string]interface{}{}
+	}
 	structured["transcript_provider"] = sttProvider
 	structured["transcript_model"] = sttModel
 	structured["transcribed"] = strings.TrimSpace(transcriptText) != ""
 	structured["transcribed_now"] = transcribedNow
+	result.StructuredContent = structured
+	return result, nil
+}
 
+// transcriptAnswer runs the retrieval half of dir2mcp_transcribe_and_ask and
+// returns the answer payload, minus the transcript provenance the caller adds.
+//
+// `rag.generate_answer: false` withholds generation here exactly as it does on
+// dir2mcp_ask (SPEC §9.4): the tool returns the same shape with `answer: ""` and
+// `citations: []`, and no chat provider is called. The tool has no `mode`
+// argument, so the server setting is the only condition that applies.
+func (s *Server) transcriptAnswer(ctx context.Context, question string, query model.SearchQuery) (toolCallResult, *toolExecutionError) {
+	if !s.generatesAnswers() {
+		return s.runSearchOnlyMode(ctx, question, query)
+	}
+	askResult, askErr := s.retriever.Ask(ctx, question, query)
+	if askErr != nil {
+		return toolCallResult{}, mapSearchError(askErr)
+	}
 	answerText := strings.TrimSpace(askResult.Answer)
 	if answerText == "" {
 		answerText = "no answer text returned"
 	}
 	return toolCallResult{
 		Content:           []toolContentItem{{Type: "text", Text: answerText}},
-		StructuredContent: structured,
+		StructuredContent: buildAskStructuredContent(askResult),
 	}, nil
 }
 
@@ -2239,23 +2275,25 @@ func parseListFilesArgs(args map[string]interface{}) (pathPrefix, glob string, l
 // parseKArg resolves the shared k argument for search, ask, related, ask_audio
 // and transcribe_and_ask.
 //
-// An OMITTED k resolves to the shipped default (DefaultSearchK). A SUPPLIED k
-// must satisfy the bound the input schema advertises, 1..50 (SPEC §15.2/§15.3,
-// canonical search.json/ask.json), and anything outside it is INVALID_RANGE.
+// An OMITTED k resolves to defaultK, which callers take from Server.effectiveK:
+// `rag.k_default` when the operator set one, else the shipped fallback (SPEC
+// §9.1, issue #654). Every tool that takes a k funnels through here, so one
+// corpus cannot end up with a different default per tool.
 //
-// This distinction is the fix for issue #648: k=0 and k=-1 used to be replaced
+// A SUPPLIED k must satisfy the bound the input schema advertises, 1..50 (SPEC
+// §15.2/§15.3, canonical search.json/ask.json), and anything outside it is
+// INVALID_RANGE. The request field wins over the configured default, so a
+// supplied value is never replaced by defaultK.
+//
+// That distinction is the fix for issue #648: k=0 and k=-1 used to be replaced
 // by the default, so a caller that asked for a k the schema forbids got a
 // silent, different retrieval instead of the machine-parseable error every
 // other out-of-bound value produced. Absent and present-but-invalid are
 // different requests and answer differently now.
-//
-// Resolving an omitted k against `rag.k_default` is deliberately NOT done here:
-// that precedence is dirstral-spec PR #90 / dir2mcp #654 and it changes what the
-// served schema must advertise as well.
-func parseKArg(args map[string]interface{}) (int, *toolExecutionError) {
+func parseKArg(args map[string]interface{}, defaultK int) (int, *toolExecutionError) {
 	rawK, exists := args["k"]
 	if !exists {
-		return DefaultSearchK, nil
+		return defaultK, nil
 	}
 	k, parseErr := parseInteger(rawK, "k")
 	if parseErr != nil {
@@ -2576,11 +2614,29 @@ func mapOpenFileError(err error) *toolExecutionError {
 	}
 }
 
-// runSearchOnlyMode performs a search-only retrieval and formats the result.
+// runSearchOnlyMode performs a search-only retrieval and formats the result. It
+// serves both reasons an ask-family request generates no answer:
+// `mode=search_only` and `rag.generate_answer: false` (SPEC §9.4, withholdsAnswer).
 func (s *Server) runSearchOnlyMode(ctx context.Context, question string, sq model.SearchQuery) (toolCallResult, *toolExecutionError) {
+	structured, hits, toolErr := s.searchOnlyPayload(ctx, question, sq)
+	if toolErr != nil {
+		return toolCallResult{}, toolErr
+	}
+	return toolCallResult{
+		Content:           []toolContentItem{{Type: "text", Text: renderSearchHitsText(hits, "supporting result")}},
+		StructuredContent: structured,
+	}, nil
+}
+
+// searchOnlyPayload runs the retrieval half of an ask-family request and builds
+// the SPEC §9.4 no-answer payload. The response SHAPE is unchanged: ask.json
+// marks `answer` and `citations` required, so both are present and empty rather
+// than absent. It returns the hits as well, so a caller that adds its own fields
+// (transcribe_and_ask) renders the same hit text without searching twice.
+func (s *Server) searchOnlyPayload(ctx context.Context, question string, sq model.SearchQuery) (map[string]interface{}, []model.SearchHit, *toolExecutionError) {
 	hits, searchErr := s.retriever.Search(ctx, sq)
 	if searchErr != nil {
-		return toolCallResult{}, mapSearchError(searchErr)
+		return nil, nil, mapSearchError(searchErr)
 	}
 	hitMaps := make([]map[string]interface{}, 0, len(hits))
 	for _, h := range hits {
@@ -2597,10 +2653,7 @@ func (s *Server) runSearchOnlyMode(ctx context.Context, question string, sq mode
 		"hits":              hitMaps,
 		"indexing_complete": indexingComplete,
 	}
-	return toolCallResult{
-		Content:           []toolContentItem{{Type: "text", Text: renderSearchHitsText(hits, "supporting result")}},
-		StructuredContent: structured,
-	}, nil
+	return structured, hits, nil
 }
 
 // synthesizeAnswer runs TTS synthesis, selecting the voice-aware path when voiceID is non-empty.
@@ -3853,6 +3906,13 @@ func hitDefinitionSchema() map[string]interface{} {
 	}
 }
 
+// kPropertyDescription documents the shared k field on every tool that takes
+// one. The `default` next to it is this deployment's EFFECTIVE default: SPEC
+// §9.1 requires a served schema to advertise the value an omitted field
+// actually produces, so a client that reads the schema and sends the advertised
+// value explicitly gets the same k as a client that omits the field.
+const kPropertyDescription = "Number of hits to return. Bound 1..50 (a supplied value outside it is INVALID_RANGE). An OMITTED field resolves to this server's configured rag.k_default, which is the `default` advertised here (SPEC §9.1)."
+
 func sharedDefinitions() map[string]interface{} {
 	return map[string]interface{}{
 		"Span": spanDefinitionSchema(),
@@ -3860,13 +3920,13 @@ func sharedDefinitions() map[string]interface{} {
 	}
 }
 
-func searchInputSchema() map[string]interface{} {
+func searchInputSchema(defaultK int) map[string]interface{} {
 	return map[string]interface{}{
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"query":       map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": defaultK, "description": kPropertyDescription},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
 			"file_glob":   map[string]interface{}{"type": "string"},
@@ -3935,7 +3995,7 @@ func searchOutputSchema() map[string]interface{} {
 	}
 }
 
-func relatedInputSchema() map[string]interface{} {
+func relatedInputSchema(defaultK int) map[string]interface{} {
 	return map[string]interface{}{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -3955,7 +4015,7 @@ func relatedInputSchema() map[string]interface{} {
 				"minLength":   1,
 				"description": "The source document (corpus-relative, normalized '/'): neighbours are ranked against the document's own chunk vectors. Chunks belonging to this document are always excluded from hits.",
 			},
-			"k":     map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":     map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": defaultK, "description": kPropertyDescription},
 			"index": map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto", "description": "Which logical vector axis to search (SPEC §6.1). 'auto' matches the source segment's own index_kind."},
 			"exclude_same_document": map[string]interface{}{
 				"type":        "boolean",
@@ -3999,13 +4059,13 @@ func relatedOutputSchema() map[string]interface{} {
 	}
 }
 
-func askInputSchema() map[string]interface{} {
+func askInputSchema(defaultK int) map[string]interface{} {
 	return map[string]interface{}{
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"question":    map[string]interface{}{"type": "string", "minLength": 1},
-			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":           map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": defaultK, "description": kPropertyDescription},
 			"mode":        map[string]interface{}{"type": "string", "enum": []string{"answer", "search_only"}, "default": "answer"},
 			"index":       map[string]interface{}{"type": "string", "enum": []string{"auto", "text", "code", "both"}, "default": "auto"},
 			"path_prefix": map[string]interface{}{"type": "string"},
@@ -4084,11 +4144,11 @@ func askOutputSchema() map[string]interface{} {
 	}
 }
 
-func askAudioInputSchema() map[string]interface{} {
-	schema := askInputSchema()
+func askAudioInputSchema(defaultK int) map[string]interface{} {
+	schema := askInputSchema(defaultK)
 	properties, ok := schema["properties"].(map[string]interface{})
 	if !ok {
-		return askInputSchema()
+		return askInputSchema(defaultK)
 	}
 	properties["voice_id"] = map[string]interface{}{"type": "string", "minLength": 1}
 	return schema
@@ -4192,14 +4252,14 @@ func annotateOutputSchema() map[string]interface{} {
 	}
 }
 
-func transcribeAndAskInputSchema() map[string]interface{} {
+func transcribeAndAskInputSchema(defaultK int) map[string]interface{} {
 	return map[string]interface{}{
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]interface{}{
 			"rel_path": map[string]interface{}{"type": "string", "minLength": 1},
 			"question": map[string]interface{}{"type": "string", "minLength": 1},
-			"k":        map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": DefaultSearchK},
+			"k":        map[string]interface{}{"type": "integer", "minimum": MinSearchK, "maximum": MaxSearchK, "default": defaultK, "description": kPropertyDescription},
 		},
 		"required": []string{"rel_path", "question"},
 	}

--- a/internal/retrieval/related.go
+++ b/internal/retrieval/related.go
@@ -31,10 +31,7 @@ func (s *Service) Related(ctx context.Context, q model.RelatedQuery) (model.Rela
 	if !ok {
 		return model.RelatedResult{}, model.ErrRelatedNotSupported
 	}
-	k := q.K
-	if k <= 0 {
-		k = 15
-	}
+	k := s.effectiveK(q.K)
 	seed, err := s.resolveRelatedSource(ctx, cs, q)
 	if err != nil {
 		return model.RelatedResult{}, err

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/usage"
@@ -161,7 +162,11 @@ type Service struct {
 	overfetchMultiplier int
 	ragSystemPrompt     string
 	ragMaxContextChars  int
-	metaMu              sync.RWMutex
+	// defaultK is the number of hits a query that carries no k of its own
+	// resolves to: the operator's rag.k_default when SetDefaultK plumbed one,
+	// else the shipped fallback (SPEC §9.1, issue #654). Guarded by metaMu.
+	defaultK int
+	metaMu   sync.RWMutex
 	// chunkByLabel is the single in-memory chunk-metadata store keyed by chunk_id
 	// label. A chunk_id belongs to exactly one axis (text or code) in production,
 	// so the previous per-index split (chunkByIndex) held a redundant second copy
@@ -392,6 +397,7 @@ func NewService(store model.Store, index model.Index, embedder model.Embedder, g
 		overfetchMultiplier: defaultOverfetchMultiplier,
 		ragSystemPrompt:     defaultRAGSystemPrompt,
 		ragMaxContextChars:  defaultRAGMaxContext,
+		defaultK:            config.RAGKFallback,
 		chunkByLabel:        make(map[uint64]model.SearchHit),
 		tombstonedRelPaths:  make(map[string]struct{}),
 		rootDir:             ".",
@@ -1334,6 +1340,34 @@ func (s *Service) SetOversampleFactor(factor int) {
 	s.metaMu.Unlock()
 }
 
+// SetDefaultK sets the number of hits a query with no k of its own resolves to.
+// The engine wires it from config.EffectiveKDefault, so this service and the MCP
+// tool layer share ONE default (SPEC §9.1). A value outside the canonical
+// 1..50 bound keeps the shipped fallback; config validation rejects such a value
+// at load, so this only guards a caller that builds a Config by hand.
+func (s *Service) SetDefaultK(k int) {
+	if k < config.RAGKMin || k > config.RAGKMax {
+		k = config.RAGKFallback
+	}
+	s.metaMu.Lock()
+	s.defaultK = k
+	s.metaMu.Unlock()
+}
+
+// effectiveK resolves the k a query runs with: the query's own k when it set
+// one, else the configured default.
+func (s *Service) effectiveK(k int) int {
+	if k > 0 {
+		return k
+	}
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	if s.defaultK <= 0 {
+		return config.RAGKFallback
+	}
+	return s.defaultK
+}
+
 // SetOverfetchMultiplier changes the multiplier used when querying the
 // underlying vector index.  The service will ask for `k * multiplier`
 // neighbors for a request that originally asked for `k` hits.  Values
@@ -1361,10 +1395,7 @@ func (s *Service) Search(ctx context.Context, query model.SearchQuery) ([]model.
 }
 
 func (s *Service) search(ctx context.Context, query model.SearchQuery) ([]model.SearchHit, error) {
-	k := query.K
-	if k <= 0 {
-		k = 15
-	}
+	k := s.effectiveK(query.K)
 
 	// When recency decay is active it re-scores each hit by its source-document
 	// age and can reorder candidates — promoting a fresh, highly-relevant doc
@@ -1778,9 +1809,7 @@ func (s *Service) Ask(ctx context.Context, question string, query model.SearchQu
 	if strings.TrimSpace(query.Query) == "" {
 		query.Query = question
 	}
-	if query.K <= 0 {
-		query.K = 15
-	}
+	query.K = s.effectiveK(query.K)
 
 	// Install a per-query usage sink so embed/rerank/generate token usage and
 	// latency for this ask are accumulated and emitted as a single

--- a/tests/cli/ask_k_default_654_test.go
+++ b/tests/cli/ask_k_default_654_test.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/cli"
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// writeAskCorpusConfig writes a .dir2mcp.yaml carrying the given rag lines into
+// dir, so the local ask path loads a real corpus configuration.
+func writeAskCorpusConfig(t *testing.T, dir, ragLines string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".dir2mcp.yaml"), []byte(ragLines), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// TestAskLocal_OmittedKUsesConfiguredKDefault pins the CLI half of the SPEC §9.1
+// scope: rag.k_default applies to "any CLI surface over" the k-bearing tools.
+//
+// On main the ask command substituted a client-side constant for an omitted -k,
+// so the corpus's configured default never reached retrieval.
+func TestAskLocal_OmittedKUsesConfiguredKDefault(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+	const configuredK = 23
+
+	tmp := t.TempDir()
+	writeAskCorpusConfig(t, tmp, "rag_k_default: 23\n")
+
+	stub := &commandTestRetrieverStub{askResult: model.AskResult{Question: "q", Answer: "a"}}
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore:     func(config.Config) model.Store { return &commandTestNoopStore{} },
+		NewRetriever: func(config.Config, model.Store) model.Retriever { return stub },
+	})
+
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(), []string{"ask", "q"}); code != 0 {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if !stub.askCalled {
+		t.Fatal("expected Ask to be called")
+	}
+	if stub.lastAskQuery.K != configuredK {
+		t.Fatalf("k=%d want the configured rag.k_default=%d", stub.lastAskQuery.K, configuredK)
+	}
+}
+
+// TestAskLocal_SuppliedKWinsOverConfiguredKDefault keeps step 1 of the
+// precedence intact on the CLI: an explicit -k is the caller's request and the
+// configured default must not replace it.
+func TestAskLocal_SuppliedKWinsOverConfiguredKDefault(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+
+	tmp := t.TempDir()
+	writeAskCorpusConfig(t, tmp, "rag_k_default: 23\n")
+
+	stub := &commandTestRetrieverStub{askResult: model.AskResult{Question: "q", Answer: "a"}}
+	var stdout, stderr bytes.Buffer
+	app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+		NewStore:     func(config.Config) model.Store { return &commandTestNoopStore{} },
+		NewRetriever: func(config.Config, model.Store) model.Retriever { return stub },
+	})
+
+	withWorkingDir(t, tmp, func() {
+		if code := app.RunWithContext(context.Background(), []string{"ask", "--k", "4", "q"}); code != 0 {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+	if stub.lastAskQuery.K != 4 {
+		t.Fatalf("k=%d want the supplied 4", stub.lastAskQuery.K)
+	}
+}
+
+// TestAskLocal_GenerateAnswerFalseIsServedAsSearchOnly pins SPEC §9.4 on the CLI:
+// `rag.generate_answer: false` withholds generation whatever the request asks,
+// so `--mode answer` returns the hits with an empty answer instead of calling a
+// chat provider.
+func TestAskLocal_GenerateAnswerFalseIsServedAsSearchOnly(t *testing.T) {
+	t.Setenv("MISTRAL_API_KEY", "test-key")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "mode omitted", args: []string{"ask", "--json", "q"}},
+		{name: "mode=answer", args: []string{"ask", "--json", "--mode", "answer", "q"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			writeAskCorpusConfig(t, tmp, "rag_generate_answer: false\n")
+
+			stub := &commandTestRetrieverStub{
+				askResult:  model.AskResult{Question: "q", Answer: "generated answer"},
+				searchHits: []model.SearchHit{{ChunkID: 1, RelPath: "a.md", Snippet: "alpha"}},
+			}
+			var stdout, stderr bytes.Buffer
+			app := cli.NewAppWithIOAndHooks(&stdout, &stderr, cli.RuntimeHooks{
+				NewStore:     func(config.Config) model.Store { return &commandTestNoopStore{} },
+				NewRetriever: func(config.Config, model.Store) model.Retriever { return stub },
+			})
+
+			withWorkingDir(t, tmp, func() {
+				if code := app.RunWithContext(context.Background(), tc.args); code != 0 {
+					t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+				}
+			})
+			if stub.askCalled {
+				t.Fatal("Ask ran with rag.generate_answer: false")
+			}
+			if !stub.searchCalled {
+				t.Fatal("retrieval did not run: generation is disabled, search is not")
+			}
+			out := stdout.String()
+			if !strings.Contains(out, `"answer":""`) {
+				t.Fatalf("expected an empty answer in the payload, got: %s", out)
+			}
+			if !strings.Contains(out, `"rel_path":"a.md"`) {
+				t.Fatalf("expected the hits in the payload, got: %s", out)
+			}
+		})
+	}
+}

--- a/tests/config/config_test.go
+++ b/tests/config/config_test.go
@@ -763,9 +763,12 @@ func TestLoad_RejectsNegativeRAGAndChunkingTunables(t *testing.T) {
 		want string
 	}{
 		{
+			// rag.k_default carries the same 1..50 bound as the k request field
+			// (SPEC §9.1), so a negative value is out of bound, not merely
+			// negative. See k_default_654_test.go for the full bound.
 			name: "negative rag k default",
 			yaml: "rag_k_default: -1\n",
-			want: "rag.k_default must be non-negative",
+			want: "rag.k_default must be between 1 and 50",
 		},
 		{
 			name: "negative chunking max tokens",

--- a/tests/config/k_default_654_test.go
+++ b/tests/config/k_default_654_test.go
@@ -1,0 +1,85 @@
+package tests
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// TestKDefault_OutOfBoundIsRejectedAtLoad pins the SPEC §9.1 bound: rag.k_default
+// MUST satisfy the same 1..50 bound the k request field does, and a configured
+// value outside it is CONFIG_INVALID AT LOAD.
+//
+// The failure has to happen here. A default that asks for a k the tool schemas
+// forbid can otherwise only fail later, at a request the operator did not write,
+// which is the worst place to discover it.
+//
+// On main the check was `k_default >= 0`, so 0 and 99 both loaded happily.
+func TestKDefault_OutOfBoundIsRejectedAtLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	for _, k := range []int{-1, 0, 51, 1000} {
+		t.Run(fmt.Sprintf("k=%d", k), func(t *testing.T) {
+			writeFile(t, path, fmt.Sprintf("rag_k_default: %d\n", k))
+			_, err := config.LoadFile(path)
+			if err == nil {
+				t.Fatalf("rag.k_default: %d loaded without error", k)
+			}
+			want := fmt.Sprintf("rag.k_default must be between %d and %d", config.RAGKMin, config.RAGKMax)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error=%v want substring %q", err, want)
+			}
+		})
+	}
+}
+
+// TestKDefault_InBoundLoads is the converse: every value the k request field
+// accepts is a legal rag.k_default, including both ends of the bound.
+func TestKDefault_InBoundLoads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".dir2mcp.yaml")
+	for _, k := range []int{config.RAGKMin, 15, 23, config.RAGKMax} {
+		t.Run(fmt.Sprintf("k=%d", k), func(t *testing.T) {
+			writeFile(t, path, fmt.Sprintf("rag_k_default: %d\n", k))
+			cfg, err := config.LoadFile(path)
+			if err != nil {
+				t.Fatalf("rag.k_default: %d was rejected: %v", k, err)
+			}
+			if cfg.RAGKDefault != k {
+				t.Fatalf("RAGKDefault=%d want %d", cfg.RAGKDefault, k)
+			}
+			if got := cfg.EffectiveKDefault(); got != k {
+				t.Fatalf("EffectiveKDefault=%d want the configured %d", got, k)
+			}
+		})
+	}
+}
+
+// TestKDefault_ShippedDefaultMatchesTheFallback pins the agreement issue #654
+// asks for: config.Default(), the generated config and the runtime fallback all
+// state ONE number, and it is the number the canonical §16 config template
+// carries. Before this change Default() said 10 while every runtime path used
+// 15, so introspection and behavior disagreed.
+func TestKDefault_ShippedDefaultMatchesTheFallback(t *testing.T) {
+	cfg := config.Default()
+	if cfg.RAGKDefault != config.RAGKFallback {
+		t.Fatalf("Default().RAGKDefault=%d want the shipped fallback %d", cfg.RAGKDefault, config.RAGKFallback)
+	}
+	if got := cfg.EffectiveKDefault(); got != config.RAGKFallback {
+		t.Fatalf("Default().EffectiveKDefault()=%d want %d", got, config.RAGKFallback)
+	}
+	if config.RAGKFallback < config.RAGKMin || config.RAGKFallback > config.RAGKMax {
+		t.Fatalf("the shipped fallback %d is outside its own bound %d..%d", config.RAGKFallback, config.RAGKMin, config.RAGKMax)
+	}
+}
+
+// TestKDefault_UnsetConfigResolvesToTheFallback covers the third precedence step
+// (SPEC §9.1): a Config that carries no rag.k_default resolves to the shipped
+// fallback, never to 0, which would retrieve nothing.
+func TestKDefault_UnsetConfigResolvesToTheFallback(t *testing.T) {
+	var cfg config.Config
+	if got := cfg.EffectiveKDefault(); got != config.RAGKFallback {
+		t.Fatalf("EffectiveKDefault on an unset config = %d, want the fallback %d", got, config.RAGKFallback)
+	}
+}

--- a/tests/conformance/k_default_654_test.go
+++ b/tests/conformance/k_default_654_test.go
@@ -1,0 +1,140 @@
+package conformance
+
+import (
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+)
+
+// kSchemaTools are the five tools whose input schema advertises k (SPEC §9.1
+// scope: search, ask, related, ask_audio, transcribe_and_ask). rag.k_default is
+// one setting about how much evidence a corpus needs, so a server MUST NOT
+// apply it to some of them and not others.
+var kSchemaTools = []string{
+	"dir2mcp_search",
+	"dir2mcp_ask",
+	"dir2mcp_related",
+	"dir2mcp_ask_audio",
+	"dir2mcp_transcribe_and_ask",
+}
+
+// advertisedKProperty returns the decoded `k` property of a tool's served input
+// schema, failing the test when the tool or the property is absent.
+func advertisedKProperty(t *testing.T, schemas map[string]map[string]interface{}, tool string) map[string]interface{} {
+	t.Helper()
+	schema, ok := schemas[tool]
+	if !ok {
+		t.Fatalf("tools/list did not advertise %s", tool)
+	}
+	properties, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s: inputSchema has no properties object", tool)
+	}
+	prop, ok := properties["k"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s: inputSchema does not advertise k: %#v", tool, properties["k"])
+	}
+	return prop
+}
+
+// TestToolsList_AdvertisedKDefaultIsTheConfiguredDefault pins the wire-visible
+// half of issue #654. SPEC §9.1: "The `default` a server advertises for `k` MUST
+// therefore be the value an omitted field actually produces, which is
+// `rag.k_default` when the operator set one."
+//
+// A served schema describes THIS deployment. A fixed advertised default states
+// something untrue the moment an operator configures another value: a client
+// that reads the schema and sends the advertised number explicitly gets a
+// different k from a client that omits the field, with nothing to explain the
+// difference.
+//
+// The configuration under test fixes rag.k_default, which is what lets this
+// fixture assert a specific advertised number at all (SPEC §9.1).
+//
+// On main every tool advertised the constant 15 whatever rag.k_default said, so
+// all five rows fail there.
+func TestToolsList_AdvertisedKDefaultIsTheConfiguredDefault(t *testing.T) {
+	t.Parallel()
+	const configuredK = 23
+
+	cfg := defaultConfig()
+	cfg.RAGKDefault = configuredK
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	schemas := toolInputSchemas(t, mcpURL, sid)
+	for _, tool := range kSchemaTools {
+		t.Run(tool, func(t *testing.T) {
+			prop := advertisedKProperty(t, schemas, tool)
+			got, ok := prop["default"].(float64)
+			if !ok {
+				t.Fatalf("%s: k advertises no numeric default: %#v", tool, prop["default"])
+			}
+			if int(got) != configuredK {
+				t.Fatalf("%s: k default=%d want the configured rag.k_default=%d", tool, int(got), configuredK)
+			}
+		})
+	}
+}
+
+// TestToolsList_AdvertisedKDefaultIsTheShippedFallback is the other half of the
+// same rule: with no operator value, the advertised default is the shipped
+// fallback. config.Default() ships that number as rag.k_default, so the config
+// template, the served schema and the runtime all state one value.
+func TestToolsList_AdvertisedKDefaultIsTheShippedFallback(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	schemas := toolInputSchemas(t, mcpURL, sid)
+	for _, tool := range kSchemaTools {
+		t.Run(tool, func(t *testing.T) {
+			prop := advertisedKProperty(t, schemas, tool)
+			got, ok := prop["default"].(float64)
+			if !ok {
+				t.Fatalf("%s: k advertises no numeric default: %#v", tool, prop["default"])
+			}
+			if int(got) != config.RAGKFallback {
+				t.Fatalf("%s: k default=%d want the shipped fallback %d", tool, int(got), config.RAGKFallback)
+			}
+		})
+	}
+}
+
+// TestToolsList_AdvertisedKKeepsItsBound guards the bound while the default
+// moves: publishing an effective default must not disturb the 1..50 minimum and
+// maximum every k-bearing tool advertises (#648), and the configured default
+// must itself lie inside that bound (SPEC §9.1).
+func TestToolsList_AdvertisedKKeepsItsBound(t *testing.T) {
+	t.Parallel()
+	cfg := defaultConfig()
+	cfg.RAGKDefault = 42
+	srv := newServer(t, cfg)
+	defer srv.Close()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+
+	schemas := toolInputSchemas(t, mcpURL, sid)
+	for _, tool := range kSchemaTools {
+		t.Run(tool, func(t *testing.T) {
+			prop := advertisedKProperty(t, schemas, tool)
+			min, minOK := prop["minimum"].(float64)
+			max, maxOK := prop["maximum"].(float64)
+			if !minOK || !maxOK {
+				t.Fatalf("%s: k advertises no numeric bound: %#v", tool, prop)
+			}
+			if int(min) != config.RAGKMin || int(max) != config.RAGKMax {
+				t.Fatalf("%s: k bound=%d..%d want %d..%d", tool, int(min), int(max), config.RAGKMin, config.RAGKMax)
+			}
+			got, ok := prop["default"].(float64)
+			if !ok || got < min || got > max {
+				t.Fatalf("%s: advertised default %#v is outside the advertised bound %d..%d", tool, prop["default"], int(min), int(max))
+			}
+		})
+	}
+}

--- a/tests/mcp/k_default_654_test.go
+++ b/tests/mcp/k_default_654_test.go
@@ -1,0 +1,402 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// kRecordingRetriever records the k that reached retrieval, whichever entry
+// point the tool used: Search (search, and any ask-family request served as
+// search_only), Ask (ask, ask_audio, transcribe_and_ask) or Related.
+//
+// It is written from the HTTP handler goroutine and read from the test
+// goroutine, so every field is guarded.
+type kRecordingRetriever struct {
+	mu        sync.Mutex
+	searchK   int
+	askK      int
+	relatedK  int
+	askCalls  int
+	hits      []model.SearchHit
+	askResult model.AskResult
+}
+
+func (r *kRecordingRetriever) Search(_ context.Context, q model.SearchQuery) ([]model.SearchHit, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.searchK = q.K
+	return r.hits, nil
+}
+
+func (r *kRecordingRetriever) Ask(_ context.Context, question string, q model.SearchQuery) (model.AskResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.askK = q.K
+	r.askCalls++
+	result := r.askResult
+	result.Question = question
+	return result, nil
+}
+
+func (r *kRecordingRetriever) Related(_ context.Context, q model.RelatedQuery) (model.RelatedResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.relatedK = q.K
+	return model.RelatedResult{
+		SourceChunkID:    q.SourceChunkID,
+		HasSourceChunkID: q.SourceChunkID != 0,
+		SourceRelPath:    "seed.md",
+		K:                q.K,
+		IndexUsed:        "text",
+		IndexingComplete: true,
+	}, nil
+}
+
+func (r *kRecordingRetriever) OpenFile(context.Context, string, model.Span, int) (string, error) {
+	return "", model.ErrNotImplemented
+}
+func (r *kRecordingRetriever) Stats(context.Context) (model.Stats, error) {
+	return model.Stats{}, model.ErrNotImplemented
+}
+func (r *kRecordingRetriever) IndexingComplete(context.Context) (bool, error) { return true, nil }
+
+// observedK returns the k recorded by whichever entry point ran.
+func (r *kRecordingRetriever) observedK() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	switch {
+	case r.askK != 0:
+		return r.askK
+	case r.relatedK != 0:
+		return r.relatedK
+	default:
+		return r.searchK
+	}
+}
+
+func (r *kRecordingRetriever) askCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.askCalls
+}
+
+var _ model.Retriever = (*kRecordingRetriever)(nil)
+var _ model.RelatedSearcher = (*kRecordingRetriever)(nil)
+
+// kRetrievalTools are the four in-process tools that take a k and reach
+// retrieval without a corpus. dir2mcp_transcribe_and_ask is the fifth tool in
+// the SPEC §9.1 scope; it needs an indexed audio document, so it has its own
+// test below.
+var kRetrievalTools = []struct {
+	name string
+	// args renders the tool arguments. k <= 0 OMITS the field entirely, which
+	// is the case rag.k_default resolves.
+	args func(k int) string
+}{
+	{
+		name: "dir2mcp_search",
+		args: func(k int) string { return `{"query":"q"` + kArgument(k) + `}` },
+	},
+	{
+		name: "dir2mcp_ask",
+		args: func(k int) string { return `{"question":"q"` + kArgument(k) + `}` },
+	},
+	{
+		name: "dir2mcp_ask_audio",
+		args: func(k int) string { return `{"question":"q"` + kArgument(k) + `}` },
+	},
+	{
+		name: "dir2mcp_related",
+		args: func(k int) string { return `{"chunk_id":1` + kArgument(k) + `}` },
+	},
+}
+
+// kArgument renders the k member of a tool argument object, or nothing at all
+// when k <= 0.
+func kArgument(k int) string {
+	if k <= 0 {
+		return ""
+	}
+	return `,"k":` + strconv.Itoa(k)
+}
+
+// callToolExpectingSuccess runs one tools/call against a server built on the
+// given config and retriever, and fails the test on any transport-level error.
+func callToolExpectingSuccess(t *testing.T, cfg config.Config, retriever model.Retriever, tool, args string) {
+	t.Helper()
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+tool+`","arguments":`+args+`}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("%s: status=%d body=%s", tool, resp.StatusCode, string(payload))
+	}
+}
+
+// TestMCPOmittedK_ResolvesToConfiguredKDefault pins the precedence SPEC §9.1
+// fixes: an omitted k resolves to rag.k_default, on EVERY tool that takes a k.
+// The setting is one statement about how much evidence this corpus needs, so a
+// server must not honor it on some surfaces and not others.
+//
+// On main rag.k_default was loaded and persisted but never read, so all four
+// rows retrieved the hardcoded 15 instead.
+func TestMCPOmittedK_ResolvesToConfiguredKDefault(t *testing.T) {
+	const configuredK = 23
+
+	for _, tool := range kRetrievalTools {
+		t.Run(tool.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.AuthMode = "none"
+			cfg.RAGKDefault = configuredK
+
+			retriever := &kRecordingRetriever{}
+			callToolExpectingSuccess(t, cfg, retriever, tool.name, tool.args(0))
+			if got := retriever.observedK(); got != configuredK {
+				t.Fatalf("%s with omitted k retrieved k=%d, want the configured rag.k_default=%d", tool.name, got, configuredK)
+			}
+		})
+	}
+}
+
+// TestMCPSuppliedK_WinsOverConfiguredKDefault pins step 1 of the same
+// precedence: the REQUEST field beats the configured default. Wiring
+// rag.k_default must not make a caller's explicit k negotiable.
+func TestMCPSuppliedK_WinsOverConfiguredKDefault(t *testing.T) {
+	const (
+		configuredK = 23
+		requestedK  = 4
+	)
+
+	for _, tool := range kRetrievalTools {
+		t.Run(tool.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.AuthMode = "none"
+			cfg.RAGKDefault = configuredK
+
+			retriever := &kRecordingRetriever{}
+			callToolExpectingSuccess(t, cfg, retriever, tool.name, tool.args(requestedK))
+			if got := retriever.observedK(); got != requestedK {
+				t.Fatalf("%s with k=%d retrieved k=%d; a supplied k must win over rag.k_default", tool.name, requestedK, got)
+			}
+		})
+	}
+}
+
+// TestMCPTranscribeAndAsk_OmittedKResolvesToConfiguredKDefault covers the fifth
+// tool in the SPEC §9.1 scope. It needs an indexed audio document and a
+// transcription upstream, so it cannot join the table above.
+func TestMCPTranscribeAndAsk_OmittedKResolvesToConfiguredKDefault(t *testing.T) {
+	const configuredK = 23
+
+	cfg, st, _ := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt data"))
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/transcriptions" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"segments":[{"start":1,"end":2,"text":"alpha in transcript"}]}`)
+	}))
+	defer upstream.Close()
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
+	cfg.RAGKDefault = configuredK
+
+	retriever := &kRecordingRetriever{askResult: model.AskResult{Answer: "alpha answer"}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_transcribe_and_ask","arguments":{"rel_path":"voice.wav","question":"what is alpha?"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	if got := retriever.observedK(); got != configuredK {
+		t.Fatalf("transcribe_and_ask with omitted k retrieved k=%d, want the configured rag.k_default=%d", got, configuredK)
+	}
+}
+
+// askStructuredContent decodes the structuredContent of a successful ask-family
+// tools/call.
+func askStructuredContent(t *testing.T, resp *http.Response) map[string]interface{} {
+	t.Helper()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("decode: %v body=%s", err, payload)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("unexpected tool error: %s", payload)
+	}
+	return envelope.Result.StructuredContent
+}
+
+// assertSearchOnlyShape checks the SPEC §9.4 no-answer payload: the response
+// SHAPE is unchanged, so `answer` and `citations` are present and empty rather
+// than absent, and the hits are still returned.
+func assertSearchOnlyShape(t *testing.T, structured map[string]interface{}, wantHits int) {
+	t.Helper()
+	answer, ok := structured["answer"].(string)
+	if !ok {
+		t.Fatalf("answer is absent or not a string: %#v", structured["answer"])
+	}
+	if answer != "" {
+		t.Fatalf("answer=%q, want empty with generation disabled", answer)
+	}
+	citations, ok := structured["citations"].([]interface{})
+	if !ok {
+		t.Fatalf("citations is absent or not an array: %#v", structured["citations"])
+	}
+	if len(citations) != 0 {
+		t.Fatalf("citations has %d entries, want none with generation disabled", len(citations))
+	}
+	hits, ok := structured["hits"].([]interface{})
+	if !ok {
+		t.Fatalf("hits is absent or not an array: %#v", structured["hits"])
+	}
+	if len(hits) != wantHits {
+		t.Fatalf("hits=%d want %d: generation is disabled, retrieval is not", len(hits), wantHits)
+	}
+}
+
+// TestMCPGenerateAnswerFalse_IsServedAsSearchOnly pins the §9.4 clause the spec
+// now names: `rag.generate_answer: false` behaves exactly as
+// `mode=search_only`. Either condition is sufficient, so a request cannot turn
+// generation back on, and `mode=answer` against it is SERVED as search_only
+// rather than refused.
+//
+// On main the key was loaded and persisted but never read, so every row called
+// the generator and returned an answer.
+func TestMCPGenerateAnswerFalse_IsServedAsSearchOnly(t *testing.T) {
+	hits := []model.SearchHit{
+		{ChunkID: 1, RelPath: "a.md", Snippet: "alpha", Score: 0.9},
+		{ChunkID: 2, RelPath: "b.md", Snippet: "beta", Score: 0.8},
+	}
+
+	for _, tc := range []struct {
+		name string
+		tool string
+		args string
+	}{
+		{name: "ask/mode=answer", tool: "dir2mcp_ask", args: `{"question":"q","mode":"answer"}`},
+		{name: "ask/mode omitted", tool: "dir2mcp_ask", args: `{"question":"q"}`},
+		{name: "ask_audio/mode=answer", tool: "dir2mcp_ask_audio", args: `{"question":"q","mode":"answer"}`},
+		{name: "ask_audio/mode omitted", tool: "dir2mcp_ask_audio", args: `{"question":"q"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.AuthMode = "none"
+			cfg.RAGGenerateAnswer = false
+
+			retriever := &kRecordingRetriever{
+				hits:      hits,
+				askResult: model.AskResult{Answer: "generated answer", Citations: []model.Citation{{ChunkID: 1, RelPath: "a.md"}}},
+			}
+			server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+			defer server.Close()
+			sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+			resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+				`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+tc.tool+`","arguments":`+tc.args+`}}`)
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				payload, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+			}
+			assertSearchOnlyShape(t, askStructuredContent(t, resp), len(hits))
+			if calls := retriever.askCallCount(); calls != 0 {
+				t.Fatalf("Ask ran %d times; generation is disabled, so no prompt may be assembled", calls)
+			}
+		})
+	}
+}
+
+// TestMCPGenerateAnswerTrue_StillAnswers is the converse guard: the default
+// deployment still generates, so disabling generation cannot be mistaken for
+// the shipped behavior.
+func TestMCPGenerateAnswerTrue_StillAnswers(t *testing.T) {
+	cfg := config.Default()
+	cfg.AuthMode = "none"
+
+	retriever := &kRecordingRetriever{askResult: model.AskResult{Answer: "generated answer"}}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever).Handler())
+	defer server.Close()
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_ask","arguments":{"question":"q"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	structured := askStructuredContent(t, resp)
+	if got, _ := structured["answer"].(string); got != "generated answer" {
+		t.Fatalf("answer=%q want the generated answer", got)
+	}
+}
+
+// TestMCPTranscribeAndAsk_GenerateAnswerFalseWithholdsGeneration extends the
+// §9.4 rule to the third ask-family surface. The tool has no `mode` argument, so
+// the server setting is the only condition, and an operator who disabled
+// generation must not have a chat provider called behind their back.
+func TestMCPTranscribeAndAsk_GenerateAnswerFalseWithholdsGeneration(t *testing.T) {
+	cfg, st, _ := setupMCPToolStore(t, "voice.wav", "audio", []byte("RIFF0000WAVEfmt data"))
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/audio/transcriptions" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"segments":[{"start":1,"end":2,"text":"alpha in transcript"}]}`)
+	}))
+	defer upstream.Close()
+	cfg = withMistralUpstream(t, cfg, "mistral-ocr", upstream.URL)
+	cfg.RAGGenerateAnswer = false
+
+	retriever := &kRecordingRetriever{
+		hits:      []model.SearchHit{{ChunkID: 1, RelPath: "voice.wav", Snippet: "alpha in transcript"}},
+		askResult: model.AskResult{Answer: "generated answer"},
+	}
+	server := httptest.NewServer(mcp.NewServer(cfg, retriever, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dir2mcp_transcribe_and_ask","arguments":{"rel_path":"voice.wav","question":"what is alpha?"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(payload))
+	}
+	structured := askStructuredContent(t, resp)
+	assertSearchOnlyShape(t, structured, 1)
+	if calls := retriever.askCallCount(); calls != 0 {
+		t.Fatalf("Ask ran %d times; generation is disabled", calls)
+	}
+	// The transcript provenance is still reported: only generation is withheld.
+	if _, ok := structured["transcript_provider"].(string); !ok {
+		t.Fatalf("transcript_provider missing from a search-only transcribe_and_ask: %#v", structured)
+	}
+}

--- a/tests/retrieval/k_default_654_test.go
+++ b/tests/retrieval/k_default_654_test.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// newKDefaultService builds a vector-only service over `count` candidates, so a
+// search that returns fewer than `count` hits was truncated by k and nothing
+// else.
+func newKDefaultService(t *testing.T, count int) *retrieval.Service {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+	for i := 1; i <= count; i++ {
+		// Fan the candidates around the query vector {1, 0} so every one of them
+		// scores above zero and their order is deterministic.
+		angle := float64(i) * (math.Pi / 4) / float64(count+1)
+		addVec(t, idx, uint64(i), []float32{float32(math.Cos(angle)), float32(math.Sin(angle))})
+	}
+	svc := retrieval.NewService(nil, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for i := 1; i <= count; i++ {
+		svc.SetChunkMetadata(uint64(i), model.SearchHit{RelPath: fmt.Sprintf("doc-%d.md", i), Snippet: "text"})
+	}
+	return svc
+}
+
+func searchHitCount(t *testing.T, svc *retrieval.Service, k int) int {
+	t.Helper()
+	hits, err := svc.Search(context.Background(), model.SearchQuery{Query: "alpha", K: k})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	return len(hits)
+}
+
+// TestService_DefaultKIsConfigurable pins the retrieval half of issue #654: the
+// service resolves a query that carries no k of its own against the operator's
+// rag.k_default, which the engine plumbs in with SetDefaultK. On main the
+// service replaced an absent k with a hardcoded 15.
+func TestService_DefaultKIsConfigurable(t *testing.T) {
+	svc := newKDefaultService(t, 20)
+	svc.SetDefaultK(3)
+	if got := searchHitCount(t, svc, 0); got != 3 {
+		t.Fatalf("search with no k returned %d hits, want the configured default 3", got)
+	}
+}
+
+// TestService_QueryKWinsOverDefaultK keeps the precedence: a query that names
+// its own k is never overridden by the configured default.
+func TestService_QueryKWinsOverDefaultK(t *testing.T) {
+	svc := newKDefaultService(t, 20)
+	svc.SetDefaultK(3)
+	if got := searchHitCount(t, svc, 7); got != 7 {
+		t.Fatalf("search with k=7 returned %d hits, want 7", got)
+	}
+}
+
+// TestService_UnsetDefaultKIsTheShippedFallback pins step 3 of the precedence: a
+// service the engine never configured retrieves the shipped fallback, so an
+// embedder that skips SetDefaultK keeps today's behavior.
+func TestService_UnsetDefaultKIsTheShippedFallback(t *testing.T) {
+	svc := newKDefaultService(t, 20)
+	if got := searchHitCount(t, svc, 0); got != config.RAGKFallback {
+		t.Fatalf("search with no k returned %d hits, want the shipped fallback %d", got, config.RAGKFallback)
+	}
+}
+
+// TestService_OutOfBoundDefaultKFallsBack guards the setter: config validation
+// rejects an out-of-bound rag.k_default at load, so a value that still arrives
+// here comes from a hand-built Config and must not silently retrieve nothing.
+func TestService_OutOfBoundDefaultKFallsBack(t *testing.T) {
+	for _, k := range []int{0, -5, config.RAGKMax + 1} {
+		t.Run(fmt.Sprintf("k=%d", k), func(t *testing.T) {
+			svc := newKDefaultService(t, 20)
+			svc.SetDefaultK(k)
+			if got := searchHitCount(t, svc, 0); got != config.RAGKFallback {
+				t.Fatalf("SetDefaultK(%d): search returned %d hits, want the fallback %d", k, got, config.RAGKFallback)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #654. Re-pins the spec submodule to 0.50.0 (dirstral-spec#90), the PR that settled both semantics.

## The symptom

An operator sets `rag.k_default: 30`. The server loads it, saves it, and prints it back in the effective config. Every request still retrieves 15 hits. The operator sets `rag.generate_answer: false`. Every ask still calls a chat provider and returns an answer. Neither key had a reader.

Worse for the second one: an operator can believe generation is off, and the server still sends retrieved corpus text to a third-party model. That is a data-flow decision, made silently against the operator.

## What the spec settled, and where each rule lives

dirstral-spec 0.50.0 decided the open questions. Nothing below is re-decided here.

### 1. Precedence: the request field, then `rag.k_default`, then the shipped fallback (SPEC 9.1)

`config.EffectiveKDefault()` is the one resolver. Everything reads it:

| Surface | Where |
|---|---|
| all five tools | `parseKArg(args, s.effectiveK())`, the shared parser |
| retrieval service | `SetDefaultK`, wired in `up.go` and in the ask CLI's retriever build |
| CLI, local | `resolveAskK(cfg, opts.k)` |
| CLI, remote | `withRemoteK` OMITS `k` when the flag is absent, so the daemon resolves its own |

The remote case is the one worth naming. A client that sent its own constant would override the server's configured default on every call, so the honest request is the one that leaves the field out.

A supplied `k` still wins and is still bound-checked. PR #849 separated an omitted `k` from a supplied one and made a supplied out-of-bound value `INVALID_RANGE`. This change touches only the omitted branch, and `TestMCPSuppliedK_WinsOverConfiguredKDefault` pins that.

### 2. Scope: every tool that takes a `k` (SPEC 9.1)

`search`, `ask`, `related`, `ask_audio`, `transcribe_and_ask`. All five already funnel through `parseKArg`, so "every surface" was also the cheap answer. The retrieval service's own fallbacks (`search`, `Ask`, `Related`) each read the same configured value instead of a hardcoded 15.

### 3. The bound is enforced at LOAD (SPEC 9.1)

`rag.k_default` carries the same `1..50` bound as the request field. Outside it is `CONFIG_INVALID` at load, not a failure at some later request the operator never wrote. The bound constants live in `internal/config` because validation needs them; `mcp.MinSearchK` / `MaxSearchK` / `DefaultSearchK` now alias them, so there is still one definition.

`config.Default()` ships `k_default: 15`, the number the canonical SPEC 16 template carries. It said 10 before, while every runtime path used 15. The generated config, the served schema and the runtime now state one number, which is the agreement #654 asks for.

### 4. The served schema reports the EFFECTIVE default (SPEC 9.1)

`tools/list` advertises `"default": <the deployment's k_default>` for `k` on all five tools. A fixed advertised default states something untrue as soon as an operator configures another value: a client that reads the schema and sends the advertised number explicitly would get a different `k` from a client that omits the field, with nothing to explain the difference. The registry is built once from the resolved config, so the advertised number cannot drift from the parser's.

### 5. `generate_answer: false` is served as `search_only` (SPEC 9.4)

`Server.withholdsAnswer(mode)` is the disjunction the spec states: either the server disabled generation, or the request asked for `search_only`. `ask` and `ask_audio` route to the existing `runSearchOnlyMode`, so the response shape is unchanged: `answer: ""`, `citations: []`, hits present. No prompt is assembled and no chat provider is called.

`mode=answer` against a disabled server is SERVED as search-only, not refused. `transcribe_and_ask` has no `mode` argument, so the server setting is its only condition; it keeps reporting its transcript provenance. The local `ask` CLI applies the same rule.

The insufficient-evidence rules (SPEC 9.4.3) are untouched: they run inside the generation path, which this branch does not enter.

## Proof each test fails on main

Run in a scratch worktree at `d6f611aa` (main) with the new tests copied in. The two files that use new API (`config.RAGKMin/RAGKMax/RAGKFallback`, `EffectiveKDefault`) had those references rewritten to literals so they compile there.

`TestToolsList_AdvertisedKDefaultIsTheConfiguredDefault` (conformance, production SDK transport), 5 of 5:

```
dir2mcp_search: k default=15 want the configured rag.k_default=23
dir2mcp_ask ... dir2mcp_related ... dir2mcp_ask_audio ... dir2mcp_transcribe_and_ask
```

`TestMCPOmittedK_ResolvesToConfiguredKDefault` + the transcribe_and_ask row, 5 of 5 tools:

```
dir2mcp_search with omitted k retrieved k=15, want the configured rag.k_default=23
dir2mcp_ask ... dir2mcp_ask_audio ... dir2mcp_related ...
transcribe_and_ask with omitted k retrieved k=15, want the configured rag.k_default=23
```

`TestMCPGenerateAnswerFalse_IsServedAsSearchOnly`, 4 of 4 rows (ask and ask_audio, `mode=answer` and mode omitted), plus the transcribe_and_ask case:

```
answer="generated answer", want empty with generation disabled
```

`TestKDefault_*` (config):

```
error=rag.k_default must be non-negative: -1 want substring "rag.k_default must be between 1 and 50"
rag.k_default: 0 loaded without error
rag.k_default: 51 loaded without error
rag.k_default: 1000 loaded without error
Default().RAGKDefault=10 want the shipped fallback 15
```

`TestAskLocal_*` (CLI):

```
k=15 want the configured rag.k_default=23
Ask ran with rag.generate_answer: false   (mode omitted and mode=answer)
```

Three tests PASS on main on purpose, and they are the regression guards: `TestMCPSuppliedK_WinsOverConfiguredKDefault`, `TestToolsList_AdvertisedKDefaultIsTheShippedFallback` and `TestToolsList_AdvertisedKKeepsItsBound`. A supplied `k`, the shipped number and the `1..50` bound must not move.

`tests/retrieval/k_default_654_test.go` has no main counterpart: it drives `SetDefaultK`, which does not exist there.

## Documentation

`README.md` gains a "Retrieval answer keys" section under Configuration: the precedence, the `1..50` bound and its load-time failure, the effective advertised default, and what `generate_answer: false` returns. Neither key was documented before, so nothing described them as inert.

## Notes

- `coderabbit review --committed --base main` refused: "Review limit reached ... this Git provider account isn't linked to an assigned seat". A line-by-line self-review replaced it and found three things, all fixed before this PR: a `if opts.k <= 0 { opts.k = 0 }` no-op left by the flag rewrite (now a meaningful negative-normalizing branch), an unguarded `structuredContent` type assertion in the transcribe_and_ask path that would have panicked on a nil map, and em dashes in one new comment.
- `make check` passes, gocyclo `-over 15` included. Two helpers were extracted to stay under the gate: `Config.validateRAGNumericBounds` and `App.reportMissingEmbedProvider` (both pure moves, no behavior change).
- One commit. The two keys are one issue, one spec PR, and they meet in the same ask-family handlers, so splitting them would have split single hunks.
