### PR TITLE
chore: pin the toolchain to go1.25.13 for three stdlib advisories (#863)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dirstral/dir2mcp
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/abadojack/whatlanggo v1.0.1


### PR DESCRIPTION
`govulncheck` is red on every branch in this repository, including `main`. This is the one-line fix.

## The advisories

```
GO-2026-6218  net/url@go1.25.12        fixed in go1.25.13
GO-2026-6091  html/template@go1.25.12  fixed in go1.25.13
GO-2026-6090  crypto/tls@go1.25.12     fixed in go1.25.13
```

## No change here caused them

They were published between `main`'s last CI run (20:05) and the next branch run (22:22). `main` reports green only because it has not been re-tested since. I confirmed the same failure on PR #862, whose four changed files contain **zero** references to `net/url`, `html/template` or `crypto/tls`.

So every branch opened from now fails that job until the pin moves, and the failure has nothing to do with what the branch changed. That is the worst kind of red check: it trains people to ignore the job.

## Why one line is enough

All three `setup-go` steps in `.github/workflows/go.yml` use `go-version-file: go.mod`, so the toolchain comes from that pin. Bumping it fixes the whole repository rather than one branch.

`go1.25.13` is released and available.

## Verified

`make check` passes on 1.25.13: the Go suite, the 361 Python annotator tests, `gocyclo -over 15`, and the build.

Closes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.25.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->