### PR TITLE
fix(retrieval): apply the recognition entity and event filters on every retrieval path (#856)

### DIFF
--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -196,9 +196,7 @@ func (s *Service) selectLexicalCandidates(
 // entity/event (design 0004 §7) predicates read.
 func (s *Service) hydrateLexicalHit(indexKind string, hit model.SearchHit) model.SearchHit {
 	cached := s.searchHitForLabel(indexKind, hit.ChunkID)
-	if cached.Span.Kind != "" {
-		hit.Span = cached.Span
-	}
+	hit.Span = resolveLexicalSpan(hit.Span, cached.Span)
 	if hit.RepType == "" {
 		hit.RepType = cached.RepType
 	}
@@ -212,6 +210,34 @@ func (s *Service) hydrateLexicalHit(indexKind string, hit model.SearchHit) model
 		hit.MTimeUnix = cached.MTimeUnix
 	}
 	return hit
+}
+
+// resolveLexicalSpan merges a lexical hit's span with the cached one.
+//
+// The cached span wins when it exists, as it always has: it is the span row the
+// vector path cites, so a chunk localizes to the same place whichever retriever
+// found it. One exception keeps the filter honest: when the cached span carries
+// no recognition attribution and the lexical span does, the attribution is
+// carried across. A candidate must never be judged against attribution it does
+// not have but its chunk does, because a non-empty filter rejects an
+// attribution-less span by design and the hit would be dropped for the wrong
+// reason (issue #856).
+func resolveLexicalSpan(lexical, cached model.Span) model.Span {
+	if cached.Kind == "" {
+		return lexical
+	}
+	resolved := cached
+	if !spanHasAttribution(resolved) && spanHasAttribution(lexical) {
+		resolved.Entities = lexical.Entities
+		resolved.Event = lexical.Event
+	}
+	return resolved
+}
+
+// spanHasAttribution reports whether a span carries a recognition annotation's
+// entity ids or event (design 0004 §7).
+func spanHasAttribution(span model.Span) bool {
+	return len(span.Entities) > 0 || strings.TrimSpace(span.Event) != ""
 }
 
 // rerankFusionPoolSize returns how many fused candidates to keep before the

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -216,28 +216,28 @@ func (s *Service) hydrateLexicalHit(indexKind string, hit model.SearchHit) model
 //
 // The cached span wins when it exists, as it always has: it is the span row the
 // vector path cites, so a chunk localizes to the same place whichever retriever
-// found it. One exception keeps the filter honest: when the cached span carries
-// no recognition attribution and the lexical span does, the attribution is
-// carried across. A candidate must never be judged against attribution it does
-// not have but its chunk does, because a non-empty filter rejects an
-// attribution-less span by design and the hit would be dropped for the wrong
-// reason (issue #856).
+// found it. One exception keeps the filter honest: an attribution field the
+// cached span lacks is taken from the lexical span. A candidate must never be
+// judged against attribution it does not have but its chunk does, because a
+// non-empty filter rejects an attribution-less span by design and the hit would
+// be dropped for the wrong reason (issue #856).
+//
+// The two fields are merged INDEPENDENTLY. `entities` and `event` are separate
+// predicates that are ANDed, so a cached span that carries the ids but not the
+// event would otherwise lose the event and fail an `events` filter its chunk
+// satisfies.
 func resolveLexicalSpan(lexical, cached model.Span) model.Span {
 	if cached.Kind == "" {
 		return lexical
 	}
 	resolved := cached
-	if !spanHasAttribution(resolved) && spanHasAttribution(lexical) {
+	if len(resolved.Entities) == 0 {
 		resolved.Entities = lexical.Entities
+	}
+	if strings.TrimSpace(resolved.Event) == "" {
 		resolved.Event = lexical.Event
 	}
 	return resolved
-}
-
-// spanHasAttribution reports whether a span carries a recognition annotation's
-// entity ids or event (design 0004 §7).
-func spanHasAttribution(span model.Span) bool {
-	return len(span.Entities) > 0 || strings.TrimSpace(span.Event) != ""
 }
 
 // rerankFusionPoolSize returns how many fused candidates to keep before the

--- a/internal/retrieval/hybrid.go
+++ b/internal/retrieval/hybrid.go
@@ -3,6 +3,7 @@ package retrieval
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/dirstral/dir2mcp/internal/model"
 )
@@ -95,11 +96,18 @@ func fuseRRFMulti(lists [][]model.SearchHit, k int) []model.SearchHit {
 // Errors from the BM25 path are deliberately swallowed and trigger a
 // vector-only fallback rather than failing the search outright. This keeps
 // hybrid retrieval an optimization, not a hard dependency.
+//
+// filters are the query's candidate predicates. They MUST be applied to the
+// lexical candidates too (issue #856): the vector path filters its own
+// candidates in collectFilteredHits, so a filter evaluated only there was
+// undone here — fusion added back candidates no predicate had judged, and a
+// filter that selected nothing still returned the whole BM25 pool.
 func (s *Service) runHybridSearch(
 	ctx context.Context,
 	query string,
 	k int,
 	indexKind string,
+	filters model.SearchQuery,
 	vectorHits []model.SearchHit,
 ) ([]model.SearchHit, bool) {
 	s.metaMu.RLock()
@@ -129,22 +137,11 @@ func (s *Service) runHybridSearch(
 	if len(bm25Hits) == 0 {
 		return vectorHits, true
 	}
-	// Re-attach cached metadata to BM25 hits for fields the FTS query did
-	// not populate (Span, etc.). The vector path already merges metadata via
-	// searchHitForLabel, so we use the same path here for parity.
-	for i, h := range bm25Hits {
-		cached := s.searchHitForLabel(indexKind, h.ChunkID)
-		// Preserve BM25's score and snippet; pull in the better Span and any
-		// other fields the lexical query left unset.
-		if cached.Span.Kind != "" {
-			bm25Hits[i].Span = cached.Span
-		}
-		if bm25Hits[i].RepType == "" {
-			bm25Hits[i].RepType = cached.RepType
-		}
-		if bm25Hits[i].DocType == "" || bm25Hits[i].DocType == "unknown" {
-			bm25Hits[i].DocType = cached.DocType
-		}
+	lexicalHits := s.selectLexicalCandidates(indexKind, bm25Hits, filters)
+	if len(lexicalHits) == 0 {
+		// Every lexical candidate was filtered out. Return the vector candidates
+		// alone, exactly as an empty BM25 result does above.
+		return vectorHits, true
 	}
 	// Fuse into a candidate pool sized for the downstream rerank stage, not just
 	// the final k. Truncating fusion to k here would defeat the over-fetch pool
@@ -152,7 +149,69 @@ func (s *Service) runHybridSearch(
 	// never rescue a relevant chunk fused at rank k+1..pool. The caller truncates
 	// to k when rerank is disabled, so the wider pool is harmless there. This
 	// mirrors the HyDE path, which already fuses to hybridCandidatePoolSize.
-	return fuseRRF(vectorHits, bm25Hits, rerankFusionPoolSize(k, rerankPool)), true
+	return fuseRRF(vectorHits, lexicalHits, rerankFusionPoolSize(k, rerankPool)), true
+}
+
+// selectLexicalCandidates hydrates each BM25 candidate from the in-memory chunk
+// metadata and then keeps only the candidates the query's predicates admit. It
+// is the lexical half of candidate selection, and the counterpart of
+// collectFilteredHits on the vector side.
+//
+// Order matters: hydrate first, filter second. matchFilters judges a candidate
+// on the metadata the candidate carries, so a lexical retriever that returns no
+// span, language or mtime would otherwise be judged against absent values and
+// every one of its hits would be dropped by an active filter. Hydration is a
+// map lookup per candidate against metadata the service already holds, so it
+// adds no query and no I/O.
+//
+// The candidate pool is the BM25 top-N for the query text, filtered. A highly
+// selective filter may therefore leave the lexical contribution empty, which
+// costs no recall relative to a vector-only search: the vector path runs its own
+// widening overfetch loop against the same filter.
+func (s *Service) selectLexicalCandidates(
+	indexKind string,
+	bm25Hits []model.SearchHit,
+	filters model.SearchQuery,
+) []model.SearchHit {
+	out := make([]model.SearchHit, 0, len(bm25Hits))
+	for _, hit := range bm25Hits {
+		hydrated := s.hydrateLexicalHit(indexKind, hit)
+		if !matchFilters(hydrated, filters) {
+			continue
+		}
+		out = append(out, hydrated)
+	}
+	return out
+}
+
+// hydrateLexicalHit re-attaches cached metadata to one BM25 hit for the fields
+// the lexical query did not populate. The vector path merges metadata via
+// searchHitForLabel, so the same source is used here for parity.
+//
+// BM25's own score and snippet are preserved. The span, the representation and
+// document types, the recorded language and the document's calendar anchor are
+// pulled from the cache when the lexical hit lacks them; those last two are what
+// the language (SPEC §9.5) and date-window (§9.6) predicates read, and the span
+// is what the speaker (§8.6.8), media time-window (§9.8) and recognition
+// entity/event (design 0004 §7) predicates read.
+func (s *Service) hydrateLexicalHit(indexKind string, hit model.SearchHit) model.SearchHit {
+	cached := s.searchHitForLabel(indexKind, hit.ChunkID)
+	if cached.Span.Kind != "" {
+		hit.Span = cached.Span
+	}
+	if hit.RepType == "" {
+		hit.RepType = cached.RepType
+	}
+	if hit.DocType == "" || hit.DocType == "unknown" {
+		hit.DocType = cached.DocType
+	}
+	if strings.TrimSpace(hit.Language) == "" {
+		hit.Language = cached.Language
+	}
+	if hit.MTimeUnix == 0 {
+		hit.MTimeUnix = cached.MTimeUnix
+	}
+	return hit
 }
 
 // rerankFusionPoolSize returns how many fused candidates to keep before the

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -2767,7 +2767,7 @@ func (s *Service) searchSingleIndex(ctx context.Context, query string, k int, mo
 	if err != nil {
 		return nil, err
 	}
-	if fused, ok := s.runHybridSearch(ctx, query, k, indexName, filtered); ok {
+	if fused, ok := s.runHybridSearch(ctx, query, k, indexName, filters, filtered); ok {
 		fused = dedupMediaCandidates(fused)
 		fused = s.dedupCrossFileCandidates(fused)
 		if allowRerank {

--- a/tests/mcp/entity_filter_end_to_end_856_test.go
+++ b/tests/mcp/entity_filter_end_to_end_856_test.go
@@ -1,0 +1,234 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// The recognition entity/event filter END TO END (issue #856, dirstral-spec
+// design 0004 §7): a real SQLite store (spans + FTS), a real vector index, the
+// real retrieval service, and the two tools that advertise the parameters.
+//
+// tests/mcp/search_entity_filter_test.go pins that the arguments reach the
+// query. It uses a retriever stub, so it cannot see whether anything applies
+// them. This file closes that gap on the production chain, where #856 lived:
+// the lexical candidates were fused back in unfiltered, so a filter value that
+// matches nothing still returned the whole BM25 pool.
+
+const filterEndToEndVectorDim = 2
+
+// staticEmbedder returns one fixed query vector, so ranking is constant and a
+// missing hit can only be the filter's work.
+type staticEmbedder struct{}
+
+func (staticEmbedder) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	out := make([][]float32, 0, len(texts))
+	for range texts {
+		out = append(out, []float32{1, 0})
+	}
+	return out, nil
+}
+
+// annotationCorpus seeds one video document with two recognition annotations
+// (one home run, one pitch) plus a text note that mentions "home run" in prose
+// but carries no attribution. The note is the candidate that must NOT survive an
+// event filter, and BM25 ranks it highly for the query text.
+func annotationCorpus(t *testing.T, st *store.SQLiteStore) map[string]uint64 {
+	t.Helper()
+	ctx := context.Background()
+	ids := make(map[string]uint64, 3)
+
+	seed := func(relPath, docType, repType, text string, span model.Span) uint64 {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: relPath, DocType: docType, SourceType: "local", Status: "ok",
+		}); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", relPath, err)
+		}
+		doc, err := st.GetDocumentByPath(ctx, relPath)
+		if err != nil {
+			t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+		}
+		repID, err := st.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: repType, RepHash: relPath + repType, CreatedUnix: 1,
+		})
+		if err != nil {
+			t.Fatalf("UpsertRepresentation(%s): %v", relPath, err)
+		}
+		chunkID, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: text,
+			IndexKind: "text", EmbeddingStatus: "ok",
+		}, []model.Span{span})
+		if err != nil {
+			t.Fatalf("InsertChunkWithSpans(%s): %v", relPath, err)
+		}
+		return uint64(chunkID)
+	}
+
+	ids["home_run"] = seed("game.mp4", "video", "recognition",
+		"Heliot Ramos hits a home run to left field",
+		model.Span{
+			Kind: "time", StartMS: 3346398, EndMS: 3354398,
+			Entities: []string{"player:heliot-ramos", "team:san-francisco-giants"},
+			Event:    "home_run",
+		})
+	ids["pitch"] = seed("game2.mp4", "video", "recognition",
+		"Logan Webb throws a pitch to the plate",
+		model.Span{
+			Kind: "time", StartMS: 120000, EndMS: 128000,
+			Entities: []string{"player:logan-webb", "team:san-francisco-giants"},
+			Event:    "pitch",
+		})
+	ids["note"] = seed("notes.md", "md", "raw_text",
+		"match report: the home run in the seventh decided the game",
+		model.Span{Kind: "lines", StartLine: 1, EndLine: 2})
+	return ids
+}
+
+// entityFilterServer wires the production chain: the store serves BM25 and the
+// warm-load metadata, the vector index serves dense candidates, and the MCP
+// server serves both tools over HTTP.
+func entityFilterServer(t *testing.T) (*httptest.Server, config.Config, map[string]uint64) {
+	t.Helper()
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ids := annotationCorpus(t, st)
+
+	idx := index.NewHNSWIndex("")
+	svc := retrieval.NewService(st, idx, staticEmbedder{}, nil)
+
+	// The daemon's warm-load path: read each embedded chunk's metadata back out
+	// of the store and register it, then index its vector. Attribution therefore
+	// reaches the filter exactly the way it does after a restart.
+	tasks, err := st.ListEmbeddedChunkMetadata(ctx, "text", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata: %v", err)
+	}
+	if len(tasks) != len(ids) {
+		t.Fatalf("warm load returned %d chunks, want %d", len(tasks), len(ids))
+	}
+	for i, task := range tasks {
+		meta := task.Metadata
+		vec := make([]float32, filterEndToEndVectorDim)
+		vec[0] = 1
+		vec[1] = float32(i) / 1000
+		if err := idx.Upsert(ctx, vec, model.IndexPayload{
+			ChunkID: meta.ChunkID, RelPath: meta.RelPath, DocType: meta.DocType,
+			RepType: meta.RepType, Span: meta.Span,
+			StartMS: meta.Span.StartMS, EndMS: meta.Span.EndMS,
+		}); err != nil {
+			t.Fatalf("Upsert(%d): %v", meta.ChunkID, err)
+		}
+		svc.SetChunkMetadata(meta.ChunkID, meta.ToSearchHit())
+	}
+
+	cfg := config.Default()
+	cfg.StateDir = tmp
+	cfg.MCPPath = protocol.DefaultMCPPath
+	cfg.AuthMode = "none"
+	srv := httptest.NewServer(mcp.NewServer(cfg, svc, mcp.WithStore(st)).Handler())
+	t.Cleanup(srv.Close)
+	return srv, cfg, ids
+}
+
+// callToolHitIDs calls one tool and returns the chunk ids of its hits, sorted.
+func callToolHitIDs(t *testing.T, srv *httptest.Server, cfg config.Config, toolName, arguments string) []uint64 {
+	t.Helper()
+	sessionID := initializeSession(t, srv.URL+cfg.MCPPath)
+	resp := postRPC(t, srv.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"`+toolName+`","arguments":`+arguments+`}}`)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status=%d body=%s", toolName, resp.StatusCode, body)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool `json:"isError"`
+			StructuredContent struct {
+				Hits []struct {
+					ChunkID uint64 `json:"chunk_id"`
+				} `json:"hits"`
+			} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("%s: decode: %v body=%s", toolName, err, body)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("%s returned an error result: %s", toolName, body)
+	}
+	out := make([]uint64, 0, len(envelope.Result.StructuredContent.Hits))
+	for _, hit := range envelope.Result.StructuredContent.Hits {
+		out = append(out, hit.ChunkID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// TestBothToolsReturnNoHitsForAnImpossibleEvent is the #856 reproduction on the
+// wire: the query text matches every chunk lexically, and the filter admits
+// none of them.
+func TestBothToolsReturnNoHitsForAnImpossibleEvent(t *testing.T) {
+	srv, cfg, _ := entityFilterServer(t)
+	cases := []struct {
+		tool string
+		args string
+	}{
+		{"dir2mcp_search", `{"query":"home run","events":["no_such_event_xyz"],"k":20}`},
+		{"dir2mcp_search", `{"query":"home run","entities":["player:nobody-at-all"],"k":20}`},
+		{"dir2mcp_ask", `{"question":"who hit home runs?","events":["no_such_event_xyz"],"k":20}`},
+		{"dir2mcp_ask", `{"question":"who hit home runs?","entities":["player:nobody-at-all"],"k":20}`},
+	}
+	for _, tc := range cases {
+		if got := callToolHitIDs(t, srv, cfg, tc.tool, tc.args); len(got) != 0 {
+			t.Fatalf("%s %s returned hits %v; a value that matches nothing must return none", tc.tool, tc.args, got)
+		}
+	}
+}
+
+// TestBothToolsSelectOnlyTheMatchingAnnotation pins the other direction: the
+// event selects its own annotation and nothing else, even though the prose note
+// is the better lexical match for the query text.
+func TestBothToolsSelectOnlyTheMatchingAnnotation(t *testing.T) {
+	srv, cfg, ids := entityFilterServer(t)
+	want := []uint64{ids["home_run"]}
+	for _, tc := range []struct{ tool, args string }{
+		{"dir2mcp_search", `{"query":"home run","events":["home_run"],"k":20}`},
+		{"dir2mcp_ask", `{"question":"who hit home runs?","events":["home_run"],"k":20}`},
+	} {
+		got := callToolHitIDs(t, srv, cfg, tc.tool, tc.args)
+		if len(got) != 1 || got[0] != want[0] {
+			t.Fatalf("%s %s = %v, want %v (the annotation only)", tc.tool, tc.args, got, want)
+		}
+	}
+}
+
+// TestAnUnfilteredCallStillReturnsEveryChunk is the compatibility guard: the fix
+// removes candidates only when a filter asks for it.
+func TestAnUnfilteredCallStillReturnsEveryChunk(t *testing.T) {
+	srv, cfg, ids := entityFilterServer(t)
+	got := callToolHitIDs(t, srv, cfg, "dir2mcp_search", `{"query":"home run","k":20}`)
+	if len(got) != len(ids) {
+		t.Fatalf("unfiltered search returned %v, want all %d chunks", got, len(ids))
+	}
+}

--- a/tests/retrieval/annotation_filter_lexical_856_test.go
+++ b/tests/retrieval/annotation_filter_lexical_856_test.go
@@ -256,6 +256,34 @@ func TestAnAbsentFilterStillFusesEveryLexicalCandidate(t *testing.T) {
 	}
 }
 
+// TestALexicalCandidateIsJudgedOnTheAttributionItCarries is the other direction
+// of the same bug: the filter must never judge a candidate against attribution
+// the candidate does not carry but its chunk does. Here the in-memory metadata
+// predates the attribution (an older indexing run) while the live lexical read
+// has it, so a matching filter must still admit the candidate.
+func TestALexicalCandidateIsJudgedOnTheAttributionItCarries(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	attributed := annotationHit(1, homeRun, []string{hrBatterID, sfgID})
+
+	// The cached metadata for the same chunk holds the span bounds only.
+	stale := attributed
+	stale.Span = model.Span{Kind: "time", StartMS: attributed.Span.StartMS, EndMS: attributed.Span.EndMS}
+	addAnnotationVector(t, idx, stale)
+
+	st := &lexicalHitStore{hits: []model.SearchHit{attributed}}
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(stale.ChunkID, stale)
+
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{homeRun}}); !sameIDs(got, []uint64{1}) {
+		t.Fatalf("events=[home_run] = %v, want [1]; the lexical candidate carries that event", got)
+	}
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{"no_such_event_xyz"}}); len(got) != 0 {
+		t.Fatalf("events=[no_such_event_xyz] = %v, want none", got)
+	}
+}
+
 // TestAskAppliesTheFilterAndCitesOnlyMatches covers the second tool that
 // advertises the parameters. `ask` is the surface the pilot uses, and a citation
 // to a filtered-out chunk is a confident wrong answer.

--- a/tests/retrieval/annotation_filter_lexical_856_test.go
+++ b/tests/retrieval/annotation_filter_lexical_856_test.go
@@ -284,6 +284,64 @@ func TestALexicalCandidateIsJudgedOnTheAttributionItCarries(t *testing.T) {
 	}
 }
 
+// TestAPartlyAttributedCacheKeepsTheLexicalEvent pins the INDEPENDENT merge of
+// the two attribution fields. `entities` and `events` are separate predicates
+// that are ANDed, so a cached span that holds the ids but not the event must
+// still be judged on the event the live lexical read carries.
+func TestAPartlyAttributedCacheKeepsTheLexicalEvent(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	attributed := annotationHit(1, homeRun, []string{hrBatterID, sfgID})
+
+	// The cached span carries the ids and no event.
+	partial := attributed
+	partial.Span = model.Span{
+		Kind: "time", StartMS: attributed.Span.StartMS, EndMS: attributed.Span.EndMS,
+		Entities: []string{hrBatterID, sfgID},
+	}
+	addAnnotationVector(t, idx, partial)
+
+	st := &lexicalHitStore{hits: []model.SearchHit{attributed}}
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	svc.SetChunkMetadata(partial.ChunkID, partial)
+
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{
+		Entities: []string{hrBatterID}, Events: []string{homeRun},
+	}); !sameIDs(got, []uint64{1}) {
+		t.Fatalf("entities=[batter] events=[home_run] = %v, want [1]; the cached ids must not erase the event", got)
+	}
+}
+
+// TestALexicalOnlyCorpusReturnsTheFilteredSet is the third path in isolation: the
+// vector index holds nothing, so every candidate comes from BM25. The zero-hit
+// assertion must hold here as well, or the answer depends on which retriever ran.
+func TestALexicalOnlyCorpusReturnsTheFilteredSet(t *testing.T) {
+	idx := index.NewHNSWIndex("")
+	hits := []model.SearchHit{
+		annotationHit(1, homeRun, []string{hrBatterID, sfgID}),
+		annotationHit(2, homeRun, []string{hrBatterID, sfgID}),
+		annotationHit(3, "pitch", []string{hrPitcherID, sfgID}),
+	}
+	st := &lexicalHitStore{hits: hits}
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for _, hit := range hits {
+		svc.SetChunkMetadata(hit.ChunkID, hit)
+	}
+
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{"no_such_event_xyz"}}); len(got) != 0 {
+		t.Fatalf("lexical-only search with an impossible event returned %v, want none", got)
+	}
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Entities: []string{"player:nobody-at-all"}}); len(got) != 0 {
+		t.Fatalf("lexical-only search with an impossible entity returned %v, want none", got)
+	}
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{homeRun}}); !sameIDs(got, []uint64{1, 2}) {
+		t.Fatalf("lexical-only search with events=[home_run] = %v, want [1 2]", got)
+	}
+}
+
 // TestAskAppliesTheFilterAndCitesOnlyMatches covers the second tool that
 // advertises the parameters. `ask` is the surface the pilot uses, and a citation
 // to a filtered-out chunk is a confident wrong answer.

--- a/tests/retrieval/annotation_filter_lexical_856_test.go
+++ b/tests/retrieval/annotation_filter_lexical_856_test.go
@@ -1,0 +1,292 @@
+package tests
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// The recognition entity/event filter on the LEXICAL and FUSED paths (issue
+// #856, dirstral-spec design 0004 §7).
+//
+// tests/retrieval/annotation_entity_filter_test.go pins the semantics on the
+// vector path. Its fixture passes a nil store, so the store satisfies no
+// model.LexicalSearcher and hybrid retrieval degrades to vector-only. Every
+// assertion there therefore never reached the BM25 half of the pipeline, and a
+// filter that a fused candidate escaped still looked correct.
+//
+// That escape is what #856 reports: on a live corpus of 394 recognition chunks,
+// `events=["no_such_event_xyz"]` returned 19 hits. The vector candidates were
+// filtered to none, then unfiltered BM25 candidates were fused back in and
+// became the whole result. The filter said "nothing matches" and the answer said
+// "here are 19 things".
+//
+// The fixture below is hybrid-enabled: a store that serves BM25, plus a vector
+// index over the same chunks. Each test states which path carries the candidate
+// it asserts on.
+
+const (
+	sfgID       = "team:san-francisco-giants"
+	hrBatterID  = "player:heliot-ramos"
+	hrPitcherID = "player:logan-webb"
+	homeRun     = "home_run"
+)
+
+// lexicalHitStore is a minimal model.Store that also satisfies
+// model.LexicalSearcher. SearchBM25 returns its seeded hits verbatim (up to k),
+// mirroring the reference store, whose FTS query joins the spans table and so
+// returns hits that already carry the annotation attribution.
+type lexicalHitStore struct {
+	hits    []model.SearchHit
+	queries []string
+}
+
+func (s *lexicalHitStore) SearchBM25(_ context.Context, query string, k int, _ string) ([]model.SearchHit, error) {
+	s.queries = append(s.queries, query)
+	if k > 0 && len(s.hits) > k {
+		return append([]model.SearchHit(nil), s.hits[:k]...), nil
+	}
+	return append([]model.SearchHit(nil), s.hits...), nil
+}
+
+func (s *lexicalHitStore) Init(context.Context) error                           { return nil }
+func (s *lexicalHitStore) UpsertDocument(context.Context, model.Document) error { return nil }
+func (s *lexicalHitStore) GetDocumentByPath(context.Context, string) (model.Document, error) {
+	return model.Document{}, model.ErrNotFound
+}
+func (s *lexicalHitStore) ListFiles(context.Context, string, string, int, int) ([]model.Document, int64, error) {
+	return nil, 0, nil
+}
+func (s *lexicalHitStore) Close() error { return nil }
+
+// annotationHit is one recognition candidate: a "time" span carrying the entity
+// ids and the backend-declared event, exactly as ingestion persists it and as
+// both the store's BM25 query and the in-memory chunk metadata return it.
+func annotationHit(id uint64, event string, entities []string) model.SearchHit {
+	return model.SearchHit{
+		ChunkID: id,
+		RelPath: "game.mp4",
+		DocType: "video",
+		RepType: "recognition",
+		Snippet: "a pitch to the plate",
+		Span: model.Span{
+			Kind: "time", StartMS: int(id) * 1000, EndMS: int(id)*1000 + 800,
+			Entities: entities, Event: event,
+		},
+	}
+}
+
+// The pilot corpus shape: five home runs, other events around them, one chunk
+// with no attribution at all, and one home run that ONLY the lexical retriever
+// returns (its vector is absent from the index). The last one is the guard
+// against "fix the leak by dropping every lexical candidate": that would pass
+// every zero-hit assertion below and silently halve recall.
+var (
+	homeRunIDs      = []uint64{1, 2, 3, 4, 5}
+	lexicalOnlyID   = uint64(9)
+	homeRunTotalIDs = []uint64{1, 2, 3, 4, 5, 9}
+)
+
+// hybridAnnotationService builds the fixture. Every chunk is registered as
+// in-memory metadata (what the vector path materialises) AND seeded into the
+// lexical store (what BM25 returns), so a candidate can be reached on either
+// path.
+func hybridAnnotationService(t *testing.T) (*retrieval.Service, *lexicalHitStore) {
+	t.Helper()
+	idx := index.NewHNSWIndex("")
+
+	hits := make([]model.SearchHit, 0, 8)
+	for _, id := range homeRunIDs {
+		hits = append(hits, annotationHit(id, homeRun, []string{hrBatterID, sfgID}))
+	}
+	// Two other events on the same corpus: a non-empty event filter must not
+	// admit them.
+	hits = append(hits,
+		annotationHit(6, "pitch", []string{hrPitcherID, sfgID}),
+		annotationHit(7, "at_bat", []string{hrBatterID, sfgID}),
+	)
+	// A plain text chunk: no attribution, so it never matches a non-empty filter.
+	hits = append(hits, model.SearchHit{
+		ChunkID: 8, RelPath: "notes.md", DocType: "md", RepType: "raw_text",
+		Snippet: "a note about the game",
+		Span:    model.Span{Kind: "lines", StartLine: 1, EndLine: 4},
+	})
+
+	for _, hit := range hits {
+		addAnnotationVector(t, idx, hit)
+	}
+
+	// The lexical retriever additionally returns a home run the vector index does
+	// not hold.
+	lexicalOnly := annotationHit(lexicalOnlyID, homeRun, []string{hrBatterID, sfgID})
+	st := &lexicalHitStore{hits: append(append([]model.SearchHit(nil), hits...), lexicalOnly)}
+
+	svc := retrieval.NewService(st, idx, &fakeRetrievalEmbedder{vectorsByModel: map[string][]float32{
+		"mistral-embed": {1, 0},
+	}}, nil)
+	for _, hit := range hits {
+		svc.SetChunkMetadata(hit.ChunkID, hit)
+	}
+	svc.SetChunkMetadata(lexicalOnly.ChunkID, lexicalOnly)
+	return svc, st
+}
+
+// addAnnotationVector upserts the hit's vector with the payload ingestion would
+// have stored, so the index-side filter sees what the Go-side re-check sees.
+func addAnnotationVector(t *testing.T, idx *index.HNSWIndex, hit model.SearchHit) {
+	t.Helper()
+	payload := model.IndexPayload{
+		ChunkID: hit.ChunkID, RelPath: hit.RelPath, DocType: hit.DocType,
+		RepType: hit.RepType, StartMS: hit.Span.StartMS, EndMS: hit.Span.EndMS,
+		Span: hit.Span,
+	}
+	// Near-identical vectors: every chunk is a candidate, so a hit that is absent
+	// from a result was removed by the filter and not by ranking.
+	vec := []float32{1, float32(hit.ChunkID) / 1000}
+	if err := idx.Upsert(context.Background(), vec, payload); err != nil {
+		t.Fatalf("Upsert(%d): %v", hit.ChunkID, err)
+	}
+}
+
+func hybridSearchIDs(t *testing.T, svc *retrieval.Service, q model.SearchQuery) []uint64 {
+	t.Helper()
+	if q.Query == "" {
+		q.Query = "pitch"
+	}
+	if q.K == 0 {
+		q.K = 20
+	}
+	hits, err := svc.Search(context.Background(), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	out := make([]uint64, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.ChunkID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func sameIDs(got, want []uint64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestAnImpossibleFilterValueReturnsZeroHits is the assertion #856 asks for, and
+// the one the previous suite lacked: a value that CANNOT match must return
+// nothing. It fails before the fix because the fused pool carries unfiltered
+// lexical candidates.
+func TestAnImpossibleFilterValueReturnsZeroHits(t *testing.T) {
+	svc, st := hybridAnnotationService(t)
+	for _, q := range []model.SearchQuery{
+		{Events: []string{"no_such_event_xyz"}},
+		{Entities: []string{"player:nobody-at-all"}},
+		{Entities: []string{sfgID}, Events: []string{"no_such_event_xyz"}},
+	} {
+		if got := hybridSearchIDs(t, svc, q); len(got) != 0 {
+			t.Fatalf("%+v returned %v; a value that matches nothing must return no hits", q, got)
+		}
+	}
+	if len(st.queries) == 0 {
+		t.Fatal("the lexical retriever was never called; this fixture must exercise the hybrid path")
+	}
+}
+
+// TestTheEventFilterSelectsEveryAnnotationWhateverTheQueryText is the pilot's
+// aggregate question: five home runs are in the corpus, the query text says
+// "pitch", and the filter must still return exactly the home runs (including the
+// one only BM25 reaches).
+func TestTheEventFilterSelectsEveryAnnotationWhateverTheQueryText(t *testing.T) {
+	svc, _ := hybridAnnotationService(t)
+	for _, queryText := range []string{"pitch", "home run", "who scored"} {
+		got := hybridSearchIDs(t, svc, model.SearchQuery{Query: queryText, Events: []string{homeRun}})
+		if !sameIDs(got, homeRunTotalIDs) {
+			t.Fatalf("query %q with events=[home_run] = %v, want %v", queryText, got, homeRunTotalIDs)
+		}
+	}
+}
+
+// TestALexicalOnlyCandidateSurvivesAMatchingFilter is the recall guard: the
+// filter must REMOVE non-matching lexical candidates, never the matching ones.
+func TestALexicalOnlyCandidateSurvivesAMatchingFilter(t *testing.T) {
+	svc, _ := hybridAnnotationService(t)
+	got := hybridSearchIDs(t, svc, model.SearchQuery{Entities: []string{hrBatterID}, Events: []string{homeRun}})
+	if !sameIDs(got, homeRunTotalIDs) {
+		t.Fatalf("entities=[batter] events=[home_run] = %v, want %v including the lexical-only chunk %d",
+			got, homeRunTotalIDs, lexicalOnlyID)
+	}
+}
+
+// TestTheFilterAppliesOnTheVectorPathToo pins the same behaviour with hybrid
+// off, so the answer never depends on which retriever ran. Chunk 9 has no
+// vector, so it is correctly absent here.
+func TestTheFilterAppliesOnTheVectorPathToo(t *testing.T) {
+	svc, _ := hybridAnnotationService(t)
+	svc.SetHybridEnabled(false)
+	if got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{"no_such_event_xyz"}}); len(got) != 0 {
+		t.Fatalf("vector-only search with an impossible event returned %v", got)
+	}
+	got := hybridSearchIDs(t, svc, model.SearchQuery{Events: []string{homeRun}})
+	if !sameIDs(got, homeRunIDs) {
+		t.Fatalf("vector-only search with events=[home_run] = %v, want %v", got, homeRunIDs)
+	}
+}
+
+// TestAnAbsentFilterStillFusesEveryLexicalCandidate is the compatibility guard:
+// with no filter the fused pool is unchanged, so the fix removes candidates only
+// when a filter asks for it.
+func TestAnAbsentFilterStillFusesEveryLexicalCandidate(t *testing.T) {
+	svc, _ := hybridAnnotationService(t)
+	got := hybridSearchIDs(t, svc, model.SearchQuery{})
+	want := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	if !sameIDs(got, want) {
+		t.Fatalf("unfiltered hybrid search = %v, want every chunk %v", got, want)
+	}
+}
+
+// TestAskAppliesTheFilterAndCitesOnlyMatches covers the second tool that
+// advertises the parameters. `ask` is the surface the pilot uses, and a citation
+// to a filtered-out chunk is a confident wrong answer.
+func TestAskAppliesTheFilterAndCitesOnlyMatches(t *testing.T) {
+	svc, _ := hybridAnnotationService(t)
+
+	res, err := svc.Ask(context.Background(), "which events happened?", model.SearchQuery{
+		Events: []string{"no_such_event_xyz"}, K: 20,
+	})
+	if err != nil {
+		t.Fatalf("Ask (impossible event): %v", err)
+	}
+	if len(res.Hits) != 0 || len(res.Citations) != 0 {
+		t.Fatalf("ask with an impossible event returned %d hits / %d citations, want none",
+			len(res.Hits), len(res.Citations))
+	}
+
+	res, err = svc.Ask(context.Background(), "who hit home runs?", model.SearchQuery{
+		Events: []string{homeRun}, K: 20,
+	})
+	if err != nil {
+		t.Fatalf("Ask (home_run): %v", err)
+	}
+	for _, cited := range res.Citations {
+		if cited.Span.Event != homeRun {
+			t.Fatalf("ask cited chunk %d with event %q; the filter admits home_run only",
+				cited.ChunkID, cited.Span.Event)
+		}
+	}
+	if len(res.Citations) != len(homeRunTotalIDs) {
+		t.Fatalf("ask cited %d chunks, want %d (every home run, including the lexical-only one)",
+			len(res.Citations), len(homeRunTotalIDs))
+	}
+}

--- a/tests/retrieval/annotation_filter_lexical_856_test.go
+++ b/tests/retrieval/annotation_filter_lexical_856_test.go
@@ -307,6 +307,19 @@ func TestAskAppliesTheFilterAndCitesOnlyMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ask (home_run): %v", err)
 	}
+	// Both surfaces of the ask result: `hits` is what a caller inspects, and
+	// `citations` is what the answer stands on. A filter honoured on one only is
+	// still a wrong answer.
+	for _, hit := range res.Hits {
+		if hit.Span.Event != homeRun {
+			t.Fatalf("ask returned chunk %d with event %q; the filter admits home_run only",
+				hit.ChunkID, hit.Span.Event)
+		}
+	}
+	if len(res.Hits) != len(homeRunTotalIDs) {
+		t.Fatalf("ask returned %d hits, want %d (every home run, including the lexical-only one)",
+			len(res.Hits), len(homeRunTotalIDs))
+	}
 	for _, cited := range res.Citations {
 		if cited.Span.Event != homeRun {
 			t.Fatalf("ask cited chunk %d with event %q; the filter admits home_run only",

--- a/tests/store/annotation_attribution_retrieval_paths_856_test.go
+++ b/tests/store/annotation_attribution_retrieval_paths_856_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -79,7 +78,17 @@ func assertAttribution(t *testing.T, path string, span model.Span) {
 	if span.Event != attributionEvent {
 		t.Fatalf("%s: event = %q, want %q", path, span.Event, attributionEvent)
 	}
-	if !strings.Contains(strings.Join(span.Entities, ","), attributionEntityID) {
+	// Exact membership, not a substring of the joined ids: an id is an opaque
+	// token, and "player:heliot-ramos-old" must not pass for
+	// "player:heliot-ramos".
+	found := false
+	for _, entityID := range span.Entities {
+		if entityID == attributionEntityID {
+			found = true
+			break
+		}
+	}
+	if !found {
 		t.Fatalf("%s: entities = %v, want %s among them", path, span.Entities, attributionEntityID)
 	}
 }

--- a/tests/store/annotation_attribution_retrieval_paths_856_test.go
+++ b/tests/store/annotation_attribution_retrieval_paths_856_test.go
@@ -1,0 +1,124 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// The two store read paths a retrieval candidate comes from must both carry a
+// recognition annotation's attribution (issue #856, design 0004 §7).
+//
+// The filter judges a candidate on the span the candidate carries, so a read
+// path that drops the attribution turns the filter into "reject everything" for
+// the candidates it produces. Both paths are joined reads that already select
+// the span row, so the attribution costs no extra query:
+//
+//   - SearchBM25 is the lexical candidate. Its FTS query joins the spans table.
+//   - ListEmbeddedChunkMetadata is the daemon's warm load, which becomes the
+//     in-memory chunk metadata the vector path materialises a hit from.
+
+const (
+	attributionEvent    = "home_run"
+	attributionEntityID = "player:heliot-ramos"
+)
+
+// embeddedAnnotationChunk seeds a live document, a recognition representation,
+// and one embedded chunk whose "time" span carries the attribution.
+func embeddedAnnotationChunk(t *testing.T, st *store.SQLiteStore, relPath, text string, span model.Span) uint64 {
+	t.Helper()
+	ctx := context.Background()
+	if err := st.UpsertDocument(ctx, model.Document{
+		RelPath: relPath, DocType: "video", SourceType: "local", Status: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertDocument: %v", err)
+	}
+	doc, err := st.GetDocumentByPath(ctx, relPath)
+	if err != nil {
+		t.Fatalf("GetDocumentByPath: %v", err)
+	}
+	repID, err := st.UpsertRepresentation(ctx, model.Representation{
+		DocID: doc.DocID, RepType: "recognition", RepHash: relPath, CreatedUnix: 1,
+	})
+	if err != nil {
+		t.Fatalf("UpsertRepresentation: %v", err)
+	}
+	chunkID, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+		RepID: repID, Ordinal: 0, Text: text,
+		IndexKind: "text", EmbeddingStatus: "ok",
+	}, []model.Span{span})
+	if err != nil {
+		t.Fatalf("InsertChunkWithSpans: %v", err)
+	}
+	return uint64(chunkID)
+}
+
+func attributionStore(t *testing.T) (*store.SQLiteStore, uint64) {
+	t.Helper()
+	st := store.NewSQLiteStore(filepath.Join(t.TempDir(), "meta.sqlite"))
+	if err := st.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	chunkID := embeddedAnnotationChunk(t, st, "game.mp4",
+		"Heliot Ramos hits a home run to left field",
+		model.Span{
+			Kind: "time", StartMS: 3346398, EndMS: 3354398,
+			Entities: []string{attributionEntityID, "team:san-francisco-giants"},
+			Event:    attributionEvent,
+		})
+	return st, chunkID
+}
+
+func assertAttribution(t *testing.T, path string, span model.Span) {
+	t.Helper()
+	if span.Event != attributionEvent {
+		t.Fatalf("%s: event = %q, want %q", path, span.Event, attributionEvent)
+	}
+	if !strings.Contains(strings.Join(span.Entities, ","), attributionEntityID) {
+		t.Fatalf("%s: entities = %v, want %s among them", path, span.Entities, attributionEntityID)
+	}
+}
+
+// TestALexicalHitCarriesTheAnnotationAttribution: the lexical candidate the
+// hybrid path fuses must arrive with its attribution, because the filter now
+// judges it (before #856 it was fused unjudged).
+func TestALexicalHitCarriesTheAnnotationAttribution(t *testing.T) {
+	st, chunkID := attributionStore(t)
+	hits, err := st.SearchBM25(context.Background(), "home run", 10, "text")
+	if err != nil {
+		t.Fatalf("SearchBM25: %v", err)
+	}
+	for _, hit := range hits {
+		if hit.ChunkID != chunkID {
+			continue
+		}
+		assertAttribution(t, "SearchBM25", hit.Span)
+		return
+	}
+	t.Fatalf("SearchBM25 returned %d hits, none of them chunk %d", len(hits), chunkID)
+}
+
+// TestWarmLoadedMetadataCarriesTheAnnotationAttribution: after a restart the
+// vector path materialises a hit from this metadata, so the attribution must
+// survive the reload as well as the first indexing run.
+func TestWarmLoadedMetadataCarriesTheAnnotationAttribution(t *testing.T) {
+	st, chunkID := attributionStore(t)
+	tasks, err := st.ListEmbeddedChunkMetadata(context.Background(), "text", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata: %v", err)
+	}
+	for _, task := range tasks {
+		if task.Metadata.ChunkID != chunkID {
+			continue
+		}
+		assertAttribution(t, "ListEmbeddedChunkMetadata", task.Metadata.Span)
+		assertAttribution(t, "ChunkMetadata.ToSearchHit", task.Metadata.ToSearchHit().Span)
+		return
+	}
+	t.Fatalf("warm load returned %d chunks, none of them chunk %d", len(tasks), chunkID)
+}


### PR DESCRIPTION
Refs #856

The recognition entity and event filters did nothing on a live corpus. A value
that can match nothing still returned hits, so every aggregate question of the
SF Giants pilot answered from an unfiltered top-k sample.

## Which of the two root causes this PR fixes

**(a) The filter was not applied on the path in use. FIXED.**

**(b) A returned hit carries no `entities`/`event` in its span. HALF FIXED, and
the other half is SPEC-blocked.**

- The INTERNAL span, which is what the filter judges, does carry the
  attribution. Both store reads rebuild it from the span's `extra_json`, and this
  PR pins that and hardens the one place a candidate could still be judged
  against attribution it does not carry.
- The SERIALIZED span, which is what a client sees, still carries only
  `kind`/`start_ms`/`end_ms`. Adding fields there is a SPEC change, so this PR
  does not do it. Details in "Attribution on the wire" below.

So #856 must stay OPEN for the wire half after this merges. The body says `Refs`
rather than `Closes` for that reason: the filter is fixed, one acceptance
criterion of the issue is not, and a silent close is the same class of gap the
issue reports. Flip it to `Closes` if you would rather track the wire half in its
own issue.

## Root cause of (a)

The filter was applied to the dense vector candidates only. `collectFilteredHits`
runs `matchFilters` on every vector candidate. `runHybridSearch` then fused the
BM25 candidates back in **without applying any predicate to them**. A filter that
selected no vector candidate therefore returned the whole BM25 pool for the query
text. That is the reported symptom exactly: `events=["no_such_event_xyz"]`
returned the 19 lexical matches for "pitch".

The same bypass leaked every other candidate predicate on the lexical path:
speaker (§8.6.8), language (§9.5), date window (§9.6), media time window (§9.8),
path prefix, file glob and doc types. One call site closes all of them.

## The fix

`runHybridSearch` receives the query predicates and calls the new
`selectLexicalCandidates`, the lexical counterpart of `collectFilteredHits`. A
lexical candidate that no predicate admits is dropped before fusion, so candidate
selection stays where the design puts it: before dedup, rerank and truncation to
`k`. When the filter empties the lexical pool the vector candidates are returned
alone, exactly as an empty BM25 result already did.

Order matters inside that function: hydrate first, filter second. A filter is
worthless if it runs against an empty span, because a non-empty filter rejects an
attribution-less span by design. `hydrateLexicalHit` fills the fields a lexical
read may leave unset (span, rep type, doc type, language, mtime), and
`resolveLexicalSpan` keeps the cached span as the citation location while filling
each attribution field the cached span lacks from the live lexical read. The two
attribution fields are merged INDEPENDENTLY, because `entities` and `events` are
separate predicates that are ANDed.

## The zero-hit assertion holds on every path

`events=["no_such_event_xyz"]` and `entities=["player:nobody-at-all"]` must return
ZERO hits. That is asserted on all three paths, in isolation:

| Path | Test | How the path is isolated |
| --- | --- | --- |
| Vector only | `TestTheFilterAppliesOnTheVectorPathToo` | `SetHybridEnabled(false)`, so no lexical candidate exists |
| Lexical only | `TestALexicalOnlyCorpusReturnsTheFilteredSet` | the vector index holds nothing, so every candidate is a BM25 hit |
| Fused | `TestAnImpossibleFilterValueReturnsZeroHits` | both retrievers hold the same chunks, and the test asserts the lexical retriever really ran |
| Fused, production chain | `TestBothToolsReturnNoHitsForAnImpossibleEvent` | real SQLite store (spans plus FTS), real vector index, real service, over HTTP |

The matching direction is asserted on each path too: a real event returns exactly
the annotations that carry it, whatever the query text says
(`TestTheEventFilterSelectsEveryAnnotationWhateverTheQueryText` runs the same
filter under three different query strings).

Recall is guarded as well. The fixture seeds one matching annotation that the
vector index does **not** hold, so only BM25 can return it, and
`TestALexicalOnlyCandidateSurvivesAMatchingFilter` requires it in the result. That
is the guard against "fix the leak by dropping every lexical candidate", which
would pass every zero-hit assertion above and halve recall.

Both tools that advertise the parameters are covered:
`tests/mcp/entity_filter_end_to_end_856_test.go` calls `dir2mcp_search` and
`dir2mcp_ask` over HTTP, and `TestAskAppliesTheFilterAndCitesOnlyMatches` checks
the `hits` and the `citations` of the ask result, because a filter honoured on one
surface only is still a wrong answer.

## Attribution on the wire is spec-blocked

Issue #856 also asks that a returned hit carry `entities` and `event` so a client
can see why the hit matched. That is a change to SPEC-pinned behavior, so this PR
stops short of it and reports instead.

`df-005` fixes the `time` span variant as `additionalProperties: false` with
exactly `kind`, `start_ms`, `end_ms`, `speaker` and `speaker_label`. The canonical
mirror `spec/tools/schemas/common.json` says the same, `df-006` closes `Hit` the
same way, and design 0004 §7 states that the `Hit`, `Citation` and `Span` schemas
stay **unchanged**. Emitting an undeclared field is the #387 and #397 failure
class: a strict client rejects the whole tool result.

The wire half therefore needs a dirstral-spec PR first (a new optional `entities`
array and `event` string on the `time` variant of `df-005`, mirrored into
`common.json`), then a gated submodule re-pin, then a small code change in
`buildOpenFileSpan` and `spanDefinitionSchema`. The filter needs none of that: it
reads the internal span, which carries the attribution today.

## The tests fail on main

Ran with `main`'s `internal/retrieval/hybrid.go` and `service.go` restored under
the new tests:

```
--- FAIL: TestAnImpossibleFilterValueReturnsZeroHits
    events=[no_such_event_xyz] returned [1 2 3 4 5 6 7 8 9]; a value that matches nothing must return no hits
--- FAIL: TestTheEventFilterSelectsEveryAnnotationWhateverTheQueryText
    query "pitch" with events=[home_run] = [1 2 3 4 5 6 7 8 9], want [1 2 3 4 5 9]
--- FAIL: TestALexicalOnlyCandidateSurvivesAMatchingFilter
--- FAIL: TestALexicalOnlyCorpusReturnsTheFilteredSet
    lexical-only search with an impossible event returned [1 2 3], want none
--- FAIL: TestAskAppliesTheFilterAndCitesOnlyMatches
    ask with an impossible event returned 9 hits / 9 citations, want none
--- FAIL: TestBothToolsReturnNoHitsForAnImpossibleEvent
    dir2mcp_search {"query":"home run","events":["no_such_event_xyz"],"k":20} returned hits [1 3]
--- FAIL: TestBothToolsSelectOnlyTheMatchingAnnotation
    dir2mcp_search {"query":"home run","events":["home_run"],"k":20} = [1 3], want [1]
```

The two ids in the MCP failure are the BM25 matches for "home run", one of which
is a prose note with no attribution at all.

`TestAPartlyAttributedCacheKeepsTheLexicalEvent` fails on the earlier commit of
this branch with `entities=[batter] events=[home_run] = [], want [1]`.

## Cost

Zero added queries and zero added I/O.

Carrying the attribution needs no per-hit read. Both store reads already join the
span row and already return `extra_json` in the same statement, so the attribution
rides along for free. On the retrieval side the hydration is the same
`searchHitForLabel` map lookup the old code already did once per lexical
candidate, so the lookup count is unchanged. The added work per query is one
`matchFilters` call per lexical candidate, bounded by the BM25 pool of 50.

One behavior note: the lexical pool stays the BM25 top-50 for the query text and
is then filtered, so a highly selective filter can leave the lexical contribution
empty. That costs no recall against a vector-only search, because the vector path
runs its own widening overfetch loop under the same filter.

## Checks

- `make check` passes.
- `go test -race ./tests/retrieval/... ./tests/mcp/...` passes.
- `coderabbit review` ran on each round. Three findings were raised and all three
  are fixed: the cached span could discard a lexical candidate's attribution, the
  two attribution fields were merged as one, and two test assertions were too
  weak.
