### PR TITLE
fix(annotator): carry the notability and batted-ball signals the feed already has

### DIFF
--- a/annotator/README.md
+++ b/annotator/README.md
@@ -33,13 +33,17 @@ unavailable.
 
 ### What the play-by-play recognizer emits
 
-One pitch produces up to three cues. Each cue carries one role:
+One pitch produces up to seven cues. Each cue carries one fact:
 
 | `event` | Keyed on | Emitted for |
 |---|---|---|
 | `pitch` | the pitcher, plus the fielding club | every pitch a rostered pitcher threw |
 | `at_bat` | the batter, plus the club at the plate | every pitch a rostered batter faced |
 | the feed's `result.eventType`: `home_run`, `strikeout`, `walk`, `single`, `double`, `field_out`, ... | the batter, plus the club at the plate | the pitch that ended the at-bat |
+| `batted_ball` | the batter, plus the club at the plate | a pitch the tracking measured (`playEvents[].hitData`) |
+| `captivating` | the batter, plus the club at the plate | a play the feed scores above 0 on `about.captivatingIndex` |
+| `reviewed` | the batter, plus the club at the plate | a play whose call went to a review (`about.hasReview`) |
+| `scoring_play` | the batter, plus the club at the plate | a play that scored a run (`about.isScoringPlay`) |
 
 The third cue makes the outcome of a play structured data. Before it, the
 outcome was prose inside the cue text alone, so `dir2mcp_search`'s `events`
@@ -49,9 +53,34 @@ question from a partial sample: it named a player who never homered and it
 dropped one who did. The vocabulary is MLB's own, so a client selects the real
 thing with `events: ["home_run"]` instead of a match on words.
 
-The three cues share one time span, so the answer path groups them into one
-moment (issue #784) and counts one event once. The phase-1 metric reads
-`event == "pitch"` alone, so the outcome cues do not move it.
+The last four cues answer the questions the outcome cannot: "the most
+captivating moments", "the hardest hit ball", "the longest home run", "the
+contested calls". Every value is the feed's own, carried verbatim.
+
+A number is neither an event nor an entity, and the design 0004 wire schema
+closes `annotations[]` (`additionalProperties: false`), so it has no numeric
+field. Each fact therefore reaches a client by the two channels the contract
+does have: `event` is the token to FILTER on, and `text` carries the number
+itself, in the feed's unit, inside the sentence that gets indexed, which is what
+a client RANKS on.
+
+```
+Captivating moment (captivating index 95): Bryce Eldridge vs Mitchell Parker
+  (bottom of the 9th) — Bryce Eldridge hits a grand slam (4) to right field. …
+Batted ball: Matt Chapman vs Foster Griffin (bottom of the 6th): exit velocity
+  107 mph, launch angle 22 degrees, distance 421 ft, fly ball, medium contact
+  — Matt Chapman homers (5) on a fly ball to left center field.
+```
+
+The recognizer sets no threshold on `captivatingIndex`. The one boundary the
+feed itself draws is zero (43 of the pilot game's 84 plays score exactly 0), so
+`captivating` means "the feed scored this play above zero" and the score rides
+in the text. A sharper cut would be this backend's judgement baked into the
+index, where no client could undo it.
+
+All the cues of one pitch share one time span, so the answer path groups them
+into one moment (issue #784) and counts one event once. The phase-1 metric reads
+`event == "pitch"` alone, so none of the added cues move it.
 
 ### The overlay text reader
 

--- a/annotator/dirstral_annotator/eval/ground_truth.py
+++ b/annotator/dirstral_annotator/eval/ground_truth.py
@@ -27,6 +27,43 @@ def _ordinal(n: int) -> str:
 
 
 @dataclass(frozen=True)
+class HitData:
+    """What the tracking system measured on a batted ball.
+
+    Every field is `playEvents[].hitData`, verbatim, in the units the feed uses
+    (mph, degrees, feet). Nothing here is derived, scaled or bucketed: "the
+    hardest hit ball" and "the longest home run" have to be answerable against
+    MLB's own measurement, not against a number this backend produced.
+
+    A field the tracking did not measure stays absent (None, or "") rather than
+    becoming a zero, because 0 mph is a claim and "not measured" is not.
+    """
+
+    launch_speed: float | None = None  # exit velocity, mph
+    launch_angle: float | None = None  # degrees off the bat
+    total_distance: float | None = None  # feet travelled
+    trajectory: str = ""  # "fly_ball" | "ground_ball" | "line_drive" | "popup"
+    hardness: str = ""  # "soft" | "medium" | "hard"
+
+    def measured(self) -> bool:
+        """True when the feed measured anything at all.
+
+        A `hitData` object with every field empty says nothing a reader or a
+        ranking can use, so callers drop it instead of reporting a batted ball
+        with no measurement in it.
+        """
+        return any(
+            (
+                self.launch_speed is not None,
+                self.launch_angle is not None,
+                self.total_distance is not None,
+                self.trajectory,
+                self.hardness,
+            )
+        )
+
+
+@dataclass(frozen=True)
 class PitchEvent:
     game_pk: int
     epoch_s: float  # wall-clock UTC epoch seconds of the pitch
@@ -54,6 +91,33 @@ class PitchEvent:
     #: structured field to select on, so it fell back to top-k search over that
     #: prose and answered a "list every X" question from a partial sample.
     event_type: str = ""
+    #: What the tracking measured on THIS pitch (`playEvents[].hitData`), or
+    #: None for a pitch that was not hit. It is per pitch, not per play, so it
+    #: rides on its own pitch: a foul that Statcast measured is a measurement of
+    #: that foul, not of the at-bat's result.
+    hit_data: HitData | None = None
+    #: How notable the play was, on MLB's own `about.captivatingIndex`,
+    #: verbatim. It is the answer to "the best moments of the game" taken from
+    #: the source instead of from a model's opinion. Measured on the pilot game:
+    #: 43 of the 84 plays score exactly 0 and one scores 95, so it does
+    #: discriminate.
+    #:
+    #: Like every other play-level field below, it rides on the pitch that ENDED
+    #: the at-bat, exactly where `event_type` and the play result text ride. One
+    #: play then produces one notable moment, not one per pitch.
+    captivating_index: int = 0
+    #: `about.hasReview`: the call went to a review. This is "the contested
+    #: calls", and it is 2 plays of the pilot game's 84.
+    has_review: bool = False
+    #: `about.isScoringPlay`: a run scored (15 plays of the pilot game).
+    is_scoring_play: bool = False
+    #: `result.rbi`, and the score AFTER the play (`result.awayScore` /
+    #: `result.homeScore`). A run can score with no RBI (an error, a wild
+    #: pitch), so the two are carried separately rather than derived from one
+    #: another.
+    rbi: int = 0
+    away_score: int = 0
+    home_score: int = 0
 
     def half_inning(self) -> str:
         """The half-inning phrased as a person would say it: "top of the 1st"."""
@@ -103,6 +167,14 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
         about = play.get("about", {})
         inning = about.get("inning", 0)
         top_inning = bool(about.get("isTopInning", True))
+        # Play-level notability, verbatim. It rides on the pitch that ended the
+        # at-bat, so one play reports one notable moment.
+        captivating_index = _int(about.get("captivatingIndex"))
+        has_review = bool(about.get("hasReview"))
+        is_scoring_play = bool(about.get("isScoringPlay"))
+        rbi = _int(result.get("rbi"))
+        away_score = _int(result.get("awayScore"))
+        home_score = _int(result.get("homeScore"))
         play_events = play.get("playEvents", [])
         last = _last_recorded_pitch(play_events)
         for i, ev in enumerate(play_events):
@@ -129,6 +201,13 @@ def parse_pitches(feed: dict) -> list[PitchEvent]:
                     home_team=home_team,
                     description=(result_desc if is_last and result_desc else call),
                     event_type=(event_type if is_last else ""),
+                    hit_data=_hit_data(ev.get("hitData")),
+                    captivating_index=(captivating_index if is_last else 0),
+                    has_review=(has_review and is_last),
+                    is_scoring_play=(is_scoring_play and is_last),
+                    rbi=(rbi if is_last else 0),
+                    away_score=(away_score if is_last else 0),
+                    home_score=(home_score if is_last else 0),
                 )
             )
     events.sort(key=lambda e: e.epoch_s)
@@ -157,6 +236,74 @@ def _last_recorded_pitch(play_events: list[dict]) -> int:
         if ev.get("isPitch") and ev.get("startTime"):
             return i
     return -1
+
+
+def _hit_data(raw: object) -> HitData | None:
+    """`playEvents[].hitData` as a HitData, or None when nothing was measured.
+
+    A pitch that was not hit carries no `hitData` at all, and a `hitData` whose
+    every field is empty measures nothing, so both read as None: a batted ball
+    with no measurement in it is a claim the feed did not make.
+    """
+    if not isinstance(raw, dict):
+        return None
+    hit = HitData(
+        launch_speed=_float(raw.get("launchSpeed")),
+        launch_angle=_float(raw.get("launchAngle")),
+        total_distance=_float(raw.get("totalDistance")),
+        trajectory=_text(raw.get("trajectory")),
+        hardness=_text(raw.get("hardness")),
+    )
+    return hit if hit.measured() else None
+
+
+def _int(value: object) -> int:
+    """A whole number off the feed, or 0 for anything that is not one.
+
+    A bool is not a measurement (`True` would read as 1), and a missing field
+    reads as 0, which is the value that means "nothing to report" for every
+    caller of these fields.
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value == value and abs(value) != float("inf") else 0
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return 0
+    return 0
+
+
+def _float(value: object) -> float | None:
+    """A measurement off the feed, or None when there is not one.
+
+    None rather than 0.0, because 0.0 mph is a measurement and an absent field
+    is not. NaN and infinity are dropped as well: they cannot be ranked and they
+    cannot be read.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        try:
+            number = float(value.strip())
+        except ValueError:
+            return None
+    else:
+        return None
+    if number != number or abs(number) == float("inf"):
+        return None
+    return number
+
+
+def _text(value: object) -> str:
+    """A label off the feed ("fly_ball", "hard"), or "" for anything else."""
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _iso_epoch(iso: str) -> float:

--- a/annotator/dirstral_annotator/recognizers/playbyplay.py
+++ b/annotator/dirstral_annotator/recognizers/playbyplay.py
@@ -22,10 +22,36 @@ runs?" had to fall back to top-k semantic search over that prose, and a
 "list every X" question answered from a partial sample invented one player
 and dropped another. A structured event makes the same question a selection.
 
-The three cues are additive. `pitch` and `at_bat` keep the entities, the
-text, the span and the confidence they had, so the pitcher-keyed phase-1
-metric (`eval.score`, which reads `event == "pitch"` alone) cannot see this
-change at all. Retagging is what broke #620; this adds instead.
+Four more cues say how notable the play was and how hard the ball was hit:
+`captivating`, `reviewed`, `scoring_play` and `batted_ball`. They exist
+because the outcome answers "who homered" and nothing else: "the most
+captivating moments", "the hardest hit ball", "the longest home run" and "the
+contested calls" had no structured handle at all, and the feed answers every
+one of them.
+
+A number is neither an event nor an entity, and the design 0004 wire schema
+closes `annotations[]` (`additionalProperties: false`), so it has no numeric
+field to hold one. Each fact therefore reaches a client by the two channels
+the contract does have, each doing the job it can do:
+
+  `event`  the token to FILTER on. One cue carries one event string, so N
+           selectable facts need N cues. They share the ending pitch's span,
+           so the answer path groups them into one moment (#784).
+  `text`   the number itself, verbatim and in the feed's units, inside the
+           sentence that gets indexed. It is what a client RANKS on and what
+           an answer quotes.
+
+`captivatingIndex` is a score, and this recognizer sets no threshold on it.
+The one boundary the feed itself draws is zero: 43 of the pilot game's 84
+plays score exactly 0. So `captivating` means "the feed scored this play
+above zero", and the score rides in the text. A sharper cut (>= 33, >= 70)
+would be this backend's judgement baked into the index, where no client could
+undo it.
+
+Every cue is additive. `pitch` and `at_bat` keep the entities, the text, the
+span and the confidence they had, so the pitcher-keyed phase-1 metric
+(`eval.score`, which reads `event == "pitch"` alone) cannot see this change
+at all. Retagging is what broke #620; this adds instead.
 
 This recognizer doubles as the eval ground-truth source; the fetch/parse
 lives in eval.ground_truth so both uses share one implementation.
@@ -36,7 +62,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ..eval.ground_truth import PitchEvent
+from ..eval.ground_truth import HitData, PitchEvent
 from ..model import Cue
 from ..roster import Roster
 
@@ -53,6 +79,16 @@ CONFIDENCE = 0.98  # official record, minus alignment slop
 # comparison, and it means the metric does not depend on a third party's
 # vocabulary staying the way it is today.
 ROLE_EVENTS = ("pitch", "at_bat")
+
+# The notability and measurement events, in the order they are emitted. They are
+# fixed names this recognizer owns, not feed tokens, because the feed states
+# these facts as flags and numbers rather than as a vocabulary. None of them may
+# ever collide with ROLE_EVENTS, for the reason above; a test pins that.
+BATTED_BALL_EVENT = "batted_ball"
+CAPTIVATING_EVENT = "captivating"
+REVIEWED_EVENT = "reviewed"
+SCORING_EVENT = "scoring_play"
+NOTABILITY_EVENTS = (BATTED_BALL_EVENT, CAPTIVATING_EVENT, REVIEWED_EVENT, SCORING_EVENT)
 
 _SLUG_SEP = re.compile(r"[^a-z0-9]+")
 
@@ -79,6 +115,38 @@ def outcome_label(event_type: str) -> str:
     """
     words = event_type.replace("_", " ").strip()
     return words[:1].upper() + words[1:]
+
+
+def measurement_phrase(hit: HitData) -> str:
+    """The batted ball's measurements as a clause a person reads.
+
+    "exit velocity 107.9 mph, launch angle 5 degrees, distance 119 ft, ground
+    ball, hard contact". Every number is the feed's, in the feed's unit, and
+    nothing is rounded: the trailing ".0" of a whole measurement is dropped and
+    that is all. This clause is the only place a number can reach a client,
+    because the wire schema closes `annotations[]` and has no numeric field, so
+    it is also what a client ranks "the hardest hit ball" on.
+
+    A measurement the tracking did not take is left out rather than printed as a
+    zero. Returns "" when it took none, and the caller then emits no cue.
+    """
+    parts = []
+    if hit.launch_speed is not None:
+        parts.append(f"exit velocity {_number(hit.launch_speed)} mph")
+    if hit.launch_angle is not None:
+        parts.append(f"launch angle {_number(hit.launch_angle)} degrees")
+    if hit.total_distance is not None:
+        parts.append(f"distance {_number(hit.total_distance)} ft")
+    if hit.trajectory:
+        parts.append(hit.trajectory.replace("_", " "))
+    if hit.hardness:
+        parts.append(f"{hit.hardness} contact")
+    return ", ".join(parts)
+
+
+def _number(value: float) -> str:
+    """107.0 -> "107", 107.9 -> "107.9". The value, not a rounding of it."""
+    return str(int(value)) if float(value).is_integer() else str(value)
 
 
 def _with_team(player_id: str, team: str) -> tuple[str, ...]:
@@ -191,4 +259,89 @@ class PlayByPlayRecognizer:
                         ),
                     )
                 )
+            if batter is not None:
+                # HOW NOTABLE THE PLAY WAS, and how hard the ball was hit. Same
+                # actor, same span, one cue per selectable fact.
+                cues.extend(
+                    self._notability_cues(
+                        ev,
+                        batter.id,
+                        who=f"{batter_name} vs {pitcher_name}{where}",
+                        desc=desc,
+                        start=start,
+                        end=end,
+                    )
+                )
         return cues
+
+    def _notability_cues(
+        self,
+        ev: PitchEvent,
+        batter_id: str,
+        *,
+        who: str,
+        desc: str,
+        start: float,
+        end: float,
+    ) -> list[Cue]:
+        """How notable the play was, and how hard the ball was hit.
+
+        One cue per fact, because a cue carries one `event` string and each of
+        these facts has to be selectable on its own. Every cue is keyed on the
+        batter and their club, like the outcome cue it accompanies: these are
+        statements about the play, and the play's actor is the batter. A rostered
+        pitcher facing an unrostered batter therefore gets none of them, because
+        they would have nobody to name.
+
+        They share the span of the pitch that ended the at-bat, which is the span
+        of the `pitch`, `at_bat` and outcome cues of the same seconds, so the
+        answer path groups the whole set into one moment (#784).
+        """
+        keyed = _with_team(batter_id, ev.batting_team())
+
+        def cue(event: str, text: str) -> Cue:
+            return Cue(
+                source=self.name,
+                start_s=start,
+                end_s=end,
+                event=event,
+                entity_ids=keyed,
+                confidence=CONFIDENCE,
+                text=text,
+            )
+
+        out = []
+        if ev.hit_data is not None:
+            # A measured batted ball. This is the cue "the hardest hit ball" and
+            # "the longest home run" are answered from, so it carries the play
+            # result text as well: one chunk then holds both the number and what
+            # the ball became, and no join across cues is needed.
+            phrase = measurement_phrase(ev.hit_data)
+            if phrase:
+                out.append(cue(BATTED_BALL_EVENT, f"Batted ball: {who}: {phrase}{desc}"))
+        if ev.captivating_index > 0:
+            # Above zero is the feed's own boundary and the only one it draws;
+            # the score itself rides in the text, so the ranking stays MLB's.
+            out.append(
+                cue(
+                    CAPTIVATING_EVENT,
+                    f"Captivating moment (captivating index "
+                    f"{ev.captivating_index}): {who}{desc}",
+                )
+            )
+        if ev.has_review:
+            out.append(cue(REVIEWED_EVENT, f"Reviewed call: {who}{desc}"))
+        if ev.is_scoring_play:
+            # The score AFTER the play, by half rather than by club name: a club
+            # in the text is the measured retrieval regression (§6.1 above). A
+            # run can score with no RBI, and "0 RBI" would read as a claim about
+            # the batter that the feed did not make, so that clause is dropped.
+            runs = f"{ev.rbi} RBI, " if ev.rbi > 0 else ""
+            out.append(
+                cue(
+                    SCORING_EVENT,
+                    f"Scoring play ({runs}score: away {ev.away_score}, "
+                    f"home {ev.home_score}): {who}{desc}",
+                )
+            )
+        return out

--- a/annotator/tests/fixtures/gumbo_823215.json
+++ b/annotator/tests/fixtures/gumbo_823215.json
@@ -16,11 +16,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "James Wood grounds out, second baseman Luis Arraez to first baseman Rafael Devers."
+      "description": "James Wood grounds out, second baseman Luis Arraez to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -73,6 +79,13 @@
        "startTime": "2026-06-10T19:46:48.885Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 75.5,
+        "launchAngle": -0.0,
+        "totalDistance": 37.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -80,11 +93,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Curtis Mead flies out to right fielder Jung Hoo Lee."
+      "description": "Curtis Mead flies out to right fielder Jung Hoo Lee.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -137,6 +156,13 @@
        "startTime": "2026-06-10T19:48:55.722Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 89.9,
+        "launchAngle": 59.0,
+        "totalDistance": 218.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -144,11 +170,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Andrés Chaparro called out on strikes."
+      "description": "Andrés Chaparro called out on strikes.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -215,11 +247,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Casey Schmitt lines out to third baseman Curtis Mead."
+      "description": "Casey Schmitt lines out to third baseman Curtis Mead.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -265,6 +303,13 @@
        "startTime": "2026-06-10T19:55:34.368Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 76.5,
+        "launchAngle": 12.0,
+        "totalDistance": 132.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -272,11 +317,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Luis Arraez grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro."
+      "description": "Luis Arraez grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -350,6 +401,13 @@
        "startTime": "2026-06-10T19:58:34.542Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 55.2,
+        "launchAngle": 3.0,
+        "totalDistance": 44.0,
+        "trajectory": "ground_ball",
+        "hardness": "soft"
        }
       }
      ]
@@ -357,11 +415,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Matt Chapman singles on a sharp ground ball to third baseman Curtis Mead."
+      "description": "Matt Chapman singles on a sharp ground ball to third baseman Curtis Mead.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -407,6 +471,13 @@
        "startTime": "2026-06-10T20:00:21.118Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 107.9,
+        "launchAngle": 5.0,
+        "totalDistance": 119.0,
+        "trajectory": "ground_ball",
+        "hardness": "hard"
        }
       }
      ]
@@ -414,11 +485,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Rafael Devers lines out to center fielder Jacob Young."
+      "description": "Rafael Devers lines out to center fielder Jacob Young.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 1,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -471,6 +548,13 @@
        "startTime": "2026-06-10T20:02:53.948Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 99.1,
+        "launchAngle": 22.0,
+        "totalDistance": 348.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -478,11 +562,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Dylan Crews flies out to center fielder Jonah Cox."
+      "description": "Dylan Crews flies out to center fielder Jonah Cox.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -507,6 +597,13 @@
        "startTime": "2026-06-10T20:05:26.846Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 87.4,
+        "launchAngle": 34.0,
+        "totalDistance": 312.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -514,11 +611,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Daylen Lile singles on a fly ball to left fielder Victor Bericoto."
+      "description": "Daylen Lile singles on a fly ball to left fielder Victor Bericoto.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -536,6 +639,13 @@
        "startTime": "2026-06-10T20:05:57.505Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 74.6,
+        "launchAngle": 29.0,
+        "totalDistance": 243.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -543,11 +653,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Jacob Young flies out to center fielder Jonah Cox."
+      "description": "Jacob Young flies out to center fielder Jonah Cox.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -607,6 +723,13 @@
        "startTime": "2026-06-10T20:08:25.551Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 93.2,
+        "launchAngle": 56.0,
+        "totalDistance": 231.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -614,11 +737,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Nasim Nuñez called out on strikes."
+      "description": "Nasim Nuñez called out on strikes.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -678,11 +807,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Jung Hoo Lee strikes out swinging."
+      "description": "Jung Hoo Lee strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -756,11 +891,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Bryce Eldridge flies out to left fielder Daylen Lile."
+      "description": "Bryce Eldridge flies out to left fielder Daylen Lile.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -785,6 +926,13 @@
        "startTime": "2026-06-10T20:16:37.706Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 86.1,
+        "launchAngle": 53.0,
+        "totalDistance": 239.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -792,11 +940,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Daniel Susac singles on a line drive to left fielder Daylen Lile."
+      "description": "Daniel Susac singles on a line drive to left fielder Daylen Lile.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -835,6 +989,13 @@
        "startTime": "2026-06-10T20:17:49.670Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 68.8,
+        "launchAngle": 22.0,
+        "totalDistance": 201.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -842,11 +1003,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Victor Bericoto strikes out swinging."
+      "description": "Victor Bericoto strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 2,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -906,11 +1073,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Jorbit Vivas flies out to left fielder Victor Bericoto."
+      "description": "Jorbit Vivas flies out to left fielder Victor Bericoto.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -935,6 +1108,13 @@
        "startTime": "2026-06-10T20:22:32.884Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 73.0,
+        "launchAngle": 31.0,
+        "totalDistance": 236.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -942,11 +1122,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Keibert Ruiz singles on a line drive to left fielder Victor Bericoto."
+      "description": "Keibert Ruiz singles on a line drive to left fielder Victor Bericoto.",
+      "rbi": 0,
+      "awayScore": 0,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -992,6 +1178,13 @@
        "startTime": "2026-06-10T20:24:12.259Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 98.0,
+        "launchAngle": 17.0,
+        "totalDistance": 274.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -999,11 +1192,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "James Wood homers (18) on a fly ball to center field. Keibert Ruiz scores."
+      "description": "James Wood homers (18) on a fly ball to center field. Keibert Ruiz scores.",
+      "rbi": 2,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 75,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -1049,6 +1248,13 @@
        "startTime": "2026-06-10T20:26:13.554Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 104.1,
+        "launchAngle": 33.0,
+        "totalDistance": 405.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1056,11 +1262,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Curtis Mead flies out to center fielder Jonah Cox."
+      "description": "Curtis Mead flies out to center fielder Jonah Cox.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1092,6 +1304,13 @@
        "startTime": "2026-06-10T20:27:29.942Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 98.6,
+        "launchAngle": 29.0,
+        "totalDistance": 380.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1099,11 +1318,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Andrés Chaparro grounds out sharply, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Andrés Chaparro grounds out sharply, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1142,6 +1367,13 @@
        "startTime": "2026-06-10T20:28:58.456Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 102.2,
+        "launchAngle": -5.0,
+        "totalDistance": 26.0,
+        "trajectory": "ground_ball",
+        "hardness": "hard"
        }
       }
      ]
@@ -1149,11 +1381,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Jonah Cox strikes out swinging."
+      "description": "Jonah Cox strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1192,11 +1430,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Casey Schmitt grounds out, first baseman Andrés Chaparro to pitcher Foster Griffin."
+      "description": "Casey Schmitt grounds out, first baseman Andrés Chaparro to pitcher Foster Griffin.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1242,6 +1486,13 @@
        "startTime": "2026-06-10T20:33:25.758Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 70.6,
+        "launchAngle": 10.0,
+        "totalDistance": 98.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1249,11 +1500,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Luis Arraez singles on a ground ball to left fielder Daylen Lile."
+      "description": "Luis Arraez singles on a ground ball to left fielder Daylen Lile.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1278,6 +1535,13 @@
        "startTime": "2026-06-10T20:34:22.155Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 93.4,
+        "launchAngle": -10.0,
+        "totalDistance": 13.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1285,11 +1549,17 @@
     {
      "result": {
       "eventType": "force_out",
-      "description": "Matt Chapman grounds into a force out, shortstop Nasim Nuñez to second baseman Jorbit Vivas. Luis Arraez out at 2nd."
+      "description": "Matt Chapman grounds into a force out, shortstop Nasim Nuñez to second baseman Jorbit Vivas. Luis Arraez out at 2nd.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 3,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1328,6 +1598,13 @@
        "startTime": "2026-06-10T20:35:55.624Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 98.5,
+        "launchAngle": -23.0,
+        "totalDistance": 5.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1335,11 +1612,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Dylan Crews grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Dylan Crews grounds out, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1406,6 +1689,13 @@
        "startTime": "2026-06-10T20:40:07.306Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 88.8,
+        "launchAngle": -19.0,
+        "totalDistance": 10.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1413,11 +1703,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Daylen Lile grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers."
+      "description": "Daylen Lile grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1477,6 +1773,13 @@
        "startTime": "2026-06-10T20:42:44.673Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 100.8,
+        "launchAngle": 2.0,
+        "totalDistance": 60.0,
+        "trajectory": "ground_ball",
+        "hardness": "hard"
        }
       }
      ]
@@ -1484,11 +1787,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Jacob Young strikes out swinging."
+      "description": "Jacob Young strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1548,11 +1857,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Rafael Devers called out on strikes."
+      "description": "Rafael Devers called out on strikes.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1598,11 +1913,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Jung Hoo Lee grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro."
+      "description": "Jung Hoo Lee grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1627,6 +1948,13 @@
        "startTime": "2026-06-10T20:48:29.701Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 70.7,
+        "launchAngle": 9.0,
+        "totalDistance": 108.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1634,11 +1962,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Bryce Eldridge grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro."
+      "description": "Bryce Eldridge grounds out softly, pitcher Foster Griffin to first baseman Andrés Chaparro.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 4,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1656,6 +1990,13 @@
        "startTime": "2026-06-10T20:49:01.418Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 39.8,
+        "launchAngle": -50.0,
+        "totalDistance": 3.0,
+        "trajectory": "ground_ball",
+        "hardness": "soft"
        }
       }
      ]
@@ -1663,11 +2004,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Nasim Nuñez grounds out, shortstop Casey Schmitt to first baseman Rafael Devers."
+      "description": "Nasim Nuñez grounds out, shortstop Casey Schmitt to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1727,6 +2074,13 @@
        "startTime": "2026-06-10T20:53:08.936Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 88.8,
+        "launchAngle": -14.0,
+        "totalDistance": 9.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1734,11 +2088,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jorbit Vivas singles on a line drive to left fielder Victor Bericoto."
+      "description": "Jorbit Vivas singles on a line drive to left fielder Victor Bericoto.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1763,6 +2123,13 @@
        "startTime": "2026-06-10T20:54:03.539Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 74.1,
+        "launchAngle": 22.0,
+        "totalDistance": 212.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -1770,11 +2137,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Keibert Ruiz flies out to right fielder Jung Hoo Lee."
+      "description": "Keibert Ruiz flies out to right fielder Jung Hoo Lee.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1792,6 +2165,13 @@
        "startTime": "2026-06-10T20:54:39.694Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 78.7,
+        "launchAngle": 53.0,
+        "totalDistance": 229.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1799,11 +2179,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "James Wood flies out to left fielder Victor Bericoto."
+      "description": "James Wood flies out to left fielder Victor Bericoto.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1863,6 +2249,13 @@
        "startTime": "2026-06-10T20:57:08.093Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 101.6,
+        "launchAngle": 39.0,
+        "totalDistance": 345.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1870,11 +2263,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Daniel Susac grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro."
+      "description": "Daniel Susac grounds out, second baseman Jorbit Vivas to first baseman Andrés Chaparro.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -1934,6 +2333,13 @@
        "startTime": "2026-06-10T21:00:48.421Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 99.5,
+        "launchAngle": -16.0,
+        "totalDistance": 9.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -1941,11 +2347,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Nationals challenged (play at 1st), call on the field was overturned: Victor Bericoto grounds out, shortstop Nasim Nuñez to first baseman Andrés Chaparro."
+      "description": "Nationals challenged (play at 1st), call on the field was overturned: Victor Bericoto grounds out, shortstop Nasim Nuñez to first baseman Andrés Chaparro.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": true,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2019,6 +2431,13 @@
        "startTime": "2026-06-10T21:03:46.673Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 96.0,
+        "launchAngle": -12.0,
+        "totalDistance": 9.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2026,11 +2445,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jonah Cox singles on a fly ball to right fielder Dylan Crews."
+      "description": "Jonah Cox singles on a fly ball to right fielder Dylan Crews.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2069,6 +2494,13 @@
        "startTime": "2026-06-10T21:06:44.793Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 63.5,
+        "launchAngle": 39.0,
+        "totalDistance": 185.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2076,11 +2508,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Casey Schmitt lines out sharply to center fielder Jacob Young."
+      "description": "Casey Schmitt lines out sharply to center fielder Jacob Young.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 5,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2112,6 +2550,13 @@
        "startTime": "2026-06-10T21:08:10.575Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 103.6,
+        "launchAngle": 17.0,
+        "totalDistance": 363.0,
+        "trajectory": "line_drive",
+        "hardness": "hard"
        }
       }
      ]
@@ -2119,11 +2564,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Curtis Mead grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Curtis Mead grounds out, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2162,6 +2613,13 @@
        "startTime": "2026-06-10T21:10:59.588Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 81.5,
+        "launchAngle": -5.0,
+        "totalDistance": 19.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2169,11 +2627,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Andrés Chaparro grounds out, shortstop Casey Schmitt to first baseman Rafael Devers."
+      "description": "Andrés Chaparro grounds out, shortstop Casey Schmitt to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2205,6 +2669,13 @@
        "startTime": "2026-06-10T21:12:01.961Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 101.2,
+        "launchAngle": 8.0,
+        "totalDistance": 146.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2212,11 +2683,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Dylan Crews singles on a fly ball to right fielder Jung Hoo Lee."
+      "description": "Dylan Crews singles on a fly ball to right fielder Jung Hoo Lee.",
+      "rbi": 0,
+      "awayScore": 2,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2234,6 +2711,13 @@
        "startTime": "2026-06-10T21:12:32.300Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 71.7,
+        "launchAngle": 30.0,
+        "totalDistance": 228.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2241,11 +2725,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Daylen Lile singles on a fly ball to left fielder Drew Gilbert. Dylan Crews scores."
+      "description": "Daylen Lile singles on a fly ball to left fielder Drew Gilbert. Dylan Crews scores.",
+      "rbi": 1,
+      "awayScore": 3,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 70,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -2291,6 +2781,13 @@
        "startTime": "2026-06-10T21:14:24.724Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 65.4,
+        "launchAngle": 42.0,
+        "totalDistance": 190.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2298,11 +2795,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jacob Young singles on a line drive to center fielder Jonah Cox. Daylen Lile to 3rd."
+      "description": "Jacob Young singles on a line drive to center fielder Jonah Cox. Daylen Lile to 3rd.",
+      "rbi": 0,
+      "awayScore": 3,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2362,6 +2865,13 @@
        "startTime": "2026-06-10T21:17:07.483Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 105.7,
+        "launchAngle": 10.0,
+        "totalDistance": 247.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -2369,11 +2879,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Nasim Nuñez singles on a ground ball to left fielder Drew Gilbert. Daylen Lile scores. Jacob Young scores."
+      "description": "Nasim Nuñez singles on a ground ball to left fielder Drew Gilbert. Daylen Lile scores. Jacob Young scores.",
+      "rbi": 2,
+      "awayScore": 5,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -2447,6 +2963,13 @@
        "startTime": "2026-06-10T21:22:03.548Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 91.2,
+        "launchAngle": -13.0,
+        "totalDistance": 7.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2454,11 +2977,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jorbit Vivas singles on a ground ball to right fielder Jung Hoo Lee. Nasim Nuñez scores. Jorbit Vivas to 2nd."
+      "description": "Jorbit Vivas singles on a ground ball to right fielder Jung Hoo Lee. Nasim Nuñez scores. Jorbit Vivas to 2nd.",
+      "rbi": 1,
+      "awayScore": 6,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -2504,6 +3033,13 @@
        "startTime": "2026-06-10T21:23:58.505Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 96.3,
+        "launchAngle": 5.0,
+        "totalDistance": 100.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2511,11 +3047,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Keibert Ruiz pops out to shortstop Casey Schmitt."
+      "description": "Keibert Ruiz pops out to shortstop Casey Schmitt.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2568,6 +3110,13 @@
        "startTime": "2026-06-10T21:26:48.802Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 64.6,
+        "launchAngle": 35.0,
+        "totalDistance": 208.0,
+        "trajectory": "popup",
+        "hardness": "medium"
        }
       }
      ]
@@ -2575,11 +3124,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Luis Arraez lines out to left fielder Daylen Lile."
+      "description": "Luis Arraez lines out to left fielder Daylen Lile.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 0
      },
      "about": {
       "inning": 6,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2604,6 +3159,13 @@
        "startTime": "2026-06-10T21:29:22.280Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 91.4,
+        "launchAngle": 22.0,
+        "totalDistance": 291.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -2611,11 +3173,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "Matt Chapman homers (5) on a fly ball to left center field."
+      "description": "Matt Chapman homers (5) on a fly ball to left center field.",
+      "rbi": 1,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 6,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 38,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -2668,6 +3236,13 @@
        "startTime": "2026-06-10T21:31:21.500Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 107.0,
+        "launchAngle": 22.0,
+        "totalDistance": 421.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2675,11 +3250,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Rafael Devers flies out to right fielder Dylan Crews."
+      "description": "Rafael Devers flies out to right fielder Dylan Crews.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 6,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2711,6 +3292,13 @@
        "startTime": "2026-06-10T21:32:40.029Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 84.2,
+        "launchAngle": 58.0,
+        "totalDistance": 211.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -2718,11 +3306,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jung Hoo Lee singles on a line drive to right fielder Dylan Crews."
+      "description": "Jung Hoo Lee singles on a line drive to right fielder Dylan Crews.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 6,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2740,6 +3334,13 @@
        "startTime": "2026-06-10T21:33:14.351Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 99.4,
+        "launchAngle": 9.0,
+        "totalDistance": 208.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -2747,11 +3348,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Bryce Eldridge strikes out swinging."
+      "description": "Bryce Eldridge strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 6,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2818,11 +3425,17 @@
     {
      "result": {
       "eventType": "walk",
-      "description": "James Wood walks."
+      "description": "James Wood walks.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2889,11 +3502,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Curtis Mead singles on a pop up to second baseman Luis Arraez."
+      "description": "Curtis Mead singles on a pop up to second baseman Luis Arraez.",
+      "rbi": 0,
+      "awayScore": 6,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -2939,6 +3558,13 @@
        "startTime": "2026-06-10T21:41:00.648Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 68.4,
+        "launchAngle": 41.0,
+        "totalDistance": 208.0,
+        "trajectory": "popup",
+        "hardness": "medium"
        }
       }
      ]
@@ -2946,11 +3572,17 @@
     {
      "result": {
       "eventType": "double",
-      "description": "Luis García Jr. doubles (12) on a fly ball to left fielder Drew Gilbert. James Wood scores. Curtis Mead to 3rd."
+      "description": "Luis García Jr. doubles (12) on a fly ball to left fielder Drew Gilbert. James Wood scores. Curtis Mead to 3rd.",
+      "rbi": 1,
+      "awayScore": 7,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 34,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -2996,6 +3628,13 @@
        "startTime": "2026-06-10T21:43:02.004Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 98.2,
+        "launchAngle": 34.0,
+        "totalDistance": 355.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3003,11 +3642,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Dylan Crews grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers. Curtis Mead scores. Luis García Jr. to 3rd."
+      "description": "Dylan Crews grounds out sharply, shortstop Casey Schmitt to first baseman Rafael Devers. Curtis Mead scores. Luis García Jr. to 3rd.",
+      "rbi": 1,
+      "awayScore": 8,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -3032,6 +3677,13 @@
        "startTime": "2026-06-10T21:44:08.053Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 100.0,
+        "launchAngle": -1.0,
+        "totalDistance": 45.0,
+        "trajectory": "ground_ball",
+        "hardness": "hard"
        }
       }
      ]
@@ -3039,11 +3691,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Daylen Lile singles on a sharp line drive to right fielder Jung Hoo Lee. Luis García Jr. scores."
+      "description": "Daylen Lile singles on a sharp line drive to right fielder Jung Hoo Lee. Luis García Jr. scores.",
+      "rbi": 1,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -3075,6 +3733,13 @@
        "startTime": "2026-06-10T21:45:22.072Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 103.3,
+        "launchAngle": 14.0,
+        "totalDistance": 235.0,
+        "trajectory": "line_drive",
+        "hardness": "hard"
        }
       }
      ]
@@ -3082,11 +3747,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Jacob Young called out on strikes."
+      "description": "Jacob Young called out on strikes.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3167,11 +3838,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Nasim Nuñez lines out to center fielder Jonah Cox."
+      "description": "Nasim Nuñez lines out to center fielder Jonah Cox.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3203,6 +3880,13 @@
        "startTime": "2026-06-10T21:50:03.052Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 78.1,
+        "launchAngle": 26.0,
+        "totalDistance": 269.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -3210,11 +3894,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Daniel Susac pops out to first baseman Luis García Jr. in foul territory."
+      "description": "Daniel Susac pops out to first baseman Luis García Jr. in foul territory.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3260,6 +3950,13 @@
        "startTime": "2026-06-10T21:53:03.103Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 66.3,
+        "launchAngle": 72.0,
+        "totalDistance": 85.0,
+        "trajectory": "popup",
+        "hardness": "medium"
        }
       }
      ]
@@ -3267,11 +3964,17 @@
     {
      "result": {
       "eventType": "walk",
-      "description": "Drew Gilbert walks."
+      "description": "Drew Gilbert walks.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3338,11 +4041,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Jonah Cox strikes out swinging."
+      "description": "Jonah Cox strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3388,11 +4097,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Casey Schmitt singles on a sharp line drive to right fielder Dylan Crews. Drew Gilbert to 2nd."
+      "description": "Casey Schmitt singles on a sharp line drive to right fielder Dylan Crews. Drew Gilbert to 2nd.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3417,6 +4132,13 @@
        "startTime": "2026-06-10T21:57:35.405Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 101.4,
+        "launchAngle": 8.0,
+        "totalDistance": 168.0,
+        "trajectory": "line_drive",
+        "hardness": "hard"
        }
       }
      ]
@@ -3424,11 +4146,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Luis Arraez grounds out, shortstop Nasim Nuñez to first baseman Luis García Jr."
+      "description": "Luis Arraez grounds out, shortstop Nasim Nuñez to first baseman Luis García Jr.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 7,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3488,6 +4216,13 @@
        "startTime": "2026-06-10T21:59:55.795Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 82.2,
+        "launchAngle": -26.0,
+        "totalDistance": 6.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3495,11 +4230,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Jorbit Vivas grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Jorbit Vivas grounds out, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 8,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3545,6 +4286,13 @@
        "startTime": "2026-06-10T22:02:55.814Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 61.0,
+        "launchAngle": -26.0,
+        "totalDistance": 5.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3552,11 +4300,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Keibert Ruiz grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Keibert Ruiz grounds out, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 8,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3609,6 +4363,13 @@
        "startTime": "2026-06-10T22:04:43.016Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 89.2,
+        "launchAngle": -27.0,
+        "totalDistance": 6.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3616,11 +4377,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "James Wood strikes out swinging."
+      "description": "James Wood strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 1
      },
      "about": {
       "inning": 8,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3666,11 +4433,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "Matt Chapman homers (6) on a fly ball to center field."
+      "description": "Matt Chapman homers (6) on a fly ball to center field.",
+      "rbi": 1,
+      "awayScore": 9,
+      "homeScore": 2
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 38,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -3688,6 +4461,13 @@
        "startTime": "2026-06-10T22:07:58.398Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 101.4,
+        "launchAngle": 31.0,
+        "totalDistance": 409.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3695,11 +4475,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "Rafael Devers homers (9) on a fly ball to center field."
+      "description": "Rafael Devers homers (9) on a fly ball to center field.",
+      "rbi": 1,
+      "awayScore": 9,
+      "homeScore": 3
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 38,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -3724,6 +4510,13 @@
        "startTime": "2026-06-10T22:08:59.373Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 101.3,
+        "launchAngle": 37.0,
+        "totalDistance": 408.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -3731,11 +4524,17 @@
     {
      "result": {
       "eventType": "walk",
-      "description": "Jung Hoo Lee walks."
+      "description": "Jung Hoo Lee walks.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 3
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3795,11 +4594,17 @@
     {
      "result": {
       "eventType": "walk",
-      "description": "Bryce Eldridge walks."
+      "description": "Bryce Eldridge walks.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 3
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -3873,11 +4678,17 @@
     {
      "result": {
       "eventType": "double",
-      "description": "Daniel Susac doubles (5) on a line drive to left fielder Daylen Lile. Jung Hoo Lee scores. Bryce Eldridge to 3rd."
+      "description": "Daniel Susac doubles (5) on a line drive to left fielder Daylen Lile. Jung Hoo Lee scores. Bryce Eldridge to 3rd.",
+      "rbi": 1,
+      "awayScore": 9,
+      "homeScore": 4
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 34,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -3944,6 +4755,13 @@
        "startTime": "2026-06-10T22:17:04.049Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 79.4,
+        "launchAngle": 20.0,
+        "totalDistance": 216.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -3951,11 +4769,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Drew Gilbert grounds out, first baseman Luis García Jr. to pitcher Orlando Ribalta. Bryce Eldridge scores. Daniel Susac to 3rd."
+      "description": "Drew Gilbert grounds out, first baseman Luis García Jr. to pitcher Orlando Ribalta. Bryce Eldridge scores. Daniel Susac to 3rd.",
+      "rbi": 1,
+      "awayScore": 9,
+      "homeScore": 5
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -4015,6 +4839,13 @@
        "startTime": "2026-06-10T22:21:28.181Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 82.2,
+        "launchAngle": -6.0,
+        "totalDistance": 20.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4022,11 +4853,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Buddy Kennedy challenged (pitch result), call on the field was confirmed: Buddy Kennedy called out on strikes."
+      "description": "Buddy Kennedy challenged (pitch result), call on the field was confirmed: Buddy Kennedy called out on strikes.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 6
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 14,
+      "hasReview": true,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4100,11 +4937,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Casey Schmitt flies out to center fielder Jacob Young."
+      "description": "Casey Schmitt flies out to center fielder Jacob Young.",
+      "rbi": 0,
+      "awayScore": 9,
+      "homeScore": 6
      },
      "about": {
       "inning": 8,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4122,6 +4965,13 @@
        "startTime": "2026-06-10T22:25:31.894Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 93.2,
+        "launchAngle": 58.0,
+        "totalDistance": 243.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4129,11 +4979,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "Curtis Mead homers (10) on a fly ball to left center field."
+      "description": "Curtis Mead homers (10) on a fly ball to left center field.",
+      "rbi": 1,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 38,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -4207,6 +5063,13 @@
        "startTime": "2026-06-10T22:29:14.541Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 101.1,
+        "launchAngle": 32.0,
+        "totalDistance": 399.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4214,11 +5077,17 @@
     {
      "result": {
       "eventType": "strikeout",
-      "description": "Luis García Jr. strikes out swinging."
+      "description": "Luis García Jr. strikes out swinging.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 14,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4278,11 +5147,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Dylan Crews lines out sharply to second baseman Luis Arraez."
+      "description": "Dylan Crews lines out sharply to second baseman Luis Arraez.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4307,6 +5182,13 @@
        "startTime": "2026-06-10T22:31:27.333Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 100.2,
+        "launchAngle": 7.0,
+        "totalDistance": 193.0,
+        "trajectory": "line_drive",
+        "hardness": "hard"
        }
       }
      ]
@@ -4314,11 +5196,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Daylen Lile singles on a line drive to left fielder Eric Haase."
+      "description": "Daylen Lile singles on a line drive to left fielder Eric Haase.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4336,6 +5224,13 @@
        "startTime": "2026-06-10T22:31:55.811Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 91.7,
+        "launchAngle": 9.0,
+        "totalDistance": 184.0,
+        "trajectory": "line_drive",
+        "hardness": "medium"
        }
       }
      ]
@@ -4343,11 +5238,17 @@
     {
      "result": {
       "eventType": "field_out",
-      "description": "Jacob Young grounds out, third baseman Matt Chapman to first baseman Rafael Devers."
+      "description": "Jacob Young grounds out, third baseman Matt Chapman to first baseman Rafael Devers.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": true
+      "isTopInning": true,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4393,6 +5294,13 @@
        "startTime": "2026-06-10T22:34:35.442Z",
        "details": {
         "description": "In play, out(s)"
+       },
+       "hitData": {
+        "launchSpeed": 97.1,
+        "launchAngle": -0.0,
+        "totalDistance": 46.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4400,11 +5308,17 @@
     {
      "result": {
       "eventType": "double",
-      "description": "Luis Arraez doubles (14) on a fly ball to right fielder Dylan Crews."
+      "description": "Luis Arraez doubles (14) on a fly ball to right fielder Dylan Crews.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 6
      },
      "about": {
       "inning": 9,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 34,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4450,6 +5364,13 @@
        "startTime": "2026-06-10T22:38:04.678Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 99.0,
+        "launchAngle": 24.0,
+        "totalDistance": 380.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4457,11 +5378,17 @@
     {
      "result": {
       "eventType": "double",
-      "description": "Matt Chapman doubles (17) on a sharp fly ball to right fielder Dylan Crews. Luis Arraez scores."
+      "description": "Matt Chapman doubles (17) on a sharp fly ball to right fielder Dylan Crews. Luis Arraez scores.",
+      "rbi": 1,
+      "awayScore": 10,
+      "homeScore": 7
      },
      "about": {
       "inning": 9,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 34,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -4500,6 +5427,13 @@
        "startTime": "2026-06-10T22:39:31.982Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 102.4,
+        "launchAngle": 27.0,
+        "totalDistance": 358.0,
+        "trajectory": "fly_ball",
+        "hardness": "hard"
        }
       }
      ]
@@ -4507,11 +5441,17 @@
     {
      "result": {
       "eventType": "walk",
-      "description": "Rafael Devers walks."
+      "description": "Rafael Devers walks.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 7
      },
      "about": {
       "inning": 9,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 0,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4578,11 +5518,17 @@
     {
      "result": {
       "eventType": "single",
-      "description": "Jung Hoo Lee singles on a ground ball to left fielder Daylen Lile. Matt Chapman to 3rd. Rafael Devers to 2nd."
+      "description": "Jung Hoo Lee singles on a ground ball to left fielder Daylen Lile. Matt Chapman to 3rd. Rafael Devers to 2nd.",
+      "rbi": 0,
+      "awayScore": 10,
+      "homeScore": 7
      },
      "about": {
       "inning": 9,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 33,
+      "hasReview": false,
+      "isScoringPlay": false
      },
      "matchup": {
       "pitcher": {
@@ -4642,6 +5588,13 @@
        "startTime": "2026-06-10T22:47:00.648Z",
        "details": {
         "description": "In play, no out"
+       },
+       "hitData": {
+        "launchSpeed": 97.4,
+        "launchAngle": 4.0,
+        "totalDistance": 111.0,
+        "trajectory": "ground_ball",
+        "hardness": "medium"
        }
       }
      ]
@@ -4649,11 +5602,17 @@
     {
      "result": {
       "eventType": "home_run",
-      "description": "Bryce Eldridge hits a grand slam (4) to right field. Matt Chapman scores. Rafael Devers scores. Jung Hoo Lee scores."
+      "description": "Bryce Eldridge hits a grand slam (4) to right field. Matt Chapman scores. Rafael Devers scores. Jung Hoo Lee scores.",
+      "rbi": 4,
+      "awayScore": 10,
+      "homeScore": 11
      },
      "about": {
       "inning": 9,
-      "isTopInning": false
+      "isTopInning": false,
+      "captivatingIndex": 95,
+      "hasReview": false,
+      "isScoringPlay": true
      },
      "matchup": {
       "pitcher": {
@@ -4685,6 +5644,13 @@
        "startTime": "2026-06-10T22:48:18.988Z",
        "details": {
         "description": "In play, run(s)"
+       },
+       "hitData": {
+        "launchSpeed": 98.1,
+        "launchAngle": 44.0,
+        "totalDistance": 326.0,
+        "trajectory": "fly_ball",
+        "hardness": "medium"
        }
       }
      ]

--- a/annotator/tests/test_eval.py
+++ b/annotator/tests/test_eval.py
@@ -254,3 +254,115 @@ def test_a_feed_without_an_eventType_leaves_the_outcome_empty(events):
     """Back-compat, and the reason every existing suite is untouched: the
     shared fixture types no play, so it produces no outcome."""
     assert all(e.event_type == "" for e in events)
+
+
+# --- how notable a play was, and how hard the ball was hit -------------------
+#
+# The outcome answers "who homered". It does not answer "what were the best
+# moments", "which was the hardest hit ball", "how far did that home run go" or
+# "which calls were contested". The feed answers all four, and the parser threw
+# every one of those fields away:
+#
+#   about.captivatingIndex   MLB's own notability score for the play
+#   about.hasReview          the call went to a review
+#   about.isScoringPlay      a run scored
+#   result.rbi / awayScore / homeScore
+#   playEvents[].hitData     exit velocity, launch angle, distance, trajectory
+#
+# Nothing here is computed or normalised. Each field is carried verbatim, so the
+# ranking a client gets is MLB's, not one this backend invented.
+
+#: The captivating index of every play of game 823215, counted from the live
+#: statsapi payload. 43 plays score 0, so the field genuinely discriminates.
+PILOT_CAPTIVATING = {95: 1, 75: 1, 70: 1, 38: 4, 34: 4, 33: 17, 14: 13, 0: 43}
+PILOT_REVIEWS = 2
+PILOT_SCORING_PLAYS = 15
+PILOT_BATTED_BALLS = 66
+#: The hardest hit ball and the longest home run of the game, in the feed's own
+#: units (mph, feet).
+PILOT_HARDEST_HIT_MPH = 107.9
+PILOT_LONGEST_HOME_RUN_FT = 421.0
+
+
+def test_the_pilot_feed_scores_every_play_for_notability(pilot_events):
+    """The measurement the "best moments" question rests on. MLB scores every
+    play, so the answer is a read of the feed rather than a model's opinion."""
+    ended = [e for e in pilot_events if e.event_type]
+    assert len(ended) == PILOT_PLAYS
+    assert dict(Counter(e.captivating_index for e in ended)) == PILOT_CAPTIVATING
+    top = max(ended, key=lambda e: e.captivating_index)
+    assert top.captivating_index == 95
+    assert top.event_type == "home_run"
+    assert "grand slam" in top.description
+
+
+def test_the_pilot_feed_marks_the_contested_and_the_scoring_plays(pilot_events):
+    """Two reviewed calls and 15 scoring plays, off the feed's own flags."""
+    ended = [e for e in pilot_events if e.event_type]
+    assert sum(1 for e in ended if e.has_review) == PILOT_REVIEWS
+    scoring = [e for e in ended if e.is_scoring_play]
+    assert len(scoring) == PILOT_SCORING_PLAYS
+    # A scoring play moves the score, so the final one holds the final score.
+    last = scoring[-1]
+    assert (last.away_score, last.home_score) == (10, 11)
+    assert sum(e.rbi for e in ended) == 20
+
+
+def test_the_batted_ball_measurements_ride_on_the_pitch_that_was_hit(pilot_events):
+    """`hitData` is a property of one pitch, not of the play, so it rides on
+    that pitch. 66 of the 344 pitches were hit."""
+    hit = [e for e in pilot_events if e.hit_data]
+    assert len(hit) == PILOT_BATTED_BALLS
+    assert all(e.hit_data.launch_speed is not None for e in hit)
+    hardest = max(hit, key=lambda e: e.hit_data.launch_speed)
+    assert hardest.hit_data.launch_speed == PILOT_HARDEST_HIT_MPH
+    assert hardest.hit_data.hardness == "hard"
+    homers = [e for e in hit if e.event_type == "home_run"]
+    assert len(homers) == 6
+    longest = max(homers, key=lambda e: e.hit_data.total_distance)
+    assert longest.hit_data.total_distance == PILOT_LONGEST_HOME_RUN_FT
+    assert longest.hit_data.trajectory == "fly_ball"
+
+
+def test_a_pitch_inside_the_at_bat_carries_no_play_level_field(pilot_events):
+    """The play-level fields ride where `event_type` rides: on the pitch that
+    ended the at-bat. One play must produce one notable moment, not one per
+    pitch, or a 6 pitch at-bat would report the same grand slam six times."""
+    inside = [e for e in pilot_events if not e.event_type]
+    assert inside, "the game must have multi-pitch at-bats, or this proves nothing"
+    assert all(e.captivating_index == 0 for e in inside)
+    assert all(not e.has_review and not e.is_scoring_play for e in inside)
+    assert all(e.rbi == 0 and e.away_score == 0 and e.home_score == 0 for e in inside)
+
+
+def test_a_feed_without_the_notability_fields_keeps_the_defaults(events):
+    """Back-compat: every field is optional, so a payload without them parses
+    exactly as it did before."""
+    assert all(e.captivating_index == 0 for e in events)
+    assert all(not e.has_review and not e.is_scoring_play for e in events)
+    assert all(e.rbi == 0 and e.away_score == 0 and e.home_score == 0 for e in events)
+    assert all(e.hit_data is None for e in events)
+
+
+def test_a_hitData_with_nothing_measured_reads_as_no_hit_data():
+    """An empty or unusable `hitData` must not become a batted ball with no
+    measurements in it, which would claim a hit that nothing measured."""
+    feed = _feed_with_clubs(top_inning=True)
+    play = feed["liveData"]["plays"]["allPlays"][0]
+    play["playEvents"][0]["hitData"] = {}
+    assert ground_truth.parse_pitches(feed)[0].hit_data is None
+    play["playEvents"][0]["hitData"] = {"launchSpeed": None, "trajectory": ""}
+    assert ground_truth.parse_pitches(feed)[0].hit_data is None
+
+
+def test_a_partly_measured_batted_ball_keeps_what_the_feed_had():
+    """Statcast misses a field now and then. What it did measure must survive,
+    and what it did not must stay absent rather than become a zero."""
+    feed = _feed_with_clubs(top_inning=True)
+    play = feed["liveData"]["plays"]["allPlays"][0]
+    play["playEvents"][0]["hitData"] = {"launchSpeed": 96.4, "trajectory": "line_drive"}
+    hit = ground_truth.parse_pitches(feed)[0].hit_data
+    assert hit.launch_speed == 96.4
+    assert hit.trajectory == "line_drive"
+    assert hit.launch_angle is None and hit.total_distance is None
+    assert hit.hardness == ""

--- a/annotator/tests/test_playbyplay.py
+++ b/annotator/tests/test_playbyplay.py
@@ -10,17 +10,21 @@ with a perfect metadata source.
 """
 
 import json
+import re
 from pathlib import Path
 
 import pytest
 
 from dirstral_annotator.eval import ground_truth
 from dirstral_annotator.eval.align import Anchor, estimate
-from dirstral_annotator.eval.ground_truth import PitchEvent
+from dirstral_annotator.eval.ground_truth import HitData, PitchEvent
 from dirstral_annotator.eval.score import score
 from dirstral_annotator.fusion import fuse
 from dirstral_annotator.model import Player, slug_entity_id
-from dirstral_annotator.recognizers.playbyplay import PlayByPlayRecognizer
+from dirstral_annotator.recognizers.playbyplay import (
+    NOTABILITY_EVENTS,
+    PlayByPlayRecognizer,
+)
 from dirstral_annotator.roster import Roster
 
 MEDIA = Path("game.mp4")  # unused by the recognizer: labels are external
@@ -403,7 +407,7 @@ def test_the_pilot_game_emits_one_outcome_per_at_bat(pilot_events, pilot_roster)
     for cue in cues:
         if cue.event in counted:
             counted[cue.event] += 1
-        else:
+        elif cue.event not in NOTABILITY_EVENTS:
             outcomes += 1
     assert counted == {"pitch": 344, "at_bat": 344}
     assert outcomes == 84
@@ -432,3 +436,315 @@ def test_the_phase_1_metric_does_not_move(pilot_events, pilot_roster):
     # that the number is the same one, and that no outcome cue became a false
     # positive.
     assert after_card.overall.tp == 342 and after_card.overall.fp == 0
+
+
+# --- how notable a play was, and how hard the ball was hit -------------------
+#
+# The outcome makes "who homered" a selection. It leaves four questions with no
+# handle at all: "the most captivating moments", "the hardest hit ball", "the
+# longest home run", "the contested calls". The feed answers all four, and every
+# one of those fields was dropped.
+#
+# A number is not an event and not an entity, and the design 0004 wire schema
+# closes `annotations[]` (`additionalProperties: false`), so it has no numeric
+# field to put one in. So each fact reaches a client twice over, by two
+# channels, each doing the job it can do:
+#
+#   `event`  a token to FILTER on: `captivating`, `reviewed`, `scoring_play`,
+#            `batted_ball`. One cue carries one event string, so N selectable
+#            facts need N cues; they share the ending pitch's span, so the
+#            answer path groups them into one moment (#784).
+#   `text`   the number itself, verbatim, in the sentence that gets indexed. It
+#            is what a client RANKS on, and what an answer quotes.
+#
+# The threshold question matters. `captivatingIndex` is a number, and the only
+# boundary the feed itself draws in it is zero: 43 of the 84 plays score exactly
+# 0. So `captivating` means "the feed scored this above zero", and the score
+# rides in the text. Any sharper cut (>= 33, >= 70) would be this backend's
+# judgement baked into the index, where no client could undo it.
+
+CAPTIVATING_IN_TEXT = re.compile(r"captivating index (\d+)")
+SPEED_IN_TEXT = re.compile(r"exit velocity ([\d.]+) mph")
+DISTANCE_IN_TEXT = re.compile(r"distance ([\d.]+) ft")
+
+HARD_HIT = HitData(
+    launch_speed=107.0, launch_angle=28.0, total_distance=421.0,
+    trajectory="fly_ball", hardness="hard",
+)
+
+
+def _notable(**kw):
+    """The pitch that ended an at-bat, carrying what the feed said about it."""
+    return _outcome("home_run", **kw)
+
+
+def test_a_captivating_play_becomes_its_own_event(roster):
+    """The "best moments" question, answered by selection. The event says the
+    feed scored the play above zero; the score itself rides in the text."""
+    cues = PlayByPlayRecognizer(
+        [_notable(captivating_index=95)], 0.0, roster
+    ).recognize(MEDIA)
+    moment = next(c for c in cues if c.event == "captivating")
+    assert moment.entity_ids == ("player:ramos-heliot", "team:san-francisco-giants")
+    assert moment.start_s == 997.0 and moment.end_s == 1005.0  # the ending pitch
+    assert CAPTIVATING_IN_TEXT.search(moment.text).group(1) == "95"
+    assert moment.text.startswith("Captivating moment")
+    assert "Heliot Ramos" in moment.text and "bottom of the 9th" in moment.text
+    assert "homers (9) on a fly ball" in moment.text
+    assert "Giants" not in moment.text  # the club stays an entity, as before
+
+
+def test_a_play_the_feed_scores_zero_is_not_a_captivating_moment(roster):
+    """43 of the pilot game's 84 plays score 0. Zero is the one boundary the
+    feed draws, so it is the one this recognizer uses."""
+    for index in (0, -1):
+        cues = PlayByPlayRecognizer(
+            [_notable(captivating_index=index)], 0.0, roster
+        ).recognize(MEDIA)
+        assert "captivating" not in [c.event for c in cues]
+
+
+def test_the_recognizer_invents_no_threshold_of_its_own(roster):
+    """A play the feed scores 1 is captivating, exactly like a play it scores
+    95. The ranking is the feed's number, not a cut this backend chose."""
+    for index in (1, 14, 33, 95):
+        cues = PlayByPlayRecognizer(
+            [_notable(captivating_index=index)], 0.0, roster
+        ).recognize(MEDIA)
+        moment = next(c for c in cues if c.event == "captivating")
+        assert CAPTIVATING_IN_TEXT.search(moment.text).group(1) == str(index)
+
+
+def test_a_contested_call_becomes_its_own_event(roster):
+    """"Which calls were contested" is `hasReview`, which the feed sets on the
+    2 plays of the pilot game that went to a review."""
+    cues = PlayByPlayRecognizer([_notable(has_review=True)], 0.0, roster).recognize(MEDIA)
+    review = next(c for c in cues if c.event == "reviewed")
+    assert review.entity_ids == ("player:ramos-heliot", "team:san-francisco-giants")
+    assert review.text.startswith("Reviewed call")
+    assert "homers (9) on a fly ball" in review.text
+    without = PlayByPlayRecognizer([_notable()], 0.0, roster).recognize(MEDIA)
+    assert "reviewed" not in [c.event for c in without]
+
+
+def test_a_scoring_play_states_the_runs_and_the_score(roster):
+    """The score is the pair the feed carries, after the play. The clubs are
+    NOT named: writing a club into the text is the measured retrieval
+    regression (design 0004 §6.1), so the halves are named instead."""
+    cues = PlayByPlayRecognizer(
+        [_notable(is_scoring_play=True, rbi=4, away_score=3, home_score=9)], 0.0, roster
+    ).recognize(MEDIA)
+    scoring = next(c for c in cues if c.event == "scoring_play")
+    assert scoring.text.startswith("Scoring play (4 RBI, score: away 3, home 9)")
+    assert "Nationals" not in scoring.text and "Giants" not in scoring.text
+
+
+def test_a_scoring_play_with_no_rbi_states_no_rbi(roster):
+    """A run can score without an RBI (an error, a wild pitch). "0 RBI" would
+    read as a claim about the batter that the feed did not make."""
+    cues = PlayByPlayRecognizer(
+        [_notable(is_scoring_play=True, rbi=0, away_score=1, home_score=0)], 0.0, roster
+    ).recognize(MEDIA)
+    scoring = next(c for c in cues if c.event == "scoring_play")
+    assert scoring.text.startswith("Scoring play (score: away 1, home 0)")
+
+
+def test_a_batted_ball_carries_every_measurement_the_feed_took(roster):
+    """"The hardest hit ball" and "the longest home run" are one number each.
+    The schema has no numeric field, so the number rides in the indexed text,
+    in the feed's own units, and a client ranks on it."""
+    cues = PlayByPlayRecognizer([_notable(hit_data=HARD_HIT)], 0.0, roster).recognize(MEDIA)
+    hit = next(c for c in cues if c.event == "batted_ball")
+    assert hit.entity_ids == ("player:ramos-heliot", "team:san-francisco-giants")
+    assert hit.text.startswith(
+        "Batted ball: Heliot Ramos vs Opp Ace (bottom of the 9th): "
+        "exit velocity 107 mph, launch angle 28 degrees, distance 421 ft, "
+        "fly ball, hard contact"
+    )
+    # The play result rides along, so one chunk answers "the longest home run"
+    # without a join across cues.
+    assert "homers (9) on a fly ball" in hit.text
+    assert SPEED_IN_TEXT.search(hit.text).group(1) == "107"
+    assert DISTANCE_IN_TEXT.search(hit.text).group(1) == "421"
+
+
+def test_a_measurement_the_feed_did_not_take_is_left_out(roster):
+    """Statcast misses a field now and then. The cue then states less; it does
+    not state a zero the tracking never measured."""
+    partial = HitData(launch_speed=96.4, trajectory="line_drive")
+    cues = PlayByPlayRecognizer([_notable(hit_data=partial)], 0.0, roster).recognize(MEDIA)
+    hit = next(c for c in cues if c.event == "batted_ball")
+    assert "exit velocity 96.4 mph" in hit.text
+    assert "line drive" in hit.text
+    assert "launch angle" not in hit.text
+    assert "distance" not in hit.text
+    assert "contact" not in hit.text
+
+
+def test_a_batted_ball_with_nothing_measured_emits_no_cue(roster):
+    """An empty measurement set has nothing to rank on and nothing to read, so
+    it must not become a cue at all."""
+    cues = PlayByPlayRecognizer([_notable(hit_data=HitData())], 0.0, roster).recognize(MEDIA)
+    assert "batted_ball" not in [c.event for c in cues]
+
+
+def test_the_new_cues_need_a_rostered_batter(roster):
+    """Each new cue is a statement about the play, and the play's actor is the
+    batter, exactly like the outcome cue. With no rostered batter there is
+    nobody to key it on, so the pitcher keeps his `pitch` cue alone."""
+    ev = _notable(
+        pitcher_id=WEBB, pitcher_name="Logan Webb",
+        batter_id=OPP_BATTER, batter_name="Opp Guy",
+        captivating_index=95, has_review=True, is_scoring_play=True,
+        hit_data=HARD_HIT,
+    )
+    cues = PlayByPlayRecognizer([ev], 0.0, roster).recognize(MEDIA)
+    assert [c.event for c in cues] == ["pitch"]
+
+
+def test_the_new_cues_change_no_existing_cue(roster):
+    """THE CONTRACT, again. #620 was caused by retagging, so this change may
+    only add. The `pitch`, `at_bat` and outcome cues must be identical with and
+    without every new field."""
+    plain = _notable(pitcher_id=WEBB, pitcher_name="Logan Webb")
+    loaded = _notable(
+        pitcher_id=WEBB, pitcher_name="Logan Webb",
+        captivating_index=95, has_review=True, is_scoring_play=True,
+        rbi=4, away_score=3, home_score=9, hit_data=HARD_HIT,
+    )
+    before = PlayByPlayRecognizer([plain], 0.0, roster).recognize(MEDIA)
+    after = PlayByPlayRecognizer([loaded], 0.0, roster).recognize(MEDIA)
+
+    assert [c.event for c in before] == ["pitch", "at_bat", "home_run"]
+    assert [c.event for c in after] == [
+        "pitch", "at_bat", "home_run",
+        "batted_ball", "captivating", "reviewed", "scoring_play",
+    ]
+    assert after[:3] == before  # byte-for-byte, entities and text too
+
+
+def test_a_whole_measurement_loses_its_trailing_zero_and_nothing_else():
+    """The number is the feed's. "107.0 mph" reads worse than "107 mph" and
+    means the same thing, so the redundant zero goes; 107.9 keeps every digit,
+    because rounding a measurement a client ranks on would change the answer."""
+    from dirstral_annotator.recognizers.playbyplay import measurement_phrase
+    assert measurement_phrase(HitData(launch_speed=107.0)) == "exit velocity 107 mph"
+    assert measurement_phrase(HitData(launch_speed=107.9)) == "exit velocity 107.9 mph"
+    assert measurement_phrase(HitData(launch_angle=-7.0)) == "launch angle -7 degrees"
+    assert measurement_phrase(HitData(total_distance=0.0)) == "distance 0 ft"
+    assert measurement_phrase(HitData(trajectory="ground_ball")) == "ground ball"
+    assert measurement_phrase(HitData()) == ""
+
+
+def test_no_new_event_can_take_a_role_event_name():
+    """The #620 guard, at the vocabulary level: the pitcher-keyed metric reads
+    `event == "pitch"`, so no cue this recognizer adds may ever be named one of
+    the role events."""
+    from dirstral_annotator.recognizers.playbyplay import ROLE_EVENTS
+    assert not set(NOTABILITY_EVENTS).intersection(ROLE_EVENTS)
+
+
+# --- the pilot game, whole --------------------------------------------------
+
+#: Game 823215 again, counted off the feed: 84 plays, of which 43 score 0 on the
+#: captivating index, 2 went to a review and 15 scored a run; 66 of the 344
+#: pitches were hit, and the feed measured every one of them.
+PILOT_CAPTIVATING = 41
+PILOT_REVIEWS = 2
+PILOT_SCORING_PLAYS = 15
+PILOT_BATTED_BALLS = 66
+
+
+def test_the_pilot_games_notable_moments_are_all_selectable(pilot_events, pilot_roster):
+    """Every new event, counted on the real game rather than on a shape
+    invented here. Both clubs are rostered, so every play has a batter to key
+    on and the cue counts are the play counts."""
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    counted = {event: 0 for event in NOTABILITY_EVENTS}
+    for cue in cues:
+        if cue.event in counted:
+            counted[cue.event] += 1
+    assert counted == {
+        "captivating": PILOT_CAPTIVATING,
+        "reviewed": PILOT_REVIEWS,
+        "scoring_play": PILOT_SCORING_PLAYS,
+        "batted_ball": PILOT_BATTED_BALLS,
+    }
+
+
+def test_the_best_moment_of_the_pilot_game_ranks_first_on_the_feeds_number(
+    pilot_events, pilot_roster
+):
+    """"Find the most captivating moments of the game", end to end: filter on
+    the event, rank on the number in the text. The answer is the grand slam,
+    which is the play MLB scored highest, and no model opinion is involved."""
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    moments = [c for c in cues if c.event == "captivating"]
+    assert len(moments) == PILOT_CAPTIVATING
+    ranked = sorted(
+        moments,
+        key=lambda c: -int(CAPTIVATING_IN_TEXT.search(c.text).group(1)),
+    )
+    assert CAPTIVATING_IN_TEXT.search(ranked[0].text).group(1) == "95"
+    assert "grand slam" in ranked[0].text
+    assert ranked[0].entity_ids[0] == "player:bryce-eldridge"
+    # It really is a ranking and not one lucky play: the next two are the other
+    # two plays the feed scored above 38.
+    assert [CAPTIVATING_IN_TEXT.search(c.text).group(1) for c in ranked[1:3]] == \
+        ["75", "70"]
+
+
+def test_the_hardest_hit_ball_and_the_longest_home_run_are_rankable(
+    pilot_events, pilot_roster
+):
+    """The two measurement questions, answered off one cue each: filter
+    `batted_ball`, then rank on the number the text carries."""
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    hits = [c for c in cues if c.event == "batted_ball"]
+    assert len(hits) == PILOT_BATTED_BALLS
+
+    hardest = max(hits, key=lambda c: float(SPEED_IN_TEXT.search(c.text).group(1)))
+    assert SPEED_IN_TEXT.search(hardest.text).group(1) == "107.9"
+    assert hardest.entity_ids[0] == "player:matt-chapman"
+    assert "singles" in hardest.text  # the hardest hit ball was not a home run
+
+    homers = [c for c in hits if "homers" in c.text or "grand slam" in c.text]
+    assert len(homers) == 6
+    longest = max(homers, key=lambda c: float(DISTANCE_IN_TEXT.search(c.text).group(1)))
+    assert DISTANCE_IN_TEXT.search(longest.text).group(1) == "421"
+    assert longest.entity_ids[0] == "player:matt-chapman"
+    # And the longest home run is NOT the most captivating one: the grand slam
+    # the feed scored 95 travelled 326 ft, the shortest of the six. The two
+    # signals are independent, which is why both are carried.
+    assert "grand slam" not in longest.text
+
+
+def test_the_contested_calls_of_the_pilot_game_are_selectable(pilot_events, pilot_roster):
+    """Two plays in 84. Top-k semantic search over prose has no chance of
+    finding exactly those two; `events: ["reviewed"]` returns them and nothing
+    else."""
+    cues = PlayByPlayRecognizer(pilot_events, 0.0, pilot_roster).recognize(MEDIA)
+    reviews = [c for c in cues if c.event == "reviewed"]
+    assert len(reviews) == PILOT_REVIEWS
+    assert all(c.text.startswith("Reviewed call") for c in reviews)
+
+
+def test_the_phase_1_metric_still_does_not_move(pilot_events, pilot_roster):
+    """The same proof as for the outcome cues, over the notability cues too:
+    the pitcher-keyed scorecard is equal term by term with and without them."""
+    alignment = estimate([Anchor(pilot_events[0].epoch_s, 60.0)])
+    cues = PlayByPlayRecognizer(
+        pilot_events, alignment.offset_s, pilot_roster
+    ).recognize(MEDIA)
+    roles = [c for c in cues if c.event in ("pitch", "at_bat")]
+    notable = [c for c in cues if c.event in NOTABILITY_EVENTS]
+    assert len(notable) == 124  # 41 + 2 + 15 + 66, really there
+
+    with_all = score(fuse(cues), pilot_events, alignment, pilot_roster)
+    roles_only = score(fuse(roles), pilot_events, alignment, pilot_roster)
+
+    assert with_all.total_events == roles_only.total_events == 344
+    assert vars(with_all.overall) == vars(roles_only.overall)
+    assert with_all.per_source_found == roles_only.per_source_found
+    assert dict(with_all.per_player) == dict(roles_only.per_player)
+    assert with_all.overall.tp == 342 and with_all.overall.fp == 0

--- a/annotator/tests/test_schema_agreement.py
+++ b/annotator/tests/test_schema_agreement.py
@@ -15,7 +15,11 @@ import jsonschema
 import pytest
 
 from dirstral_annotator.emit import build_response
-from dirstral_annotator.model import Annotation, Document
+from dirstral_annotator.eval import ground_truth
+from dirstral_annotator.fusion import fuse
+from dirstral_annotator.model import Annotation, Document, Player, slug_entity_id
+from dirstral_annotator.recognizers.playbyplay import NOTABILITY_EVENTS, PlayByPlayRecognizer
+from dirstral_annotator.roster import Roster
 
 SCHEMA_REL = "docs/design/0004-recognize-response.schema.json"
 
@@ -49,3 +53,41 @@ def test_serve_response_validates_against_design_0004_draft_schema():
     )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     jsonschema.validate(build_response(doc), schema)
+
+
+def test_the_notability_cues_are_legal_wire():
+    """The whole pilot game, through the real path, against the same schema.
+
+    `annotations[]` is closed (`additionalProperties: false`), so the contract
+    has no numeric field: a captivating index or an exit velocity can only reach
+    a client inside `text`, and a fact can only be selected on through `event`,
+    which the contract leaves as a "producer-defined event vocabulary". This
+    validates that the cues carrying them are legal wire, and it fails the day
+    somebody answers "where does the number go?" by inventing a field here
+    instead of proposing one in dirstral-spec.
+    """
+    schema_path = find_schema()
+    if schema_path is None:
+        pytest.skip("dirstral-spec design-0004 draft schema not available")
+    import json
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    feed = ground_truth.load_game(Path(__file__).parent / "fixtures" / "gumbo_823215.json")
+    events = ground_truth.parse_pitches(feed)
+    players, mlbam = [], {}
+    for ev in events:
+        for pid, name in ((ev.pitcher_id, ev.pitcher_name), (ev.batter_id, ev.batter_name)):
+            if pid and pid not in mlbam:
+                player = Player(id=slug_entity_id(name), name=name)
+                mlbam[pid] = player.id
+                players.append(player)
+    roster = Roster(players, mlbam)
+
+    cues = PlayByPlayRecognizer(events, 0.0, roster).recognize(Path("game.mp4"))
+    annotations = fuse(cues)
+    doc = Document(media="game.mp4", annotations=annotations)
+    payload = build_response(doc, roster)
+    jsonschema.validate(payload, schema)
+
+    emitted = {a["event"] for a in payload["annotations"]}
+    assert set(NOTABILITY_EVENTS).issubset(emitted), emitted


### PR DESCRIPTION
## The defect

Four questions a person asks of a game, and the pilot cannot answer any of them:

- "find the most captivating moments of the game"
- "the hardest hit ball"
- "the longest home run"
- "the contested calls"

Nothing in the index holds those facts. So each question falls back to top-k semantic search over prose, which is the same failure mode as #855: a question about a whole game answered from a partial sample.

The MLB GUMBO feed holds every one of them, and the parser threw them all away. Game 823215, verified on the live payload:

| field | what game 823215 holds |
|---|---|
| `about.captivatingIndex` | MLB's own notability score: `95:1, 75:1, 70:1, 38:4, 34:4, 33:17, 14:13, 0:43` |
| `about.hasReview` | 2 plays |
| `about.isScoringPlay` | 15 plays |
| `result.rbi` / `awayScore` / `homeScore` | 20 RBI, final 10-11 |
| `playEvents[].hitData` | 66 pitches, every field measured |

43 plays score 0 on the captivating index, so the field genuinely discriminates. The three highest are the grand slam (95), a two-run homer (75) and a single (70). That is the answer to "the best moments" taken from the source, not from a model's opinion.

## The fix

Same shape as #855: read the feed, add cues, touch nothing that exists.

1. **`eval/ground_truth.py`**: `PitchEvent` gains `captivating_index`, `has_review`, `is_scoring_play`, `rbi`, `away_score`, `home_score` and `hit_data` (a frozen `HitData`: launch speed, launch angle, total distance, trajectory, hardness). Every value is the feed's, verbatim, in the feed's unit. Nothing is computed, scaled or bucketed.
   - The play-level fields ride on the pitch that **ended** the at-bat, exactly where `event_type` and the play result text already ride. One play then reports one notable moment, not one per pitch.
   - `hitData` is a property of one pitch, not of the play, so it rides on its own pitch. All 66 in this game happen to be the at-bat-ending pitch; a measured foul would ride on the foul, which is what it measured.
   - A field the tracking did not measure stays `None`, never `0.0`. 0 mph is a claim; "not measured" is not.
2. **`recognizers/playbyplay.py`**: the batter's pitch emits one cue per selectable fact.

| `event` | Emitted for | Answers |
|---|---|---|
| `batted_ball` | a pitch the tracking measured | "the hardest hit ball", "the longest home run" |
| `captivating` | `about.captivatingIndex > 0` | "the most captivating moments" |
| `reviewed` | `about.hasReview` | "the contested calls" |
| `scoring_play` | `about.isScoringPlay` | "when did they take the lead" |

## Decision 1: how does a number reach the client?

**Checked the contract first.** `Cue` carries `event`, `entity_ids`, `text` and `confidence`. `emit.py` writes `start_s`, `end_s`, `event`, `entities`, `text`, `confidence`, `sources`. And `0004-recognize-response.schema.json` **closes** `annotations[]`:

```json
"annotations": { "items": { "additionalProperties": false, "properties": { ... } } }
```

**So the wire contract has no numeric field, and this PR does not invent one.** That is a dirstral-spec question, not a backend one. This PR uses the two channels the contract does have:

- **`event` is what a client FILTERS on.** The schema calls it a "producer-defined event vocabulary ... not enumerated by the contract", so new tokens need no spec change. One annotation carries one `event` string, so N selectable facts need N cues.
- **`text` is what a client RANKS on.** The number goes in the indexed sentence, verbatim, in the feed's unit. "exit velocity 107.9 mph", "distance 421 ft", "captivating index 95". A whole measurement drops its redundant trailing `.0`; nothing is rounded, because rounding a number a client ranks on can change the answer.

Both channels, not one. `event` alone cannot hold a number. `text` alone leaves "the contested calls" as a semantic guess over prose, which is exactly the failure being fixed: 2 plays in 84 is not something top-k over prose finds.

Real cues off the fixture:

```
Captivating moment (captivating index 95): Bryce Eldridge vs Mitchell Parker
  (bottom of the 9th) — Bryce Eldridge hits a grand slam (4) to right field. …
Batted ball: Matt Chapman vs Foster Griffin (bottom of the 6th): exit velocity
  107 mph, launch angle 22 degrees, distance 421 ft, fly ball, medium contact
  — Matt Chapman homers (5) on a fly ball to left center field.
Scoring play (4 RBI, score: away 10, home 11): Bryce Eldridge vs Mitchell Parker
  (bottom of the 9th) — Bryce Eldridge hits a grand slam (4) to right field. …
```

The `batted_ball` cue carries the play result text as well, on purpose: one chunk then holds both the number and what the ball became, so "the longest home run" needs no join across cues.

**Rejected: numbers as entity ids** (`entities: ["stat:launch-speed-107-9"]`). It would be filterable today with no spec change, and it is wrong. The schema says every id "should resolve in the top-level entities dictionary", so `emit.py` would fabricate an entity labelled "Launch Speed 107 9" for every distinct value and pollute every client's entity list with hundreds of pseudo-entities. Entity ids are also meant to be stable across the corpus, and a per-pitch measurement is not. It would break the one property that makes the entity filter exact (`entities` + `event` selects a role), which is the measured decision in design 0004 §6.1.

**Follow-up, not in this PR:** a real numeric sort (`ORDER BY launch_speed`) needs an `attributes` object on `annotations[]` in dirstral-spec design 0004, then the ingest side to persist and filter on it. Spec first, per the governance loop. Until then, filter on `event` and rank on the number in the text, which is what the tests do end to end.

## Decision 2: does a captivating play get its own event?

**Yes, `event: "captivating"`, and only above zero.**

The threshold is the judgment, and the number is not, so the recognizer makes the smallest judgment available: **the only boundary the feed itself draws is zero.** 43 of the 84 plays score exactly 0, which is the feed saying "this play has no notability". A play it scores 1 gets the event, exactly like a play it scores 95, and a test pins that. Any sharper cut (>= 33, >= 70) would be this backend's opinion baked into the index, where no client could undo it.

The alternative (no event, the index only in the text) was rejected: it leaves "the most captivating moments" as pure semantic search over 84 near-identical sentences, with no way to narrow the candidate set. With the event, the client narrows to 41 candidates and ranks them on MLB's number. The filtered set is half the game, which is fine: it is a candidate set, and the ranking inside it is the feed's.

The two signals are genuinely independent, which is why both are carried. The most captivating home run of the game (the grand slam, index 95) travelled 326 ft, the **shortest** of the six. The longest (421 ft) scored 38. A test asserts exactly that.

## The existing cues are untouched

`pitch`, `at_bat` and the #855 outcome cue keep their event, their entities, their text, their span and their confidence.

`test_the_new_cues_change_no_existing_cue` compares cue lists with and without every new field:

```
before: ["pitch", "at_bat", "home_run"]
after:  ["pitch", "at_bat", "home_run", "batted_ball", "captivating", "reviewed", "scoring_play"]
after[:3] == before          # byte-for-byte, entities and text too
```

**The phase-1 metric does not move, and that is measured, not argued.** #855's `test_the_phase_1_metric_does_not_move` still passes unchanged, and `test_the_phase_1_metric_still_does_not_move` repeats the same proof over the 124 new cues of the whole pilot game:

```
total_events      344 == 344
overall           PRCount(tp=342, fn=2, fp=0) == PRCount(tp=342, fn=2, fp=0)
per_player        equal
per_source_found  equal
```

(The two misses are the same two pitches inside the fusion merge gap that missed before #855.)

Two further guards:

- `test_no_new_event_can_take_a_role_event_name` pins that no added event name can ever be `pitch` or `at_bat`. Retagging is what caused #620.
- fusion groups on an exact `event` match, so a new cue can never merge into a `pitch` annotation.

`test_the_pilot_game_emits_one_outcome_per_at_bat` needed one line: it counted every non-role cue as an outcome, so it now excludes the notability events. It still asserts 344 `pitch`, 344 `at_bat` and exactly 84 outcomes.

## Tests fail before, pass after

New tests: 7 in `test_eval.py`, 15 in `test_playbyplay.py`, 1 in `test_schema_agreement.py`.

`test_playbyplay.py` cannot even import before the change:

```
E   ImportError: cannot import name 'HitData' from 'dirstral_annotator.eval.ground_truth'
```

`test_eval.py`, before:

```
FAILED tests/test_eval.py::test_the_pilot_feed_scores_every_play_for_notability
FAILED tests/test_eval.py::test_the_pilot_feed_marks_the_contested_and_the_scoring_plays
FAILED tests/test_eval.py::test_the_batted_ball_measurements_ride_on_the_pitch_that_was_hit
FAILED tests/test_eval.py::test_a_pitch_inside_the_at_bat_carries_no_play_level_field
FAILED tests/test_eval.py::test_a_feed_without_the_notability_fields_keeps_the_defaults
FAILED tests/test_eval.py::test_a_hitData_with_nothing_measured_reads_as_no_hit_data
FAILED tests/test_eval.py::test_a_partly_measured_batted_ball_keeps_what_the_feed_had
7 failed, 14 passed
```

```
E   AttributeError: 'PitchEvent' object has no attribute 'hit_data'
```

After: `361 passed`.

The headline tests answer the four questions by selection and ranking, off the real feed:

```python
moments = [c for c in cues if c.event == "captivating"]          # 41
ranked = sorted(moments, key=lambda c: -index_in_text(c))
assert index_in_text(ranked[0]) == 95 and "grand slam" in ranked[0].text
assert [index_in_text(c) for c in ranked[1:3]] == [75, 70]

hits = [c for c in cues if c.event == "batted_ball"]             # 66
assert speed_in_text(max(hits, key=speed_in_text)) == 107.9      # Matt Chapman, a single
assert distance_in_text(longest_homer) == 421                    # Matt Chapman
assert len([c for c in cues if c.event == "reviewed"]) == 2
assert len([c for c in cues if c.event == "scoring_play"]) == 15
```

`test_the_notability_cues_are_legal_wire` runs the whole pilot game through the real path (parse, recognize, fuse, `build_response`) and validates it against the design 0004 draft schema. It fails the day somebody answers "where does the number go?" by inventing a field in the backend instead of proposing one in dirstral-spec.

## Fixture

`gumbo_823215.json` is re-projected from the live statsapi payload (`/api/v1.1/game/823215/feed/live`). Only the new fields are added: every field the parser already read is byte-identical, so the diff is additive line by line. The shared `gumbo_min.json` carries none of the new fields, which is why every existing suite is untouched.

## Deliberately out of scope

- **`playEvents[].pitchData`** (`startSpeed`, `breaks`, `zone`, ...). It is per pitch, and every pitch has one, so surfacing it means one more cue on all 344 pitches to answer a question nobody in the pilot asked. The `pitch` cue's text cannot carry it either, because that text is pinned byte-for-byte by the metric equality test. Worth its own PR with its own measurement.
- **`about.hasOut`**. The outcome event already carries `field_out`, `force_out` and `strikeout`.
- A club name can still appear in a cue text when the feed's own play description names one ("Nationals challenged (play at 1st) ..."). That is the feed's sentence, carried verbatim as before. The design 0004 §6.1 rule is about the recognizer's own phrasing, and this PR adds no club name to any text.

## Gates

- `make check`: pass (Go plus the annotator suite, 361 passed).
- `coderabbit review --include-untracked`: **No findings**.
- This worktree needed `git submodule update --init` for `tests/security` and the two schema-agreement tests. The submodule pointer is unchanged.
