### PR TITLE
fix(mcp): show the entity and event a recognition hit matched on (#856)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3494,6 +3494,12 @@ func serializeTimeSpan(span model.Span) map[string]interface{} {
 		"start_ms": span.StartMS,
 		"end_ms":   span.EndMS,
 	}
+	// speaker_label is nested under speaker on purpose: a label always comes with
+	// a stable id in this tree. The subtitle assigner returns ("", "") for a cue
+	// with no voice name, the diarizer skips a segment whose id is empty, and
+	// timeSpanExtraJSON persists nothing at all when speaker is empty. So a
+	// label-only span cannot be produced or stored, and emitting one would
+	// advertise a speaker the caller cannot then filter on.
 	if speaker := strings.TrimSpace(span.Speaker); speaker != "" {
 		out["speaker"] = speaker
 		if label := strings.TrimSpace(span.SpeakerLabel); label != "" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3456,22 +3456,7 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 			"page": span.Page,
 		}
 	case "time":
-		out := map[string]interface{}{
-			"kind":     "time",
-			"start_ms": span.StartMS,
-			"end_ms":   span.EndMS,
-		}
-		// Additive (SPEC §8.6.8/§9.2): a diarized transcript's time span surfaces
-		// the stable speaker id and optional label. Omitted when absent, so a
-		// non-diarized span is byte-identical to before and consumers degrade to
-		// a flat citation.
-		if speaker := strings.TrimSpace(span.Speaker); speaker != "" {
-			out["speaker"] = speaker
-			if label := strings.TrimSpace(span.SpeakerLabel); label != "" {
-				out["speaker_label"] = label
-			}
-		}
-		return out
+		return serializeTimeSpan(span)
 	case "region":
 		return buildRegionSpan(span)
 	default:
@@ -3484,6 +3469,47 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 			"kind": "document",
 		}
 	}
+}
+
+// serializeTimeSpan renders a "time" span per df-005 0.2.0. Every optional field
+// is omitted when absent, so a plain transcript span stays byte-identical to the
+// one served before this function existed.
+//
+// speaker/speaker_label come from diarization (td-003). entities/event come from
+// the recognition capability (bs-007, design 0004 §7) and are the values the
+// `entities` and `events` filters match on. Serving them is what lets a caller
+// SEE why a hit matched: before this, a caller who asked for
+// events: ["home_run"] and received five hits could not confirm that all five
+// carry that event, nor tell a filtered result from an unfiltered one (#856).
+//
+// The values are already on the in-memory span (the store rebuilds them from the
+// span's extra_json on every chunk read), so this costs no extra query.
+//
+// `derivation` is declared by df-005 but is NOT emitted here: no producer in this
+// tree sets it yet (the captioning recognizer that needs it is issue #860), and
+// df-005 makes absent mean `observed`, which is what every current producer is.
+func serializeTimeSpan(span model.Span) map[string]interface{} {
+	out := map[string]interface{}{
+		"kind":     "time",
+		"start_ms": span.StartMS,
+		"end_ms":   span.EndMS,
+	}
+	if speaker := strings.TrimSpace(span.Speaker); speaker != "" {
+		out["speaker"] = speaker
+		if label := strings.TrimSpace(span.SpeakerLabel); label != "" {
+			out["speaker_label"] = label
+		}
+	}
+	// NormalizeEntityIDs trims, drops blanks and dedupes, which is exactly the
+	// set model.Filter matches against. So a served hit shows the matchable
+	// values, never a blank id the filter could not have selected on.
+	if entities := model.NormalizeEntityIDs(span.Entities); len(entities) > 0 {
+		out["entities"] = entities
+	}
+	if event := strings.TrimSpace(span.Event); event != "" {
+		out["event"] = event
+	}
+	return out
 }
 
 // buildRegionSpan renders a region span per spec §15.1.1: page range plus the
@@ -3822,6 +3848,29 @@ func spanDefinitionSchema() map[string]interface{} {
 					"speaker_label": map[string]interface{}{
 						"type":        "string",
 						"description": "Optional human-readable speaker name (SPEC §8.6.8).",
+					},
+					// df-005 0.2.0. These MUST be declared: the time branch is
+					// additionalProperties:false, so a field the server emits but
+					// does not advertise makes a strict client reject the whole
+					// tool result ("Failed to call tool", the #397/#849 class).
+					"entities": map[string]interface{}{
+						"type":        "array",
+						"items":       map[string]interface{}{"type": "string"},
+						"description": "Optional (SPEC 5.4, design 0004): entity ids the recognizer attributed to this span. Same values the entities filter matches. Absent on a span that is not a recognition annotation.",
+					},
+					"event": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional (SPEC 5.4, design 0004): the producer's event token for this span, for example pitch or home_run. Same value the events filter matches. The vocabulary is producer-defined and not enumerated here.",
+					},
+					// Declared but never emitted by this server: no producer here
+					// sets it yet (#860). It stays in the advertised contract so a
+					// client validating against the canonical common.json and a
+					// client validating against this schema accept the same set of
+					// payloads.
+					"derivation": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"observed", "generated"},
+						"description": "Optional (SPEC 5.4): whether this span records something observed or something a model generated. Absent means observed. A client MUST NOT present a generated span as a record of what happened.",
 					},
 				},
 				"required": []string{"kind", "start_ms", "end_ms"},

--- a/tests/conformance/span_attribution_856_test.go
+++ b/tests/conformance/span_attribution_856_test.go
@@ -401,6 +401,38 @@ func TestSpan_ServedSpansValidateAgainstCanonicalSchema(t *testing.T) {
 	}
 }
 
+// TestSpan_CanonicalValidatorRejectsAnUndeclaredField is the negative control
+// for the check above. Validating against the canonical file only means
+// something if the validator really rejects a field the contract does not
+// declare. Without this, a validator that resolved to "accept anything" would
+// make every canonical check in this file pass vacuously.
+//
+// It uses `sources` as the undeclared field on purpose. That is the field
+// #861 asks about, and this is the machine-readable reason this PR does not
+// serve it: the canonical time branch is additionalProperties:false and does not
+// declare it, so a span carrying it would make a strict client reject the whole
+// tool result.
+func TestSpan_CanonicalValidatorRejectsAnUndeclaredField(t *testing.T) {
+	t.Parallel()
+	validator := canonicalSpanValidator(t)
+
+	conforming := map[string]interface{}{
+		"kind": "time", "start_ms": float64(0), "end_ms": float64(1000),
+		"entities": []interface{}{"player:heliot-ramos"}, "event": "home_run",
+	}
+	if err := validator.Validate(conforming); err != nil {
+		t.Fatalf("the canonical Span validator rejected a conforming time span: %v", err)
+	}
+
+	undeclared := map[string]interface{}{
+		"kind": "time", "start_ms": float64(0), "end_ms": float64(1000),
+		"sources": []interface{}{"pbp-feed"},
+	}
+	if err := validator.Validate(undeclared); err == nil {
+		t.Fatal("the canonical Span validator accepted an undeclared `sources` field, so every canonical check in this file would pass vacuously")
+	}
+}
+
 // TestSpan_AdvertisedTimeBranchMatchesCanonical pins the other direction. The
 // payload check above only sees what this corpus happens to emit. This one reads
 // the schema the server publishes through tools/list and requires the same

--- a/tests/conformance/span_attribution_856_test.go
+++ b/tests/conformance/span_attribution_856_test.go
@@ -215,9 +215,8 @@ func recognitionServer856(t *testing.T) (*runningServer, config.Config) {
 
 	cfg := defaultConfig()
 	cfg.StateDir = tmp
-	srv := newServerWithRetriever(t, cfg, svc, mcp.WithStore(st))
-	t.Cleanup(srv.Close)
-	return srv, cfg
+	// newServerWithRetriever registers its own cleanup, so the caller does not.
+	return newServerWithRetriever(t, cfg, svc, mcp.WithStore(st)), cfg
 }
 
 // callToolStructured856 calls one tool over the production transport and returns

--- a/tests/conformance/span_attribution_856_test.go
+++ b/tests/conformance/span_attribution_856_test.go
@@ -1,0 +1,444 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// The WIRE half of issue #856, on the production SDK transport.
+//
+// PR #857 fixed the SELECTION: an impossible filter value now returns zero hits.
+// It did not fix the VISIBILITY, because a served span carried only kind,
+// start_ms and end_ms. So a caller who asked for events: ["home_run"] and got
+// five hits could not confirm that all five carry that event, nor tell a
+// filtered result from an unfiltered one. That is #856's first acceptance
+// criterion, and it is why the original defect went unnoticed: no client could
+// look.
+//
+// dirstral-spec 0.51.0 (df-005 0.2.0) permits `entities` and `event` on a time
+// span, so the server can now show WHY a hit matched. These tests read the
+// payload a real client gets, and validate it against the canonical
+// common.json inside the pinned submodule, so prose and schema cannot drift.
+
+// canonicalCommonSchemaPath is the pinned canonical shared-types schema inside
+// the dirstral-spec submodule. The suite reads THAT file, not a copy, so a
+// spec-side change reaches this test through the submodule pin.
+var canonicalCommonSchemaPath = filepath.Join("..", "..", "dirstral-spec", "spec", "tools", "schemas", "common.json")
+
+// spanVectorDim856 is the width of the toy embedding space these tests index in.
+const spanVectorDim856 = 2
+
+// spanStaticEmbedder856 returns one fixed vector for every text, so ranking is
+// constant and a missing or extra hit can only be the filter's work.
+type spanStaticEmbedder856 struct{}
+
+func (spanStaticEmbedder856) Embed(_ context.Context, _ string, _ model.EmbedRole, texts []string) ([][]float32, error) {
+	out := make([][]float32, 0, len(texts))
+	for range texts {
+		out = append(out, []float32{1, 0})
+	}
+	return out, nil
+}
+
+// canonicalSpanRaw returns the raw `definitions.Span` subschema of the canonical
+// common.json. That subschema is the contract for every served span.
+func canonicalSpanRaw(t *testing.T) json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(canonicalCommonSchemaPath)
+	if err != nil {
+		t.Fatalf("read canonical common.json (run: git submodule update --init): %v", err)
+	}
+	var doc struct {
+		Definitions map[string]json.RawMessage `json:"definitions"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode canonical common.json: %v", err)
+	}
+	span, ok := doc.Definitions["Span"]
+	if !ok {
+		t.Fatal("canonical common.json declares no definitions.Span")
+	}
+	return span
+}
+
+// canonicalSpanValidator compiles the canonical Span subschema into a validator.
+func canonicalSpanValidator(t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(canonicalSpanRaw(t), &schema); err != nil {
+		t.Fatalf("decode canonical Span subschema: %v", err)
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("resolve canonical Span subschema: %v", err)
+	}
+	return resolved
+}
+
+// timeBranch856 picks the `time` member out of a Span schema's oneOf list. Both
+// the canonical file and the served schema are compared through it, so neither
+// side depends on the order the branches happen to be written in.
+func timeBranch856(t *testing.T, span map[string]interface{}, label string) map[string]interface{} {
+	t.Helper()
+	branches, ok := span["oneOf"].([]interface{})
+	if !ok {
+		t.Fatalf("%s Span schema has no oneOf list: %#v", label, span["oneOf"])
+	}
+	for _, raw := range branches {
+		branch, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		properties, ok := branch["properties"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		kind, ok := properties["kind"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if kind["const"] == "time" {
+			return branch
+		}
+	}
+	t.Fatalf("%s Span schema declares no time branch", label)
+	return nil
+}
+
+// recognitionCorpus856 seeds one recognition annotation per event plus a prose
+// note that mentions "home run" but carries no attribution. The note is the
+// candidate an event filter must drop, and it is also the span that must NOT
+// grow the new fields.
+func recognitionCorpus856(t *testing.T, st *store.SQLiteStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	seed := func(relPath, docType, repType, text string, span model.Span) {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: relPath, DocType: docType, SourceType: "local", Status: "ok",
+		}); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", relPath, err)
+		}
+		doc, err := st.GetDocumentByPath(ctx, relPath)
+		if err != nil {
+			t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+		}
+		repID, err := st.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: repType, RepHash: relPath + repType, CreatedUnix: 1,
+		})
+		if err != nil {
+			t.Fatalf("UpsertRepresentation(%s): %v", relPath, err)
+		}
+		if _, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: text,
+			IndexKind: "text", EmbeddingStatus: "ok",
+		}, []model.Span{span}); err != nil {
+			t.Fatalf("InsertChunkWithSpans(%s): %v", relPath, err)
+		}
+	}
+
+	seed("game.mp4", "video", "recognition",
+		"Heliot Ramos hits a home run to left field",
+		model.Span{
+			Kind: "time", StartMS: 3346398, EndMS: 3354398,
+			Entities: []string{"player:heliot-ramos", "team:san-francisco-giants"},
+			Event:    "home_run",
+		})
+	seed("game2.mp4", "video", "recognition",
+		"Logan Webb throws a home run ball on a pitch to the plate",
+		model.Span{
+			Kind: "time", StartMS: 120000, EndMS: 128000,
+			Entities: []string{"player:logan-webb"},
+			Event:    "pitch",
+		})
+	seed("notes.md", "md", "raw_text",
+		"match report: the home run in the seventh decided the game",
+		model.Span{Kind: "lines", StartLine: 1, EndLine: 2})
+}
+
+// recognitionServer856 wires the production chain behind the production SDK
+// transport: a real SQLite store (spans + FTS), a real vector index, the real
+// retrieval service, and the tools that advertise the filters.
+func recognitionServer856(t *testing.T) (*runningServer, config.Config) {
+	t.Helper()
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	recognitionCorpus856(t, st)
+
+	idx := index.NewHNSWIndex("")
+	svc := retrieval.NewService(st, idx, spanStaticEmbedder856{}, nil)
+
+	// The daemon's warm-load path: read each embedded chunk's metadata back out
+	// of the store and register it, then index its vector. The attribution
+	// therefore reaches serialization exactly the way it does after a restart.
+	tasks, err := st.ListEmbeddedChunkMetadata(ctx, "text", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("warm load returned %d chunks, want 3", len(tasks))
+	}
+	for i, task := range tasks {
+		meta := task.Metadata
+		vec := make([]float32, spanVectorDim856)
+		vec[0] = 1
+		vec[1] = float32(i) / 1000
+		if err := idx.Upsert(ctx, vec, model.IndexPayload{
+			ChunkID: meta.ChunkID, RelPath: meta.RelPath, DocType: meta.DocType,
+			RepType: meta.RepType, Span: meta.Span,
+			StartMS: meta.Span.StartMS, EndMS: meta.Span.EndMS,
+		}); err != nil {
+			t.Fatalf("Upsert(%d): %v", meta.ChunkID, err)
+		}
+		svc.SetChunkMetadata(meta.ChunkID, meta.ToSearchHit())
+	}
+
+	cfg := defaultConfig()
+	cfg.StateDir = tmp
+	srv := newServerWithRetriever(t, cfg, svc, mcp.WithStore(st))
+	t.Cleanup(srv.Close)
+	return srv, cfg
+}
+
+// callToolStructured856 calls one tool over the production transport and returns
+// the structuredContent a real client validates.
+func callToolStructured856(t *testing.T, srv *runningServer, cfg config.Config, toolName, arguments string) map[string]interface{} {
+	t.Helper()
+	mcpURL := srv.URL + cfg.MCPPath
+	sid := initSession(t, mcpURL)
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"` + toolName + `","arguments":` + arguments + `}}`
+	resp := sendRPC(t, mcpURL, sid, body, nil)
+	payload := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status=%d want=200 body=%s", toolName, resp.StatusCode, payload)
+	}
+	var envelope struct {
+		Result struct {
+			IsError           bool                   `json:"isError"`
+			StructuredContent map[string]interface{} `json:"structuredContent"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		t.Fatalf("%s: decode response: %v body=%s", toolName, err, payload)
+	}
+	if envelope.Result.IsError {
+		t.Fatalf("%s: isError=true body=%s", toolName, payload)
+	}
+	if envelope.Result.StructuredContent == nil {
+		t.Fatalf("%s: missing structuredContent body=%s", toolName, payload)
+	}
+	return envelope.Result.StructuredContent
+}
+
+// spansOf856 pulls the span object out of every entry of a structuredContent
+// array field (hits or citations).
+func spansOf856(t *testing.T, structured map[string]interface{}, field string) []map[string]interface{} {
+	t.Helper()
+	entries, ok := structured[field].([]interface{})
+	if !ok {
+		t.Fatalf("structuredContent has no %s array: %#v", field, structured[field])
+	}
+	out := make([]map[string]interface{}, 0, len(entries))
+	for i, raw := range entries {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s[%d] is not an object: %#v", field, i, raw)
+		}
+		span, ok := entry["span"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s[%d] carries no span object: %#v", field, i, entry["span"])
+		}
+		out = append(out, span)
+	}
+	return out
+}
+
+// assertShowsHomeRun856 is the assertion that matters for #856: a hit returned
+// under events: ["home_run"] must SHOW that event on its span, and must show the
+// entity ids the recognizer attributed.
+func assertShowsHomeRun856(t *testing.T, span map[string]interface{}, label string) {
+	t.Helper()
+	if span["event"] != "home_run" {
+		pretty, _ := json.MarshalIndent(span, "", "  ")
+		t.Fatalf("%s was selected by events:[\"home_run\"] but its span does not show that event, so a caller cannot tell a filtered result from an unfiltered one:\n%s", label, pretty)
+	}
+	entities, ok := span["entities"].([]interface{})
+	if !ok {
+		pretty, _ := json.MarshalIndent(span, "", "  ")
+		t.Fatalf("%s span carries no entities array:\n%s", label, pretty)
+	}
+	want := map[string]bool{"player:heliot-ramos": false, "team:san-francisco-giants": false}
+	for _, raw := range entities {
+		id, _ := raw.(string)
+		if _, tracked := want[id]; tracked {
+			want[id] = true
+		}
+	}
+	for id, seen := range want {
+		if !seen {
+			t.Errorf("%s span.entities is missing %q: got %#v", label, id, entities)
+		}
+	}
+}
+
+// TestSearch_FilteredHitShowsTheEventItMatched is #856's first acceptance
+// criterion on the wire. It FAILS on main: the served span carries only kind,
+// start_ms and end_ms, so span["event"] is nil.
+func TestSearch_FilteredHitShowsTheEventItMatched(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer856(t)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameSearch,
+		`{"query":"home run","events":["home_run"],"k":20}`)
+	spans := spansOf856(t, structured, "hits")
+	if len(spans) != 1 {
+		t.Fatalf("events:[\"home_run\"] returned %d hits, want 1 (the annotation only)", len(spans))
+	}
+	assertShowsHomeRun856(t, spans[0], "the dir2mcp_search hit")
+}
+
+// TestAsk_CitationSpanShowsTheAttribution covers the other tool that serves a
+// Span. #849 exists because five tools disagreed with their own schemas, so a
+// fix that only reaches dir2mcp_search is not a fix.
+func TestAsk_CitationSpanShowsTheAttribution(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer856(t)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameAsk,
+		`{"question":"who hit a home run?","events":["home_run"],"k":20}`)
+	for _, field := range []string{"hits", "citations"} {
+		spans := spansOf856(t, structured, field)
+		if len(spans) != 1 {
+			t.Fatalf("dir2mcp_ask returned %d %s, want 1", len(spans), field)
+		}
+		assertShowsHomeRun856(t, spans[0], "the dir2mcp_ask "+field+" entry")
+	}
+}
+
+// TestSpan_NonRecognitionSpanCarriesNoAttribution is the compatibility guard.
+// df-005 makes the three fields additive: a chunk that is not a recognition
+// annotation carries none of them, so an existing consumer sees no change.
+func TestSpan_NonRecognitionSpanCarriesNoAttribution(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer856(t)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameSearch,
+		`{"query":"home run","k":20}`)
+	spans := spansOf856(t, structured, "hits")
+	if len(spans) != 3 {
+		t.Fatalf("an unfiltered search returned %d hits, want all 3", len(spans))
+	}
+	var checked int
+	for _, span := range spans {
+		if span["kind"] != "lines" {
+			continue
+		}
+		checked++
+		for _, field := range []string{"entities", "event", "derivation"} {
+			if _, present := span[field]; present {
+				t.Errorf("a non-recognition span carries %q: %#v", field, span)
+			}
+		}
+	}
+	if checked != 1 {
+		t.Fatalf("the prose note's lines span was not in the result, so this guard checked nothing: %#v", spans)
+	}
+}
+
+// TestSpan_ServedSpansValidateAgainstCanonicalSchema validates every span a
+// client actually receives against the canonical Span in the PINNED submodule.
+// PR #852 did exactly this for stats and found a real break: prose and schema
+// cannot drift apart while this test reads the canonical file.
+//
+// It is the guard that makes the emission safe. Every Span branch is
+// additionalProperties:false, so a field the server invents but the contract
+// does not declare makes a strict client reject the whole tool result: the #397
+// "Failed to call tool" class.
+func TestSpan_ServedSpansValidateAgainstCanonicalSchema(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer856(t)
+	validator := canonicalSpanValidator(t)
+
+	cases := []struct {
+		tool, arguments, field string
+	}{
+		{protocol.ToolNameSearch, `{"query":"home run","k":20}`, "hits"},
+		{protocol.ToolNameSearch, `{"query":"home run","events":["home_run"],"k":20}`, "hits"},
+		{protocol.ToolNameAsk, `{"question":"who hit a home run?","k":20}`, "hits"},
+		{protocol.ToolNameAsk, `{"question":"who hit a home run?","k":20}`, "citations"},
+	}
+	for _, tc := range cases {
+		structured := callToolStructured856(t, srv, cfg, tc.tool, tc.arguments)
+		spans := spansOf856(t, structured, tc.field)
+		if len(spans) == 0 {
+			t.Fatalf("%s %s returned no %s, so this check would be vacuous", tc.tool, tc.arguments, tc.field)
+		}
+		for i, span := range spans {
+			if err := validator.Validate(span); err != nil {
+				pretty, _ := json.MarshalIndent(span, "", "  ")
+				t.Errorf("%s %s[%d] is invalid against the canonical common.json Span: %v\nspan:\n%s", tc.tool, tc.field, i, err, pretty)
+			}
+		}
+	}
+}
+
+// TestSpan_AdvertisedTimeBranchMatchesCanonical pins the other direction. The
+// payload check above only sees what this corpus happens to emit. This one reads
+// the schema the server publishes through tools/list and requires the same
+// property set and required list on the time branch as the canonical file.
+//
+// It fails on main, where the served time branch declares neither `entities`
+// nor `event`. A served branch that omits a canonical field is a real defect on
+// its own: additionalProperties is false, so a client that validates against the
+// SERVED schema rejects a conforming response from any implementation that
+// emits the field.
+func TestSpan_AdvertisedTimeBranchMatchesCanonical(t *testing.T) {
+	t.Parallel()
+	served, ok := toolsListSchemas(t)[protocol.ToolNameSearch].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tools/list advertises no outputSchema for %s", protocol.ToolNameSearch)
+	}
+	definitions, ok := served["definitions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("served %s outputSchema declares no definitions: %#v", protocol.ToolNameSearch, served["definitions"])
+	}
+	servedSpan, ok := definitions["Span"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("served outputSchema declares no definitions.Span: %#v", definitions["Span"])
+	}
+
+	var canonicalSpan map[string]interface{}
+	if err := json.Unmarshal(canonicalSpanRaw(t), &canonicalSpan); err != nil {
+		t.Fatalf("decode canonical Span subschema as a tree: %v", err)
+	}
+
+	canonicalTime := timeBranch856(t, canonicalSpan, "canonical")
+	servedTime := timeBranch856(t, servedSpan, "served")
+
+	assertSameStrings(t, "common.json Span", "time-branch property",
+		schemaPropertyNames(t, canonicalTime, "canonical time branch"),
+		schemaPropertyNames(t, servedTime, "served time branch"))
+	assertSameStrings(t, "common.json Span", "time-branch required field",
+		schemaRequired(t, canonicalTime, "canonical time branch"),
+		schemaRequired(t, servedTime, "served time branch"))
+}

--- a/tests/conformance/stats_canonical_schema_850_test.go
+++ b/tests/conformance/stats_canonical_schema_850_test.go
@@ -258,10 +258,10 @@ func TestStats_AdvertisedSchemaMatchesCanonical(t *testing.T) {
 	}
 	canonical := canonicalStatsTree(t)
 
-	assertSameStrings(t, "top-level property",
+	assertSameStrings(t, "stats.json", "top-level property",
 		schemaPropertyNames(t, canonical, "canonical"),
 		schemaPropertyNames(t, served, "served"))
-	assertSameStrings(t, "required field",
+	assertSameStrings(t, "stats.json", "required field",
 		schemaRequired(t, canonical, "canonical"),
 		schemaRequired(t, served, "served"))
 }
@@ -270,7 +270,11 @@ func TestStats_AdvertisedSchemaMatchesCanonical(t *testing.T) {
 // direction, because the two directions are different defects: served-only means
 // the server publishes a field outside the contract, canonical-only means it
 // fails to publish a field the contract defines.
-func assertSameStrings(t *testing.T, label string, canonical, served []string) {
+//
+// `subject` names the canonical file under comparison, so a second caller (the
+// Span check in span_attribution_856_test.go) does not report a Span drift as a
+// stats drift.
+func assertSameStrings(t *testing.T, subject, label string, canonical, served []string) {
 	t.Helper()
 	inCanonical := make(map[string]bool, len(canonical))
 	for _, name := range canonical {
@@ -282,12 +286,12 @@ func assertSameStrings(t *testing.T, label string, canonical, served []string) {
 	}
 	for _, name := range served {
 		if !inCanonical[name] {
-			t.Errorf("served stats schema declares %s %q, which the canonical stats.json does not: served=%v canonical=%v", label, name, served, canonical)
+			t.Errorf("the served schema declares %s %q, which the canonical %s does not: served=%v canonical=%v", label, name, subject, served, canonical)
 		}
 	}
 	for _, name := range canonical {
 		if !inServed[name] {
-			t.Errorf("canonical stats.json declares %s %q, which the served stats schema does not: served=%v canonical=%v", label, name, served, canonical)
+			t.Errorf("the canonical %s declares %s %q, which the served schema does not: served=%v canonical=%v", subject, label, name, served, canonical)
 		}
 	}
 }


### PR DESCRIPTION
Closes #856

PR #857 fixed the SELECTION half of #856: the entity and event filters now apply
on every retrieval path, and a value that can match nothing returns zero hits.

This PR fixes the VISIBILITY half, which was spec-blocked at the time.

## The defect

A served hit's span carried only `kind`, `start_ms` and `end_ms`:

```json
{"end_ms": 3354398, "kind": "time", "start_ms": 3346398}
```

So a caller who asked for `events: ["home_run"]` and got five hits could not
confirm that all five carry that event. The caller could not tell a filtered
result from an unfiltered one either. That is #856's first acceptance criterion,
and it is why the original defect went unnoticed for so long: no client could
look.

## What unblocked it

dirstral-spec 0.51.0 (`e5319c9`) adds three OPTIONAL fields to the `time` branch
of the published `Span`: `entities`, `event` and `derivation`. df-005 0.2.0 is
the source of truth. This PR re-pins the submodule to that commit, which is the
gated re-pin the governance loop requires.

## The change

`serializeTimeSpan` now emits `entities` and `event` when the span carries them:

```json
{"kind": "time", "start_ms": 3346398, "end_ms": 3354398,
 "entities": ["player:heliot-ramos", "team:san-francisco-giants"],
 "event": "home_run"}
```

Both fields are omitted when absent, so a plain transcript span is
byte-identical to the one served before. df-005 makes the fields additive, and a
chunk that is not a recognition annotation carries none of them.

**Every tool, not just search.** All 7 handlers that serve a Span go through one
function, `buildOpenFileSpan`: `search`, `related`, `ask`, `ask_audio`,
`transcribe_and_ask`, `open_file` and `open_media_clip`. An `ask` citation
therefore gains the fields as well. The 5 served output schemas share one
`Span` definition through `sharedDefinitions()`, so the advertised contract moves
with the payload. #849 exists because five tools disagreed with their own
schemas; one shared definition is what stops that repeating here.

The served schema MUST gain the fields. Every Span branch is
`additionalProperties: false`, so a field the server emits but does not advertise
makes a strict MCP client reject the whole tool result: the #397 "Failed to call
tool" class.

## Cost: none

The attribution is already in memory at every serialization point. `model.Span`
carries `Entities []string` and `Event string`, and the store rebuilds both from
the time span's `extra_json` on every chunk read (PR #857 pinned that
behaviour). So this is a pure serialization change. It adds no query, no per-hit
lookup, and nothing to batch.

## `derivation`: declared, never emitted

The served schema declares `derivation`, but the server never sets it. Nothing
in this tree produces one: the captioning recognizer that needs it is scoped in
#860. df-005 makes absent mean `observed`, which is what every current producer
is, so an omitted field is already correct.

Declaring it without emitting it is deliberate. A schema states what MAY appear.
Declaring it makes the served schema and the canonical `common.json` accept the
same set of payloads, so a client that validates against either one accepts a
conforming response from any implementation. Leaving it out would make the
served schema reject a conforming response from a producer that does emit it.

The normative rule df-005 attaches to it is a CONSUMER rule: a consumer MUST NOT
present a `generated` annotation as the source's own account of what happened.
Nothing here presents one, because nothing here produces one.

## `sources`: stays dropped, on purpose

`internal/ingest/recognize.go` decodes `Sources` at line 69 and assigns it at
line 108, but `recognitionSegments` (line 278) builds its internal struct from
`startMS, endMS, text, entities, event` only. So `sources` is parsed and then
silently dropped before storage.

This PR does NOT carry it through. The canonical `time` branch declares exactly
`kind, start_ms, end_ms, speaker, speaker_label, entities, event, derivation`.
`sources` is not in that list, and the branch is `additionalProperties: false`,
so a span carrying it would be non-conforming and a strict client would reject
the whole result. Carrying it to storage without a wire surface would also be
dead weight this PR cannot test end to end.

It needs a spec change first, per the spec-first governance loop. Filed as #861
with the full trace, so the knowledge is not lost.

## Tests

`tests/conformance/span_attribution_856_test.go`, on the production SDK
transport, against a real SQLite store, a real vector index and the real
retrieval service:

1. `TestSearch_FilteredHitShowsTheEventItMatched` is the assertion that matters:
   a hit returned under `events: ["home_run"]` must SHOW `event: "home_run"`.
2. `TestAsk_CitationSpanShowsTheAttribution` covers `ask` hits AND `ask`
   citations, so the fix is not search-only.
3. `TestSpan_NonRecognitionSpanCarriesNoAttribution` is the compatibility guard:
   a prose chunk's span gains none of the three fields.
4. `TestSpan_ServedSpansValidateAgainstCanonicalSchema` validates every served
   span against `definitions.Span` read from `common.json` INSIDE the pinned
   submodule. PR #852 did this for `stats` and found a real break.
5. `TestSpan_CanonicalValidatorRejectsAnUndeclaredField` is the negative
   control. It feeds the validator a span carrying `sources` and requires a
   rejection, so check 4 cannot pass vacuously. It is also the machine-readable
   reason `sources` stays off the wire.
6. `TestSpan_AdvertisedTimeBranchMatchesCanonical` pins the other direction: the
   `tools/list` time branch must declare the same properties as the canonical
   file.

### Proof they fail without the fix

With `internal/mcp/tools.go` reverted to `main` and the submodule at the new pin:

```
--- FAIL: TestSearch_FilteredHitShowsTheEventItMatched
    the dir2mcp_search hit was selected by events:["home_run"] but its span
    does not show that event, so a caller cannot tell a filtered result from an
    unfiltered one:
        {"end_ms": 3354398, "kind": "time", "start_ms": 3346398}
--- FAIL: TestAsk_CitationSpanShowsTheAttribution
    (same span, on the ask path)
--- FAIL: TestSpan_AdvertisedTimeBranchMatchesCanonical
    canonical declares "entities", "event" and "derivation", which the served
    schema does not:
    served=[end_ms kind speaker speaker_label start_ms]
```

On the FULL `main` tree (old pin plus old code) the two payload tests fail the
same way. The schema-parity test passes there only because the old pinned
`common.json` declares no such fields either, which is the drift the re-pin
closes.

## Gates

- `make check`: green.
- `go test -race ./tests/conformance ./tests/mcp ./internal/mcp ./internal/model
  ./internal/retrieval`: green.
- `gocyclo -over 15`: clean. The `time` branch moved out of `buildOpenFileSpan`
  into `serializeTimeSpan` to keep it that way.

`assertSameStrings` in `stats_canonical_schema_850_test.go` gained a `subject`
parameter so a Span drift is not reported as a stats drift. Behaviour is
unchanged.

## The red govulncheck job is not this PR

`govulncheck` reports 7 Go standard library advisories against `go1.25.12`, the
toolchain `go.mod` pins. All 7 are fixed in `go1.25.13`. The job reads the
vulnerability database fresh on every run, and the advisories landed between two
runs of this same branch: run 31749393887 passed it, run 31749641447 failed it,
and the two differ only by a comment and two test files.

So no diff here can turn it green. It needs a `go.mod` bump on `main`, filed as
#863. Every other job on this PR is green.

## Review

The CodeRabbit GitHub bot reported "Review rate limited" on this PR. The
CodeRabbit CLI ran instead and raised one minor finding: `speaker_label` is
suppressed when `speaker` is empty. That nesting is pre-existing code this PR
moved verbatim, and the case cannot occur here: the subtitle assigner returns no
label without an id, the diarizer skips a segment whose id is empty, and
`timeSpanExtraJSON` persists nothing when `speaker` is empty. Changing it would
emit a field the store cannot persist. The invariant is now recorded in a
comment so the nesting does not read as an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMUGXpNtkZH63icDRKLCZ9
