### PR TITLE
fix(annotator): make the outcome of a play an event, not prose

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -31,6 +31,28 @@ Core (play-by-play, fusion, serving, eval) is **stdlib-only**; vision
 recognizers pull their stacks via extras and are skipped gracefully when
 unavailable.
 
+### What the play-by-play recognizer emits
+
+One pitch produces up to three cues. Each cue carries one role:
+
+| `event` | Keyed on | Emitted for |
+|---|---|---|
+| `pitch` | the pitcher, plus the fielding club | every pitch a rostered pitcher threw |
+| `at_bat` | the batter, plus the club at the plate | every pitch a rostered batter faced |
+| the feed's `result.eventType`: `home_run`, `strikeout`, `walk`, `single`, `double`, `field_out`, ... | the batter, plus the club at the plate | the pitch that ended the at-bat |
+
+The third cue makes the outcome of a play structured data. Before it, the
+outcome was prose inside the cue text alone, so `dir2mcp_search`'s `events`
+filter could not reach it. "Who hit home runs? List every player" fell back to
+top-k semantic search over that prose, and it answered a "list every X"
+question from a partial sample: it named a player who never homered and it
+dropped one who did. The vocabulary is MLB's own, so a client selects the real
+thing with `events: ["home_run"]` instead of a match on words.
+
+The three cues share one time span, so the answer path groups them into one
+moment (issue #784) and counts one event once. The phase-1 metric reads
+`event == "pitch"` alone, so the outcome cues do not move it.
+
 ### The overlay text reader
 
 `recognizers/overlay.py` is the reusable half of the scorebug recognizer:

--- a/annotator/dirstral_annotator/eval/ground_truth.py
+++ b/annotator/dirstral_annotator/eval/ground_truth.py
@@ -43,6 +43,17 @@ class PitchEvent:
     #: which keeps every existing caller and fixture valid.
     away_team: str = ""
     home_team: str = ""
+    #: The at-bat's outcome as the feed types it: `result.eventType`, verbatim
+    #: ("home_run", "strikeout", "walk", "field_out", ...). It rides on the
+    #: pitch that ENDED the at-bat and is empty on every other pitch, exactly
+    #: like `description`, which already carries the play result text only
+    #: there. Empty as well when the payload omits the field.
+    #:
+    #: The outcome is the one part of a play that used to exist only as prose
+    #: inside `description`. A question like "who hit home runs?" then had no
+    #: structured field to select on, so it fell back to top-k search over that
+    #: prose and answered a "list every X" question from a partial sample.
+    event_type: str = ""
 
     def half_inning(self) -> str:
         """The half-inning phrased as a person would say it: "top of the 1st"."""
@@ -86,11 +97,15 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
         matchup = play.get("matchup", {})
         pitcher = matchup.get("pitcher", {})
         batter = matchup.get("batter", {})
-        result_desc = play.get("result", {}).get("description", "")
+        result = play.get("result", {})
+        result_desc = result.get("description", "")
+        event_type = (result.get("eventType") or "").strip()
         about = play.get("about", {})
         inning = about.get("inning", 0)
         top_inning = bool(about.get("isTopInning", True))
-        for ev in play.get("playEvents", []):
+        play_events = play.get("playEvents", [])
+        last = _last_recorded_pitch(play_events)
+        for i, ev in enumerate(play_events):
             if not ev.get("isPitch"):
                 continue
             start = ev.get("startTime")
@@ -99,7 +114,7 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
             call = ev.get("details", {}).get("description", "")
             # The play's result text describes the final pitch of the at-bat
             # better than the raw call does.
-            is_last = ev is play["playEvents"][-1]
+            is_last = i == last
             events.append(
                 PitchEvent(
                     game_pk=game_pk,
@@ -113,10 +128,35 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
                     away_team=away_team,
                     home_team=home_team,
                     description=(result_desc if is_last and result_desc else call),
+                    event_type=(event_type if is_last else ""),
                 )
             )
     events.sort(key=lambda e: e.epoch_s)
     return events
+
+
+def _last_recorded_pitch(play_events: list[dict]) -> int:
+    """Index of the pitch that ends the at-bat, or -1 for a play with none.
+
+    A play does not always end on a pitch, and the test this replaced
+    (`ev is play["playEvents"][-1]`) ran AFTER the loop had skipped every
+    non-pitch, so a play that ends on anything else marked no pitch as last.
+    The play result text, and now the outcome, then attached to nothing.
+
+    Measured on 594 plays of 8 games of the 2025 season: one play ended on an
+    "Automatic Ball - Pitcher Pitch Timer Violation", which the feed records
+    with `isPitch: false`. It is rare, not theoretical, and one dropped
+    outcome is one at-bat that no structured query can reach.
+
+    A pitch with no `startTime` cannot be placed on the video timeline, so the
+    parse skips it; it cannot end an at-bat either, or the outcome would ride
+    on a pitch that never reaches a caller.
+    """
+    for i in range(len(play_events) - 1, -1, -1):
+        ev = play_events[i]
+        if ev.get("isPitch") and ev.get("startTime"):
+            return i
+    return -1
 
 
 def _iso_epoch(iso: str) -> float:

--- a/annotator/dirstral_annotator/recognizers/playbyplay.py
+++ b/annotator/dirstral_annotator/recognizers/playbyplay.py
@@ -13,6 +13,20 @@ keyed: a rostered batter appearing at an opponent's pitch is a real
 appearance, not a pitch by that player, and tagging it `pitch` would make
 every opponent-pitched at-bat a false positive.
 
+The pitch that ENDS an at-bat carries a third cue: the outcome. Its `event`
+is the feed's own `result.eventType` ("home_run", "strikeout", "walk",
+"field_out", ...) and it is keyed on the batter, because the outcome is the
+batter's. Before it, the outcome existed only as prose inside the cue text,
+so `dir2mcp_search`'s `events` filter could not reach it: "who hit home
+runs?" had to fall back to top-k semantic search over that prose, and a
+"list every X" question answered from a partial sample invented one player
+and dropped another. A structured event makes the same question a selection.
+
+The three cues are additive. `pitch` and `at_bat` keep the entities, the
+text, the span and the confidence they had, so the pitcher-keyed phase-1
+metric (`eval.score`, which reads `event == "pitch"` alone) cannot see this
+change at all. Retagging is what broke #620; this adds instead.
+
 This recognizer doubles as the eval ground-truth source; the fetch/parse
 lives in eval.ground_truth so both uses share one implementation.
 """
@@ -32,6 +46,14 @@ PRE_ROLL_S = 3.0
 POST_ROLL_S = 5.0
 CONFIDENCE = 0.98  # official record, minus alignment slop
 
+# The two role events this recognizer owns. An outcome may never take one of
+# these names: a batter-keyed cue tagged `pitch` is the #620 regression, and
+# the pitcher-keyed metric would score it as a false positive. MLB types no
+# play "pitch" or "at_bat", so the guard should never fire. It costs one
+# comparison, and it means the metric does not depend on a third party's
+# vocabulary staying the way it is today.
+ROLE_EVENTS = ("pitch", "at_bat")
+
 _SLUG_SEP = re.compile(r"[^a-z0-9]+")
 
 
@@ -45,6 +67,18 @@ def team_id(name: str) -> str:
     """
     slug = _SLUG_SEP.sub("-", name.strip().lower()).strip("-")
     return f"team:{slug}" if slug else ""
+
+
+def outcome_label(event_type: str) -> str:
+    """"home_run" -> "Home run". The feed's own vocabulary, spelled for a
+    reader, so the cue text stays a sentence a person can read while `event`
+    stays the exact token a filter selects on.
+
+    Returns "" for an event type that is empty or only whitespace, which is
+    how a feed without `result.eventType` reaches here.
+    """
+    words = event_type.replace("_", " ").strip()
+    return words[:1].upper() + words[1:]
 
 
 def _with_team(player_id: str, team: str) -> tuple[str, ...]:
@@ -126,6 +160,35 @@ class PlayByPlayRecognizer:
                         entity_ids=_with_team(batter.id, ev.batting_team()),
                         confidence=CONFIDENCE,
                         text=f"At bat: {batter_name} vs {pitcher_name}{where}{desc}",
+                    )
+                )
+            outcome = ev.event_type.strip()
+            if batter is not None and outcome and outcome not in ROLE_EVENTS:
+                # THE OUTCOME OF THE AT-BAT, as structured data. The feed types
+                # every play ("home_run", "strikeout", "walk", ...), and only
+                # the pitch that ended the at-bat carries it, so one at-bat
+                # produces exactly one outcome cue.
+                #
+                # It is keyed on the batter and their club, like the `at_bat`
+                # cue it accompanies: the batter is who homered. A rostered
+                # pitcher facing an unrostered batter therefore gets no outcome
+                # cue, because the cue would have nobody to name.
+                #
+                # The span is the span of that last pitch, which the answer
+                # path groups with the `pitch` and `at_bat` annotations of the
+                # same seconds (issue #784), so one moment stays one moment.
+                cues.append(
+                    Cue(
+                        source=self.name,
+                        start_s=start,
+                        end_s=end,
+                        event=outcome,
+                        entity_ids=_with_team(batter.id, ev.batting_team()),
+                        confidence=CONFIDENCE,
+                        text=(
+                            f"{outcome_label(outcome)}: {batter_name} "
+                            f"vs {pitcher_name}{where}{desc}"
+                        ),
                     )
                 )
         return cues

--- a/annotator/tests/fixtures/gumbo_823215.json
+++ b/annotator/tests/fixtures/gumbo_823215.json
@@ -1,0 +1,4695 @@
+{
+ "gamePk": 823215,
+ "gameData": {
+  "teams": {
+   "away": {
+    "name": "Washington Nationals"
+   },
+   "home": {
+    "name": "San Francisco Giants"
+   }
+  }
+ },
+ "liveData": {
+  "plays": {
+   "allPlays": [
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "James Wood grounds out, second baseman Luis Arraez to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695578,
+       "fullName": "James Wood"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T17:46:17.665Z",
+       "details": {
+        "description": "Status Change - Pre-Game"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T19:24:39.730Z",
+       "details": {
+        "description": "Status Change - Warmup"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T19:45:35.972Z",
+       "details": {
+        "description": "Status Change - In Progress"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:46:01.493Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:46:30.271Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:46:48.885Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Curtis Mead flies out to right fielder Jung Hoo Lee."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 678554,
+       "fullName": "Curtis Mead"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:47:20.121Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:47:36.569Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:47:54.200Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:48:13.696Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:48:36.245Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:48:55.722Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Andrés Chaparro called out on strikes."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 665953,
+       "fullName": "Andrés Chaparro"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:49:33.962Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:49:54.885Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:50:21.926Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:50:38.907Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:50:55.801Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:51:18.078Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:51:40.435Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Casey Schmitt lines out to third baseman Curtis Mead."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 669477,
+       "fullName": "Casey Schmitt"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:53:58.107Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:54:34.280Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:54:52.243Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:55:13.192Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:55:34.368Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Luis Arraez grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 650333,
+       "fullName": "Luis Arraez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:56:04.011Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:56:18.332Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T19:56:30.700Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:56:37.511Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:57:00.574Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:57:21.284Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:57:44.702Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:58:16.154Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:58:34.542Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Matt Chapman singles on a sharp ground ball to third baseman Curtis Mead."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 656305,
+       "fullName": "Matt Chapman"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:59:07.726Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:59:21.139Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:59:40.704Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T19:59:59.003Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:00:21.118Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Rafael Devers lines out to center fielder Jacob Young."
+     },
+     "about": {
+      "inning": 1,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 646240,
+       "fullName": "Rafael Devers"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:00:58.096Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:01:28.956Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:01:46.466Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:02:05.122Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:02:24.629Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:02:53.948Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Dylan Crews flies out to center fielder Jonah Cox."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 686611,
+       "fullName": "Dylan Crews"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:05:09.555Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:05:26.846Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Daylen Lile singles on a fly ball to left fielder Victor Bericoto."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695734,
+       "fullName": "Daylen Lile"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:05:57.505Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Jacob Young flies out to center fielder Jonah Cox."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 696285,
+       "fullName": "Jacob Young"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:06:36.996Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:06:57.122Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:07:15.199Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:07:25.062Z",
+       "details": {
+        "description": "Pickoff Attempt 1B"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:07:47.916Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:08:03.566Z",
+       "details": {
+        "description": "Daylen Lile steals (6) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:08:25.551Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Nasim Nuñez called out on strikes."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 683083,
+       "fullName": "Nasim Nuñez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:09:07.840Z",
+       "details": {
+        "description": "Pitcher Step Off"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:09:28.620Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:09:47.545Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:10:17.722Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:10:28.875Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:10:42.640Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Jung Hoo Lee strikes out swinging."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 808982,
+       "fullName": "Jung Hoo Lee"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:13:05.010Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:13:18.835Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:13:35.112Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:14:18.872Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:14:39.881Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:15:01.543Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:15:26.882Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:15:53.741Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Bryce Eldridge flies out to left fielder Daylen Lile."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 805811,
+       "fullName": "Bryce Eldridge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:16:23.630Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:16:37.706Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Daniel Susac singles on a line drive to left fielder Daylen Lile."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 691740,
+       "fullName": "Daniel Susac"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:17:11.815Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:17:26.077Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:17:37.938Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:17:49.670Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Victor Bericoto strikes out swinging."
+     },
+     "about": {
+      "inning": 2,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 682674,
+       "fullName": "Victor Bericoto"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:18:26.376Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:18:42.316Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:18:58.965Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:19:11.945Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:19:24.602Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:19:47.849Z",
+       "details": {
+        "description": "Swinging Strike (Blocked)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Jorbit Vivas flies out to left fielder Victor Bericoto."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 678391,
+       "fullName": "Jorbit Vivas"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:22:16.562Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:22:32.884Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Keibert Ruiz singles on a line drive to left fielder Victor Bericoto."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 660688,
+       "fullName": "Keibert Ruiz"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:23:07.045Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:23:20.771Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:23:37.171Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:23:56.316Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:24:12.259Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "James Wood homers (18) on a fly ball to center field. Keibert Ruiz scores."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695578,
+       "fullName": "James Wood"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:24:49.187Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:25:09.697Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:25:28.849Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:25:46.517Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:26:13.554Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Curtis Mead flies out to center fielder Jonah Cox."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 678554,
+       "fullName": "Curtis Mead"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:26:58.782Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:27:14.723Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:27:29.942Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Andrés Chaparro grounds out sharply, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 665953,
+       "fullName": "Andrés Chaparro"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:28:04.317Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:28:21.797Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:28:41.787Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:28:58.456Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Jonah Cox strikes out swinging."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 813841,
+       "fullName": "Jonah Cox"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:31:11.404Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:31:25.334Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:31:44.958Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Casey Schmitt grounds out, first baseman Andrés Chaparro to pitcher Foster Griffin."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 669477,
+       "fullName": "Casey Schmitt"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:32:12.412Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:32:32.223Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:32:48.023Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:33:09.859Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:33:25.758Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Luis Arraez singles on a ground ball to left fielder Daylen Lile."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 650333,
+       "fullName": "Luis Arraez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:34:05.736Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:34:22.155Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "force_out",
+      "description": "Matt Chapman grounds into a force out, shortstop Nasim Nuñez to second baseman Jorbit Vivas. Luis Arraez out at 2nd."
+     },
+     "about": {
+      "inning": 3,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 656305,
+       "fullName": "Matt Chapman"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:35:01.052Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:35:17.703Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:35:34.809Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:35:55.624Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Dylan Crews grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 686611,
+       "fullName": "Dylan Crews"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:38:13.543Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:38:32.326Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:38:48.561Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:39:07.399Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:39:24.173Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:39:33.953Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:39:43.958Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:40:07.306Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Daylen Lile grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695734,
+       "fullName": "Daylen Lile"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:40:41.835Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:41:23.854Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:41:39.695Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:41:49.488Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:42:06.639Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:42:24.905Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:42:44.673Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Jacob Young strikes out swinging."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 696285,
+       "fullName": "Jacob Young"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:43:23.642Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:43:40.907Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:43:55.872Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:44:09.700Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:44:26.604Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:44:44.244Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Rafael Devers called out on strikes."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 646240,
+       "fullName": "Rafael Devers"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:46:57.441Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:47:12.420Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:47:28.153Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:47:45.619Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Jung Hoo Lee grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 808982,
+       "fullName": "Jung Hoo Lee"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:48:15.087Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:48:29.701Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Bryce Eldridge grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro."
+     },
+     "about": {
+      "inning": 4,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 805811,
+       "fullName": "Bryce Eldridge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:49:01.418Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Nasim Nuñez grounds out, shortstop Casey Schmitt to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 683083,
+       "fullName": "Nasim Nuñez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:51:20.460Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:51:38.104Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:51:39.897Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:52:12.346Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:52:32.727Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:52:48.033Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:53:08.936Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jorbit Vivas singles on a line drive to left fielder Victor Bericoto."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 678391,
+       "fullName": "Jorbit Vivas"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:53:43.935Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:54:03.539Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Keibert Ruiz flies out to right fielder Jung Hoo Lee."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 660688,
+       "fullName": "Keibert Ruiz"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:54:39.694Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "James Wood flies out to left fielder Victor Bericoto."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695578,
+       "fullName": "James Wood"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:55:13.960Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:55:31.091Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:55:52.660Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:56:11.764Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:56:34.159Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:56:53.436Z",
+       "details": {
+        "description": "Pitcher Step Off"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:57:08.093Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Daniel Susac grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 691740,
+       "fullName": "Daniel Susac"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T20:59:24.688Z",
+       "details": {
+        "description": "Automatic Strike - Batter Pitch Timer Violation"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:59:44.254Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T20:59:58.043Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:00:11.383Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:00:22.477Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:00:32.332Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:00:48.421Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Nationals challenged (play at 1st), call on the field was overturned: Victor Bericoto grounds out, shortstop Nasim Nuñez to first baseman Andrés Chaparro."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 682674,
+       "fullName": "Victor Bericoto"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:01:22.230Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:01:36.068Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:01:52.873Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:02:14.439Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:02:30.480Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:02:44.997Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:03:06.156Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:03:23.813Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:03:46.673Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jonah Cox singles on a fly ball to right fielder Dylan Crews."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 813841,
+       "fullName": "Jonah Cox"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:06:00.099Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:06:15.147Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:06:29.384Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:06:44.793Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Casey Schmitt lines out sharply to center fielder Jacob Young."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 669477,
+       "fullName": "Casey Schmitt"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:07:22.764Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:07:52.719Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:08:10.575Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Curtis Mead grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 678554,
+       "fullName": "Curtis Mead"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:10:05.363Z",
+       "details": {
+        "description": "Defensive Substitution: Drew Gilbert replaces left fielder Victor Bericoto, batting 8th, playing left field."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:10:25.905Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:10:44.421Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:10:59.588Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Andrés Chaparro grounds out, shortstop Casey Schmitt to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 665953,
+       "fullName": "Andrés Chaparro"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:11:28.905Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:11:46.469Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:12:01.961Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Dylan Crews singles on a fly ball to right fielder Jung Hoo Lee."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 686611,
+       "fullName": "Dylan Crews"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:12:32.300Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Daylen Lile singles on a fly ball to left fielder Drew Gilbert. Dylan Crews scores."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 695734,
+       "fullName": "Daylen Lile"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:13:09.875Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:13:28.460Z",
+       "details": {
+        "description": "Dylan Crews steals (2) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:13:45.544Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:14:06.559Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:14:24.724Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jacob Young singles on a line drive to center fielder Jonah Cox. Daylen Lile to 3rd."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 592662,
+       "fullName": "Robbie Ray"
+      },
+      "batter": {
+       "id": 696285,
+       "fullName": "Jacob Young"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:15:06.622Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:15:25.984Z",
+       "details": {
+        "description": "Pickoff Attempt 1B"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:15:47.872Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:16:16.269Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:16:40.904Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:16:45.305Z",
+       "details": {
+        "description": "Pickoff Attempt 1B"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:17:07.483Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Nasim Nuñez singles on a ground ball to left fielder Drew Gilbert. Daylen Lile scores. Jacob Young scores."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 683083,
+       "fullName": "Nasim Nuñez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:17:38.751Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:18:17.721Z",
+       "details": {
+        "description": "Pitching Change: Carson Seymour replaces Robbie Ray."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:20:11.279Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:20:28.006Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:20:58.155Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:21:25.065Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:21:37.076Z",
+       "details": {
+        "description": "Jacob Young steals (6) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:21:43.864Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:22:03.548Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jorbit Vivas singles on a ground ball to right fielder Jung Hoo Lee. Nasim Nuñez scores. Jorbit Vivas to 2nd."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 678391,
+       "fullName": "Jorbit Vivas"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:22:43.257Z",
+       "details": {
+        "description": "Foul Tip"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:23:08.832Z",
+       "details": {
+        "description": "Pickoff Attempt 1B"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:23:28.529Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:23:43.491Z",
+       "details": {
+        "description": "Nasim Nuñez steals (25) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:23:58.505Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Keibert Ruiz pops out to shortstop Casey Schmitt."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 660688,
+       "fullName": "Keibert Ruiz"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:25:09.005Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:25:26.109Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:25:41.582Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:26:09.937Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:26:28.178Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:26:48.802Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Luis Arraez lines out to left fielder Daylen Lile."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 650333,
+       "fullName": "Luis Arraez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:29:08.061Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:29:22.280Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "Matt Chapman homers (5) on a fly ball to left center field."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 656305,
+       "fullName": "Matt Chapman"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:29:54.005Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:30:10.387Z",
+       "details": {
+        "description": "Foul Tip"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:30:19.811Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:30:30.248Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:30:49.974Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:31:21.500Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Rafael Devers flies out to right fielder Dylan Crews."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 646240,
+       "fullName": "Rafael Devers"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:32:05.855Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:32:21.001Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:32:40.029Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jung Hoo Lee singles on a line drive to right fielder Dylan Crews."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 808982,
+       "fullName": "Jung Hoo Lee"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:33:14.351Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Bryce Eldridge strikes out swinging."
+     },
+     "about": {
+      "inning": 6,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 656492,
+       "fullName": "Foster Griffin"
+      },
+      "batter": {
+       "id": 805811,
+       "fullName": "Bryce Eldridge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:33:48.740Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:34:13.553Z",
+       "details": {
+        "description": "Wild pitch by pitcher Foster Griffin. Jung Hoo Lee to 2nd."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:34:15.905Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:34:36.979Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:34:55.010Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:35:14.459Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:35:38.465Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "James Wood walks."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 695578,
+       "fullName": "James Wood"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:37:49.271Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:38:03.151Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:38:21.812Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:38:37.836Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:38:54.456Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:39:11.407Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:39:32.077Z",
+       "details": {
+        "description": "Ball"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Curtis Mead singles on a pop up to second baseman Luis Arraez."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 678554,
+       "fullName": "Curtis Mead"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:39:58.496Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:40:14.934Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:40:33.518Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:40:49.865Z",
+       "details": {
+        "description": "Wild pitch by pitcher Carson Seymour. James Wood to 2nd."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:41:00.648Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "double",
+      "description": "Luis García Jr. doubles (12) on a fly ball to left fielder Drew Gilbert. James Wood scores. Curtis Mead to 3rd."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 671277,
+       "fullName": "Luis García Jr."
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:42:01.052Z",
+       "details": {
+        "description": "Offensive Substitution: Pinch-hitter Luis García Jr. replaces Andrés Chaparro."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:42:01.054Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:42:22.290Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:42:41.203Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:43:02.004Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Dylan Crews grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers. Curtis Mead scores. Luis García Jr. to 3rd."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 686611,
+       "fullName": "Dylan Crews"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:43:52.720Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:44:08.053Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Daylen Lile singles on a sharp line drive to right fielder Jung Hoo Lee. Luis García Jr. scores."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 695734,
+       "fullName": "Daylen Lile"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:44:51.933Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:45:06.416Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:45:22.072Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Jacob Young called out on strikes."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 696285,
+       "fullName": "Jacob Young"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:45:57.486Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:46:12.492Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:46:28.800Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:46:53.122Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:47:12.469Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:47:36.455Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:47:58.771Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:48:17.783Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:48:40.988Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Nasim Nuñez lines out to center fielder Jonah Cox."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 693313,
+       "fullName": "Carson Seymour"
+      },
+      "batter": {
+       "id": 683083,
+       "fullName": "Nasim Nuñez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:49:08.102Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:49:39.217Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:50:03.052Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Daniel Susac pops out to first baseman Luis García Jr. in foul territory."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 691740,
+       "fullName": "Daniel Susac"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:52:01.875Z",
+       "details": {
+        "description": "Luis García Jr. remains in the game as the first baseman."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:52:01.891Z",
+       "details": {
+        "description": "Pitching Change: Paxton Schultz replaces Foster Griffin."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:52:31.319Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:52:46.188Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:53:03.103Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "Drew Gilbert walks."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 687551,
+       "fullName": "Drew Gilbert"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:53:38.162Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:53:53.983Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:54:12.958Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:54:29.968Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:54:44.119Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:55:01.418Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:55:19.715Z",
+       "details": {
+        "description": "Ball"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Jonah Cox strikes out swinging."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 813841,
+       "fullName": "Jonah Cox"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:55:49.702Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:56:06.682Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:56:25.429Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:56:42.291Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Casey Schmitt singles on a sharp line drive to right fielder Dylan Crews. Drew Gilbert to 2nd."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 669477,
+       "fullName": "Casey Schmitt"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:57:12.481Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:57:35.405Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Luis Arraez grounds out, shortstop Nasim Nuñez to first baseman Luis García Jr."
+     },
+     "about": {
+      "inning": 7,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 650333,
+       "fullName": "Luis Arraez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:58:12.324Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:58:30.118Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:58:52.888Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:59:13.708Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:59:32.582Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T21:59:43.729Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T21:59:55.795Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Jorbit Vivas grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 678391,
+       "fullName": "Jorbit Vivas"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:01:43.706Z",
+       "details": {
+        "description": "Pitching Change: Reiver Sanmartin replaces Carson Seymour."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:02:20.720Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:02:30.584Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:02:52.407Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:02:55.814Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Keibert Ruiz grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 660688,
+       "fullName": "Keibert Ruiz"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:03:25.023Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:03:41.034Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:03:47.551Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:03:59.554Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:04:17.401Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:04:43.016Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "James Wood strikes out swinging."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 695578,
+       "fullName": "James Wood"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:05:12.167Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:05:22.424Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:05:33.887Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:05:46.228Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "Matt Chapman homers (6) on a fly ball to center field."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 656305,
+       "fullName": "Matt Chapman"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:07:58.398Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "Rafael Devers homers (9) on a fly ball to center field."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 646240,
+       "fullName": "Rafael Devers"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:08:43.522Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:08:59.373Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "Jung Hoo Lee walks."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 808982,
+       "fullName": "Jung Hoo Lee"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:09:49.263Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:10:05.756Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:10:20.743Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:10:38.175Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:10:56.619Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:11:13.579Z",
+       "details": {
+        "description": "Ball"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "Bryce Eldridge walks."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 805811,
+       "fullName": "Bryce Eldridge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:11:31.789Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:12:16.522Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:12:35.753Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:13:00.565Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:13:17.607Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:13:40.932Z",
+       "details": {
+        "description": "Jung Hoo Lee steals (3) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:13:44.778Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:14:17.205Z",
+       "details": {
+        "description": "Ball"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "double",
+      "description": "Daniel Susac doubles (5) on a line drive to left fielder Daylen Lile. Jung Hoo Lee scores. Bryce Eldridge to 3rd."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687606,
+       "fullName": "Paxton Schultz"
+      },
+      "batter": {
+       "id": 691740,
+       "fullName": "Daniel Susac"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:14:49.697Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:15:08.174Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:15:22.262Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:15:37.872Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:15:56.419Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:16:18.732Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:16:41.523Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:17:04.049Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Drew Gilbert grounds out, first baseman Luis García Jr. to pitcher Orlando Ribalta. Bryce Eldridge scores. Daniel Susac to 3rd."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687377,
+       "fullName": "Orlando Ribalta"
+      },
+      "batter": {
+       "id": 687551,
+       "fullName": "Drew Gilbert"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:17:55.441Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:18:44.152Z",
+       "details": {
+        "description": "Pitching Change: Orlando Ribalta replaces Paxton Schultz."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:20:09.323Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:20:31.544Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:20:42.483Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:21:00.228Z",
+       "details": {
+        "description": "Ball In Dirt"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:21:28.181Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Buddy Kennedy challenged (pitch result), call on the field was confirmed: Buddy Kennedy called out on strikes."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687377,
+       "fullName": "Orlando Ribalta"
+      },
+      "batter": {
+       "id": 671083,
+       "fullName": "Buddy Kennedy"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:22:19.367Z",
+       "details": {
+        "description": "Offensive Substitution: Pinch-hitter Buddy Kennedy replaces Jonah Cox."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:22:50.657Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:22:55.899Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:23:19.366Z",
+       "details": {
+        "description": "Wild pitch by pitcher Orlando Ribalta. Daniel Susac scores."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:23:33.445Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:24:02.575Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:24:22.203Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:24:50.696Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Casey Schmitt flies out to center fielder Jacob Young."
+     },
+     "about": {
+      "inning": 8,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 687377,
+       "fullName": "Orlando Ribalta"
+      },
+      "batter": {
+       "id": 669477,
+       "fullName": "Casey Schmitt"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:25:31.894Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "Curtis Mead homers (10) on a fly ball to left center field."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 678554,
+       "fullName": "Curtis Mead"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:27:47.397Z",
+       "details": {
+        "description": "Defensive switch from left field to center field for Drew Gilbert."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:27:47.399Z",
+       "details": {
+        "description": "Defensive Substitution: Eric Haase replaces Buddy Kennedy, batting 9th, playing left field."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:27:47.401Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:27:58.222Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:28:21.051Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:28:34.139Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:28:47.363Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:29:14.539Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:29:14.541Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "strikeout",
+      "description": "Luis García Jr. strikes out swinging."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 671277,
+       "fullName": "Luis García Jr."
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:29:50.046Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:29:59.786Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:30:10.808Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:30:23.327Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:30:36.451Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:30:51.092Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Dylan Crews lines out sharply to second baseman Luis Arraez."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 686611,
+       "fullName": "Dylan Crews"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:31:16.288Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:31:27.333Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Daylen Lile singles on a line drive to left fielder Eric Haase."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 695734,
+       "fullName": "Daylen Lile"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:31:55.811Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "field_out",
+      "description": "Jacob Young grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": true
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 665665,
+       "fullName": "Reiver Sanmartin"
+      },
+      "batter": {
+       "id": 696285,
+       "fullName": "Jacob Young"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:32:27.745Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:32:44.202Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:33:00.642Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:33:24.714Z",
+       "details": {
+        "description": "Giants challenged (tag play), call on the field was upheld: Daylen Lile steals (7) 2nd base."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:34:35.442Z",
+       "details": {
+        "description": "In play, out(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "double",
+      "description": "Luis Arraez doubles (14) on a fly ball to right fielder Dylan Crews."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 681402,
+       "fullName": "Gus Varland"
+      },
+      "batter": {
+       "id": 650333,
+       "fullName": "Luis Arraez"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:36:48.540Z",
+       "details": {
+        "description": "Pitching Change: Gus Varland replaces Orlando Ribalta."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:37:05.259Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:37:19.850Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:37:36.156Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:38:04.678Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "double",
+      "description": "Matt Chapman doubles (17) on a sharp fly ball to right fielder Dylan Crews. Luis Arraez scores."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 681402,
+       "fullName": "Gus Varland"
+      },
+      "batter": {
+       "id": 656305,
+       "fullName": "Matt Chapman"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:38:50.632Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:39:11.100Z",
+       "details": {
+        "description": "Swinging Strike"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:39:19.489Z",
+       "details": {
+        "description": "Batter Timeout."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:39:31.982Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "Rafael Devers walks."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 681402,
+       "fullName": "Gus Varland"
+      },
+      "batter": {
+       "id": 646240,
+       "fullName": "Rafael Devers"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:40:11.141Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:40:59.536Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:41:14.843Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:41:35.159Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:41:53.793Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:42:14.402Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:42:34.685Z",
+       "details": {
+        "description": "Ball"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "single",
+      "description": "Jung Hoo Lee singles on a ground ball to left fielder Daylen Lile. Matt Chapman to 3rd. Rafael Devers to 2nd."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 680730,
+       "fullName": "Mitchell Parker"
+      },
+      "batter": {
+       "id": 808982,
+       "fullName": "Jung Hoo Lee"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:43:02.921Z",
+       "details": {
+        "description": "Mound Visit."
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2026-06-10T22:43:33.485Z",
+       "details": {
+        "description": "Pitching Change: Mitchell Parker replaces Gus Varland."
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:45:28.403Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:45:45.101Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:46:12.985Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:46:37.949Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:47:00.648Z",
+       "details": {
+        "description": "In play, no out"
+       }
+      }
+     ]
+    },
+    {
+     "result": {
+      "eventType": "home_run",
+      "description": "Bryce Eldridge hits a grand slam (4) to right field. Matt Chapman scores. Rafael Devers scores. Jung Hoo Lee scores."
+     },
+     "about": {
+      "inning": 9,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 680730,
+       "fullName": "Mitchell Parker"
+      },
+      "batter": {
+       "id": 805811,
+       "fullName": "Bryce Eldridge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:47:41.076Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:48:01.023Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2026-06-10T22:48:18.988Z",
+       "details": {
+        "description": "In play, run(s)"
+       }
+      }
+     ]
+    }
+   ]
+  }
+ }
+}

--- a/annotator/tests/fixtures/gumbo_trailing_action.json
+++ b/annotator/tests/fixtures/gumbo_trailing_action.json
@@ -1,0 +1,83 @@
+{
+ "gamePk": 776815,
+ "gameData": {
+  "teams": {
+   "away": {
+    "name": "Houston Astros"
+   },
+   "home": {
+    "name": "New York Yankees"
+   }
+  }
+ },
+ "liveData": {
+  "plays": {
+   "allPlays": [
+    {
+     "result": {
+      "eventType": "walk",
+      "description": "Aaron Judge walks."
+     },
+     "about": {
+      "inning": 5,
+      "isTopInning": false
+     },
+     "matchup": {
+      "pitcher": {
+       "id": 664285,
+       "fullName": "Framber Valdez"
+      },
+      "batter": {
+       "id": 592450,
+       "fullName": "Aaron Judge"
+      }
+     },
+     "playEvents": [
+      {
+       "isPitch": true,
+       "startTime": "2025-08-09T19:29:46.855Z",
+       "details": {
+        "description": "Called Strike"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2025-08-09T19:30:01.456Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2025-08-09T19:30:22.524Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2025-08-09T19:30:45.078Z",
+       "details": {
+        "description": "Ball"
+       }
+      },
+      {
+       "isPitch": true,
+       "startTime": "2025-08-09T19:31:05.703Z",
+       "details": {
+        "description": "Foul"
+       }
+      },
+      {
+       "isPitch": false,
+       "startTime": "2025-08-09T19:31:29.307Z",
+       "details": {
+        "description": "Automatic Ball - Pitcher Pitch Timer Violation"
+       }
+      }
+     ]
+    }
+   ]
+  }
+ }
+}

--- a/annotator/tests/test_eval.py
+++ b/annotator/tests/test_eval.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -156,3 +157,100 @@ def test_a_feed_without_gameData_leaves_the_clubs_empty(events):
     must stay valid, with no club rather than a guessed one."""
     assert all(e.away_team == "" and e.home_team == "" for e in events)
     assert all(e.batting_team() == "" and e.pitching_team() == "" for e in events)
+
+
+# --- the outcome of a play, as structured data ------------------------------
+#
+# The outcome used to live only in the prose of `description`. Nothing could
+# select on it, so "who hit home runs? list every player" fell back to top-k
+# search over that prose and answered a "list every X" question from a partial
+# sample. `result.eventType` is the outcome the feed already types, so these
+# tests run on the real pilot game rather than on a shape invented here.
+#
+# Both fixtures are real statsapi payloads
+# (`/api/v1.1/game/{game_pk}/feed/live`), projected down to the fields
+# `parse_pitches` reads and otherwise unedited:
+#
+#   gumbo_823215.json         game 823215, the pilot game, all 84 plays
+#   gumbo_trailing_action.json game 776815, the one play in 8 games whose last
+#                             playEvent is not a pitch
+
+PILOT = Path(__file__).parent / "fixtures" / "gumbo_823215.json"
+TRAILING = Path(__file__).parent / "fixtures" / "gumbo_trailing_action.json"
+
+#: What game 823215 (Washington at San Francisco) actually holds. Counted from
+#: the live statsapi payload, then projected down to the fields the parser
+#: reads; nothing here is chosen, it is what the game was.
+PILOT_OUTCOMES = {
+    "field_out": 37, "single": 18, "strikeout": 13, "home_run": 6,
+    "walk": 5, "double": 4, "force_out": 1,
+}
+PILOT_PLAYS = 84
+PILOT_PITCHES = 344
+
+
+@pytest.fixture
+def pilot_events():
+    return ground_truth.parse_pitches(ground_truth.load_game(PILOT))
+
+
+def test_the_pilot_feed_types_every_outcome(pilot_events):
+    """The measurement this change rests on: the outcome is already structured
+    in the feed, for every play, with no prose parsing anywhere."""
+    assert len(pilot_events) == PILOT_PITCHES
+    outcomes = Counter(e.event_type for e in pilot_events if e.event_type)
+    assert dict(outcomes) == PILOT_OUTCOMES
+    assert sum(outcomes.values()) == PILOT_PLAYS  # one outcome per at-bat
+
+
+def test_only_the_pitch_that_ended_the_at_bat_carries_the_outcome(pilot_events):
+    """A 6 pitch at-bat is not 6 home runs. The outcome rides where the play
+    result text already rides: on the pitch that ended the at-bat."""
+    ended = [e for e in pilot_events if e.event_type]
+    assert len(ended) == PILOT_PLAYS
+    # The play result text is a sentence about the whole play ("... homers (9)
+    # on a fly ball ..."); a mid-at-bat pitch carries its own call instead.
+    assert all(e.description.endswith(".") for e in ended)
+    homers = [e for e in pilot_events if e.event_type == "home_run"]
+    assert len(homers) == 6
+    assert all("homer" in e.description or "grand slam" in e.description
+               for e in homers)
+
+
+def test_a_play_that_does_not_end_on_a_pitch_still_records_its_outcome():
+    """The `is_last` hazard, from a real game.
+
+    `ev is play["playEvents"][-1]` was evaluated after the loop had skipped
+    every non-pitch, so a play whose last playEvent is not a pitch marked NO
+    pitch as last. This fixture is that play, unedited: Aaron Judge walks on an
+    "Automatic Ball - Pitcher Pitch Timer Violation", which the feed records
+    with `isPitch: false`. One play in 594 across 8 games of 2025, so it is
+    rare and real, and each occurrence is an at-bat whose outcome no
+    structured query could reach.
+    """
+    events = ground_truth.parse_pitches(ground_truth.load_game(TRAILING))
+    assert events, "the fixture must hold pitches, or this proves nothing"
+    ended = [e for e in events if e.event_type]
+    assert [e.event_type for e in ended] == ["walk"]
+    assert ended[0] is events[-1]  # the last PITCH, not the last playEvent
+    assert ended[0].description == "Aaron Judge walks."
+
+
+def test_a_pitch_with_no_timestamp_cannot_end_an_at_bat():
+    """A pitch with no `startTime` is skipped, because it cannot be placed on
+    the video timeline. It must not take the outcome with it: the outcome moves
+    to the last pitch that a caller can actually reach."""
+    feed = _feed_with_clubs(top_inning=True)
+    play = feed["liveData"]["plays"]["allPlays"][0]
+    play["result"] = {"description": "B strikes out swinging.", "eventType": "strikeout"}
+    play["playEvents"].append({"isPitch": True, "details": {"description": "no time"}})
+    parsed = ground_truth.parse_pitches(feed)
+    assert len(parsed) == 1
+    assert parsed[0].event_type == "strikeout"
+    assert parsed[0].description == "B strikes out swinging."
+
+
+def test_a_feed_without_an_eventType_leaves_the_outcome_empty(events):
+    """Back-compat, and the reason every existing suite is untouched: the
+    shared fixture types no play, so it produces no outcome."""
+    assert all(e.event_type == "" for e in events)

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -14,10 +14,12 @@ from pathlib import Path
 
 import pytest
 
+from dirstral_annotator.eval import ground_truth
 from dirstral_annotator.eval.align import Anchor, estimate
 from dirstral_annotator.eval.ground_truth import PitchEvent
 from dirstral_annotator.eval.score import score
 from dirstral_annotator.fusion import fuse
+from dirstral_annotator.model import Player, slug_entity_id
 from dirstral_annotator.recognizers.playbyplay import PlayByPlayRecognizer
 from dirstral_annotator.roster import Roster
 
@@ -233,3 +235,200 @@ def test_a_club_name_that_slugs_to_nothing_is_dropped():
     assert team_id("") == ""
     assert team_id("   ") == ""
     assert team_id("!!!") == ""
+
+
+# --- the outcome of an at-bat is an event, not a sentence --------------------
+#
+# THE DEFECT. Asked "who hit home runs? list every player", the pilot answered
+# "Bryce Eldridge, Curtis Mead, Matt Chapman": it invented a player and dropped
+# one who really homered. It was not the model (mistral-large-latest gave the
+# same wrong list) and not retrieval depth (k=8, k=30 and k=50 all did). Each
+# span carried event="at_bat" and the outcome only inside the prose of the cue
+# text, so the `events` filter could not reach it, the question fell back to
+# top-k semantic search over prose, and a "list every X" question was answered
+# from a partial sample: 3 of 14 retrieved hits mentioned a homer, and one
+# hitter's chunk was never retrieved at all.
+#
+# The feed types every play. So the outcome becomes an event, and the question
+# becomes a selection instead of a sample.
+
+PILOT = Path(__file__).parent / "fixtures" / "gumbo_823215.json"
+
+#: Game 823215, Washington at San Francisco: what the feed records.
+PILOT_HOME_RUNS = 6
+PILOT_STRIKEOUTS = 13
+PILOT_HOME_RUN_HITTERS = {
+    "player:james-wood", "player:matt-chapman", "player:rafael-devers",
+    "player:curtis-mead", "player:bryce-eldridge",
+}
+
+
+@pytest.fixture
+def pilot_events():
+    return ground_truth.parse_pitches(ground_truth.load_game(PILOT))
+
+
+@pytest.fixture
+def pilot_roster(pilot_events):
+    """Both clubs, off the feed itself. The pilot roster covers both sides,
+    because a question about the game is not a question about one club."""
+    players, mlbam = [], {}
+    for ev in pilot_events:
+        for pid, name in ((ev.pitcher_id, ev.pitcher_name),
+                          (ev.batter_id, ev.batter_name)):
+            if pid and pid not in mlbam:
+                player = Player(id=slug_entity_id(name), name=name)
+                mlbam[pid] = player.id
+                players.append(player)
+    return Roster(players, mlbam)
+
+
+def _outcome(event_type, **kw):
+    """The last pitch of an at-bat: the one the feed types."""
+    fields = {
+        "game_pk": 1, "epoch_s": 1000.0,
+        "pitcher_id": OPP_PITCHER, "pitcher_name": "Opp Ace",
+        "batter_id": RAMOS, "batter_name": "Heliot Ramos",
+        "inning": 9, "top_inning": False,
+        "description": "Heliot Ramos homers (9) on a fly ball to center field.",
+        "event_type": event_type, **BOTH_CLUBS,
+    }
+    return PitchEvent(**{**fields, **kw})
+
+
+def test_the_outcome_becomes_its_own_event_keyed_on_the_batter(roster):
+    """The whole fix in one assertion: the outcome is selectable."""
+    cues = PlayByPlayRecognizer([_outcome("home_run")], 0.0, roster).recognize(MEDIA)
+    homer = next(c for c in cues if c.event == "home_run")
+    assert homer.entity_ids == ("player:ramos-heliot", "team:san-francisco-giants")
+    assert homer.start_s == 997.0 and homer.end_s == 1005.0  # the ending pitch
+
+
+def test_the_outcome_cue_reads_as_a_sentence(roster):
+    """`event` is the feed's exact token, so a filter can select it. The text
+    stays something a person reads, with the inning and both names, because it
+    is also the passage an answer quotes."""
+    cues = PlayByPlayRecognizer([_outcome("home_run")], 0.0, roster).recognize(MEDIA)
+    homer = next(c for c in cues if c.event == "home_run")
+    assert homer.text.startswith("Home run: Heliot Ramos vs Opp Ace")
+    assert "bottom of the 9th" in homer.text
+    assert "homers (9) on a fly ball" in homer.text
+    assert "Giants" not in homer.text  # the club stays an entity, as before
+
+
+def test_the_outcome_is_an_extra_cue_and_changes_no_existing_one(roster):
+    """THE CONTRACT. #620 was caused by retagging, so this change may only add.
+    The `pitch` and `at_bat` cues must be identical with and without it."""
+    with_outcome = PlayByPlayRecognizer(
+        [_outcome("home_run", pitcher_id=WEBB, pitcher_name="Logan Webb")],
+        0.0, roster,
+    ).recognize(MEDIA)
+    without = PlayByPlayRecognizer(
+        [_outcome("", pitcher_id=WEBB, pitcher_name="Logan Webb")], 0.0, roster
+    ).recognize(MEDIA)
+
+    assert [c.event for c in without] == ["pitch", "at_bat"]
+    assert [c.event for c in with_outcome] == ["pitch", "at_bat", "home_run"]
+    assert with_outcome[:2] == without  # byte-for-byte, entities and text too
+
+
+def test_a_pitch_that_does_not_end_the_at_bat_emits_no_outcome(roster):
+    """One at-bat is one outcome. A 6 pitch home run at-bat is not 6 homers."""
+    mid = _outcome("", description="Foul")  # a pitch inside the at-bat
+    cues = PlayByPlayRecognizer([mid], 0.0, roster).recognize(MEDIA)
+    assert [c.event for c in cues] == ["at_bat"]
+
+
+def test_an_unrostered_batter_gets_no_outcome_cue(roster):
+    """The outcome is the batter's, so it needs a batter to name. A rostered
+    pitcher facing an unrostered batter still emits his `pitch` cue."""
+    ev = _outcome("strikeout", pitcher_id=WEBB, pitcher_name="Logan Webb",
+                  batter_id=OPP_BATTER, batter_name="Opp Guy")
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert [c.event for c in cues] == ["pitch"]
+
+
+def test_an_outcome_of_whitespace_is_not_an_event(roster):
+    """An empty or blank `eventType` must not reach the wire as `event: ""`,
+    which no filter could select and no reader could understand."""
+    for blank in ("", "   "):
+        cues = PlayByPlayRecognizer([_outcome(blank)], 0.0, roster).recognize(MEDIA)
+        assert [c.event for c in cues] == ["at_bat"]
+
+
+def test_an_outcome_may_never_take_a_role_event_name(roster):
+    """The #620 guard. A batter-keyed cue tagged `pitch` would enter the
+    pitcher-keyed metric as a false positive. MLB types no play "pitch" or
+    "at_bat", so this cannot happen today; the metric must not depend on that
+    staying true."""
+    for stolen in ("pitch", "at_bat"):
+        ev = _outcome(stolen, pitcher_id=WEBB, pitcher_name="Logan Webb")
+        cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+        assert [c.event for c in cues] == ["pitch", "at_bat"]
+        assert cues[0].entity_ids[0] == "player:webb-logan"  # still the pitcher
+
+
+def test_the_outcome_label_spells_the_feeds_own_vocabulary():
+    from dirstral_annotator.recognizers.playbyplay import outcome_label
+    assert outcome_label("home_run") == "Home run"
+    assert outcome_label("strikeout") == "Strikeout"
+    assert outcome_label("field_out") == "Field out"
+    assert outcome_label("") == ""
+
+
+# --- the pilot game, whole --------------------------------------------------
+
+
+def test_every_home_run_in_the_pilot_game_is_selectable(pilot_events, pilot_roster):
+    """The question that failed, answered by selection instead of by sample.
+
+    Six home runs, five hitters, off the real feed. No prose is matched
+    anywhere: the list comes from `event == "home_run"` alone.
+    """
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    homers = [c for c in cues if c.event == "home_run"]
+    assert len(homers) == PILOT_HOME_RUNS
+    hitters = {c.entity_ids[0] for c in homers}
+    assert hitters == PILOT_HOME_RUN_HITTERS
+    strikeouts = [c for c in cues if c.event == "strikeout"]
+    assert len(strikeouts) == PILOT_STRIKEOUTS
+
+
+def test_the_pilot_game_emits_one_outcome_per_at_bat(pilot_events, pilot_roster):
+    """84 plays, 344 pitches: the outcomes must count the plays, not the
+    pitches, or every long at-bat would be reported several times over."""
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    counted = {"pitch": 0, "at_bat": 0}
+    outcomes = 0
+    for cue in cues:
+        if cue.event in counted:
+            counted[cue.event] += 1
+        else:
+            outcomes += 1
+    assert counted == {"pitch": 344, "at_bat": 344}
+    assert outcomes == 84
+
+
+def test_the_phase_1_metric_does_not_move(pilot_events, pilot_roster):
+    """The pitcher-keyed metric reads `event == "pitch"` alone, so it cannot
+    see the outcome cues. Measured here on the whole pilot game rather than
+    argued: the scorecards are equal, term by term."""
+    alignment = estimate([Anchor(pilot_events[0].epoch_s, 60.0)])
+    cues = PlayByPlayRecognizer(
+        pilot_events, alignment.offset_s, pilot_roster
+    ).recognize(MEDIA)
+    before = [c for c in cues if c.event in ("pitch", "at_bat")]
+    assert len(cues) > len(before)  # the outcome cues are really there
+
+    after_card = score(fuse(cues), pilot_events, alignment, pilot_roster)
+    before_card = score(fuse(before), pilot_events, alignment, pilot_roster)
+
+    assert after_card.total_events == before_card.total_events == 344
+    assert vars(after_card.overall) == vars(before_card.overall)
+    assert after_card.per_source_found == before_card.per_source_found
+    assert dict(after_card.per_player) == dict(before_card.per_player)
+    # The two misses are two pitches thrown inside the fusion merge gap, which
+    # this change does not touch: the same two miss before it. What matters is
+    # that the number is the same one, and that no outcome cue became a false
+    # positive.
+    assert after_card.overall.tp == 342 and after_card.overall.fp == 0


### PR DESCRIPTION
## The defect

Asked "Who hit home runs? List every player", the pilot answered **"Bryce Eldridge, Curtis Mead, Matt Chapman"**. It named a player who did not homer in the indexed material, and it dropped one who did (Rafael Devers).

It is not the model: `mistral-large-latest` returns the identical wrong list, and its invented strikeout count changes from run to run (4, then 5). It is not retrieval depth: k=8, k=30 and k=50 all return the same wrong answer.

The outcome of a play is not structured data. Each span carries:

```json
{"entities": ["player:dylan-crews", "team:washington-nationals"], "event": "at_bat"}
```

`event` is only `at_bat` or `pitch`. The outcome (homers, strikeout, walk) exists only inside the free-text `description`. So the `events` filter of `dir2mcp_search` cannot reach it, the question falls back to top-k semantic search over prose, and a "list every X" question is answered from a partial sample. For the failing question, 3 of 14 retrieved hits mentioned a homer, and one hitter's chunk was never retrieved.

## The fix

The MLB GUMBO feed already types every play. Game 823215, verified on the live payload:

| `result.eventType` | count |
|---|---|
| field_out | 37 |
| single | 18 |
| strikeout | 13 |
| home_run | 6 |
| walk | 5 |
| double | 4 |
| force_out | 1 |

So the change reads `result.eventType`. No prose is matched anywhere.

1. **`eval/ground_truth.py`**: `PitchEvent` gains `event_type`. It carries the feed's token verbatim, and only on the pitch that ENDED the at-bat, exactly where `description` already carries the play result text. One at-bat therefore produces one outcome, not one per pitch.
2. **`recognizers/playbyplay.py`**: the pitch that ends an at-bat emits a third cue. Its `event` is the feed's token and it is keyed on the batter plus the club at the plate, because the outcome is the batter's. The text stays a sentence a person reads.

## The new event vocabulary

| `event` | Keyed on | Emitted for |
|---|---|---|
| `pitch` (unchanged) | the pitcher, plus the fielding club | every pitch a rostered pitcher threw |
| `at_bat` (unchanged) | the batter, plus the club at the plate | every pitch a rostered batter faced |
| the feed's `result.eventType`: `home_run`, `strikeout`, `walk`, `single`, `double`, `field_out`, `force_out`, ... (new) | the batter, plus the club at the plate | the pitch that ended the at-bat |

The vocabulary is MLB's own, not one this backend invents, so a client selects the real thing with `events: ["home_run"]`. The design 0004 wire schema calls `event` a "producer-defined event vocabulary ... not enumerated by the contract", so no spec change is needed.

The three cues share one time span, so the answer path groups them into one moment (#784) and counts one event once.

## The existing metric is unaffected

The change is purely additive. `pitch` and `at_bat` keep their event, their entities, their text, their span and their confidence. `eval.score` reads `event == "pitch"` alone (`SCORED_EVENT`), so it cannot see the new cues.

That is measured, not argued. `test_the_phase_1_metric_does_not_move` scores the whole pilot game twice, once with the outcome cues and once with them filtered out:

```
total_events 344 == 344
overall      PRCount(tp=342, fn=2, fp=0) == PRCount(tp=342, fn=2, fp=0)
per_player   equal
per_source   {'playbyplay': 342} == {'playbyplay': 342}
```

(The two misses are two pitches thrown inside the fusion merge gap. They miss before this change as well, which is what the equality shows.)

`test_the_outcome_is_an_extra_cue_and_changes_no_existing_one` pins the same rule at cue level: with and without an outcome, the first two cues compare equal, entities and text included.

A guard also refuses an outcome that ever takes the name `pitch` or `at_bat`. MLB types no play that way, so it should never fire; it means the pitcher-keyed metric does not depend on a third party's vocabulary staying as it is. Retagging is what caused #620.

## `is_last`

`is_last` was `ev is play["playEvents"][-1]`, and the loop skips every non-pitch BEFORE that test. So a play whose final `playEvent` is not a pitch marks no pitch as last.

**On the pilot feed it never fires.** All 84 plays of game 823215 end on a pitch, and all 344 pitches carry a `startTime`.

**In the wild it does.** A survey of 8 further games of the 2025 season (594 plays) found one occurrence: Aaron Judge walks on an "Automatic Ball - Pitcher Pitch Timer Violation", which the feed records with `isPitch: false`. Against the old parser, that play's result text reached no pitch at all:

```
pitches parsed: 5
    Called Strike
    Ball
    Ball
    Ball
    Foul
any pitch carrying the play result text 'Aaron Judge walks.': False
```

The outcome would have reached none either, so the walk would be invisible to a structured query. It is fixed: `_last_recorded_pitch` marks the last playEvent that is both a pitch and has a `startTime`. That also covers a final pitch with no timestamp, which the parse skips and which therefore must not carry the outcome away with it. After the fix, the same probe prints `Aaron Judge walks.` on the fifth pitch and `True`.

## Tests

15 new tests. Every one fails before this change and passes after it:

```
FAILED tests/test_playbyplay.py::test_the_outcome_becomes_its_own_event_keyed_on_the_batter
FAILED tests/test_playbyplay.py::test_the_outcome_cue_reads_as_a_sentence
FAILED tests/test_playbyplay.py::test_the_outcome_is_an_extra_cue_and_changes_no_existing_one
FAILED tests/test_playbyplay.py::test_a_pitch_that_does_not_end_the_at_bat_emits_no_outcome
FAILED tests/test_playbyplay.py::test_an_unrostered_batter_gets_no_outcome_cue
FAILED tests/test_playbyplay.py::test_an_outcome_of_whitespace_is_not_an_event
FAILED tests/test_playbyplay.py::test_the_outcome_label_spells_the_feeds_own_vocabulary
FAILED tests/test_playbyplay.py::test_every_home_run_in_the_pilot_game_is_selectable
FAILED tests/test_playbyplay.py::test_the_pilot_game_emits_one_outcome_per_at_bat
FAILED tests/test_playbyplay.py::test_the_phase_1_metric_does_not_move
FAILED tests/test_eval.py::test_the_pilot_feed_types_every_outcome
FAILED tests/test_eval.py::test_only_the_pitch_that_ended_the_at_bat_carries_the_outcome
FAILED tests/test_eval.py::test_a_play_that_does_not_end_on_a_pitch_still_records_its_outcome
FAILED tests/test_eval.py::test_a_pitch_with_no_timestamp_cannot_end_an_at_bat
FAILED tests/test_eval.py::test_a_feed_without_an_eventType_leaves_the_outcome_empty
15 failed, 24 passed
```

(`test_an_outcome_may_never_take_a_role_event_name` was added afterwards, with the guard it covers, so it is the 16th.)

The headline test answers the question that failed, by selection instead of by sample:

```python
homers = [c for c in cues if c.event == "home_run"]
assert len(homers) == 6
assert {c.entity_ids[0] for c in homers} == {
    "player:james-wood", "player:matt-chapman", "player:rafael-devers",
    "player:curtis-mead", "player:bryce-eldridge",
}
assert len([c for c in cues if c.event == "strikeout"]) == 13
```

## Fixtures

Both new fixtures are real statsapi payloads (`/api/v1.1/game/{game_pk}/feed/live`), projected down to the fields `parse_pitches` reads and otherwise unedited:

- `gumbo_823215.json`: the pilot game, all 84 plays, all 344 pitches.
- `gumbo_trailing_action.json`: game 776815, the one play in 594 whose last playEvent is not a pitch.

The shared `gumbo_min.json` types no play, so it produces no outcome, which is why every existing suite is untouched.

## Gates

- `make check`: pass (Go plus the annotator suite, 335 passed).
- `coderabbit review --include-untracked`: 0 findings.

Note: this worktree needed `git submodule update --init` for `tests/security` and the schema-agreement test; the submodule pointer is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured at-bat outcome cues, including readable labels, batter and team details, timing, and confidence.
  * Outcomes are assigned to the pitch that ends each at-bat and can be filtered as selectable events.
  * Added support for outcomes such as home runs, strikeouts, walks, and other play results.

* **Documentation**
  * Updated documentation to explain outcome cues, shared timing, and pitch metric handling.

* **Bug Fixes**
  * Improved handling of trailing, untimestamped, incomplete, or missing outcome data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->