### PR TITLE
fix(ingest): carry a recognizer's sources through to the served span (#861)

### DIFF
--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -282,6 +282,7 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		text     string
 		entities []string
 		event    string
+		sources  []string
 	}
 	valid := make([]validAnnotation, 0, len(anns))
 	for _, ann := range anns {
@@ -296,6 +297,13 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 			// persisting only the text made the filter unimplementable.
 			entities: model.NormalizeEntityIDs(ann.Entities),
 			event:    strings.TrimSpace(ann.Event),
+			// Carried for the same reason, but for a different question
+			// (df-005 0.3.0 `sources`): entities and event say WHAT the
+			// annotation is about, sources says WHICH recognizer said it. The
+			// backend has always sent it and this function used to drop it, so
+			// no client could tell a scorebug reading from a face match (#861).
+			// Provenance only: nothing downstream ranks or filters on it.
+			sources: model.NormalizeSources(ann.Sources),
 		})
 	}
 	sort.Slice(valid, func(i, j int) bool {
@@ -314,7 +322,7 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 			Text: v.text,
 			Span: model.Span{
 				Kind: "time", StartMS: v.startMS, EndMS: v.endMS,
-				Entities: v.entities, Event: v.event,
+				Entities: v.entities, Event: v.event, Sources: v.sources,
 			},
 		})
 		// The attribution joins the derivation hash: a backend that changes
@@ -332,6 +340,26 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 			v.startMS, v.endMS, len(v.text), v.text, len(v.event), v.event, len(v.entities))
 		for _, id := range v.entities {
 			fmt.Fprintf(&hashInput, "|%d:%s", len(id), id)
+		}
+		// The recognizer tags join the hash too, and for the same reason: a
+		// backend that re-attributes an annotation from the scorebug to the
+		// play-by-play feed has stored different provenance, so the
+		// representation must be re-derived rather than kept because the prose
+		// matches. Same length-prefixed encoding, because a tag is an opaque
+		// backend token that may contain any delimiter.
+		//
+		// The whole group is APPENDED ONLY WHEN PRESENT, unlike the entity
+		// count above. The entity list ends at a known count, so a line either
+		// stops there or continues with the source count: both readings are
+		// unambiguous. Emitting "|0" instead would change the hash input of
+		// every annotation that carries no sources, and that re-runs the
+		// recognition backend over a whole corpus of video to store a field
+		// those annotations do not have.
+		if len(v.sources) > 0 {
+			fmt.Fprintf(&hashInput, "|%d", len(v.sources))
+			for _, source := range v.sources {
+				fmt.Fprintf(&hashInput, "|%d:%s", len(source), source)
+			}
 		}
 		hashInput.WriteByte('\n')
 	}

--- a/internal/ingest/recognize.go
+++ b/internal/ingest/recognize.go
@@ -271,10 +271,12 @@ func RecognitionSegments(anns []model.RecognizedAnnotation) ([]ChunkSegment, str
 // core does not rely on the draft schema alone): empty or whitespace-only text
 // (a non-searchable chunk), a negative start (the wire contract is 0-based, §5),
 // or a reversed span (end before start). The survivors are sorted by
-// (start, end, text) so the rep_hash and the persisted chunk order are STABLE
-// regardless of the order the backend emitted them in — the serve contract makes
-// no ordering guarantee, and an order-only change MUST NOT flap the rep_hash and
-// force a spurious re-derivation.
+// (start, end, text, canonical line) so the rep_hash and the persisted chunk
+// order are STABLE regardless of the order the backend emitted them in — the
+// serve contract makes no ordering guarantee, and an order-only change MUST NOT
+// flap the rep_hash and force a spurious re-derivation. The canonical line is
+// the last key because bounds and text alone do not identify an annotation: two
+// annotations can share all three and differ in their attribution.
 func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, string) {
 	type validAnnotation struct {
 		startMS  int
@@ -283,6 +285,44 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		entities []string
 		event    string
 		sources  []string
+		// hashLine is this annotation's whole contribution to the derivation
+		// hash input, and also the final sort tie-break below.
+		hashLine string
+	}
+	// canonicalLine renders one annotation as the line the rep_hash covers.
+	//
+	// The attribution joins the derivation hash: a backend that changes which
+	// entities an annotation names, or which recognizer produced it, has
+	// produced different content, and the representation must be re-derived
+	// rather than kept because the prose happens to match (§8.6.7).
+	//
+	// Every variable-length field is LENGTH-PREFIXED rather than delimited.
+	// Entity ids and recognizer tags are opaque backend-declared tokens, so any
+	// delimiter can legitimately appear inside one: joining with commas would
+	// encode ["a,b", "c"] and ["a", "b,c"] identically, and two genuinely
+	// different attributions that hash the same would silently NOT re-derive.
+	// That is the exact failure this input exists to prevent.
+	//
+	// The source group is APPENDED ONLY WHEN PRESENT, unlike the entity count.
+	// The entity list ends at a known count, so a line either stops there or
+	// continues with the source count: both readings are unambiguous. Emitting
+	// "|0" instead would change the hash input of every annotation that carries
+	// no sources, and that re-runs the recognition backend over a whole corpus
+	// of video to store a field those annotations do not have.
+	canonicalLine := func(v validAnnotation) string {
+		var line strings.Builder
+		fmt.Fprintf(&line, "%d|%d|%d:%s|%d:%s|%d",
+			v.startMS, v.endMS, len(v.text), v.text, len(v.event), v.event, len(v.entities))
+		for _, id := range v.entities {
+			fmt.Fprintf(&line, "|%d:%s", len(id), id)
+		}
+		if len(v.sources) > 0 {
+			fmt.Fprintf(&line, "|%d", len(v.sources))
+			for _, source := range v.sources {
+				fmt.Fprintf(&line, "|%d:%s", len(source), source)
+			}
+		}
+		return line.String()
 	}
 	valid := make([]validAnnotation, 0, len(anns))
 	for _, ann := range anns {
@@ -290,7 +330,7 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		if text == "" || ann.StartMS < 0 || ann.EndMS < ann.StartMS {
 			continue
 		}
-		valid = append(valid, validAnnotation{
+		v := validAnnotation{
 			startMS: ann.StartMS, endMS: ann.EndMS, text: text,
 			// Carried, not dropped: these are what an entity filter selects on
 			// (design 0004 §7). The backend is required to compute them, and
@@ -304,7 +344,9 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 			// no client could tell a scorebug reading from a face match (#861).
 			// Provenance only: nothing downstream ranks or filters on it.
 			sources: model.NormalizeSources(ann.Sources),
-		})
+		}
+		v.hashLine = canonicalLine(v)
+		valid = append(valid, v)
 	}
 	sort.Slice(valid, func(i, j int) bool {
 		if valid[i].startMS != valid[j].startMS {
@@ -313,7 +355,18 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 		if valid[i].endMS != valid[j].endMS {
 			return valid[i].endMS < valid[j].endMS
 		}
-		return valid[i].text < valid[j].text
+		if valid[i].text != valid[j].text {
+			return valid[i].text < valid[j].text
+		}
+		// Bounds and text do not identify an annotation: two of them can share
+		// all three and still name different entities, a different event or a
+		// different recognizer. sort.Slice is not stable, so without this final
+		// key the emitted order (and with it the hash input) would depend on the
+		// order the backend happened to send them in, and a re-ordered response
+		// would re-derive the representation for no change. The canonical line
+		// covers every field, so equal keys mean identical annotations and the
+		// order between them cannot matter.
+		return valid[i].hashLine < valid[j].hashLine
 	})
 	segments := make([]chunkSegment, 0, len(valid))
 	var hashInput strings.Builder
@@ -325,42 +378,7 @@ func recognitionSegments(anns []model.RecognizedAnnotation) ([]chunkSegment, str
 				Entities: v.entities, Event: v.event, Sources: v.sources,
 			},
 		})
-		// The attribution joins the derivation hash: a backend that changes
-		// which entities an annotation names has produced different content,
-		// and the representation must be re-derived rather than kept because
-		// the prose happens to match (§8.6.7).
-		//
-		// Every variable-length field is LENGTH-PREFIXED rather than delimited.
-		// Entity ids are opaque backend-declared tokens, so any delimiter can
-		// legitimately appear inside one: joining with commas would encode
-		// ["a,b", "c"] and ["a", "b,c"] identically, and two genuinely
-		// different attributions that hash the same would silently NOT
-		// re-derive. That is the exact failure this input exists to prevent.
-		fmt.Fprintf(&hashInput, "%d|%d|%d:%s|%d:%s|%d",
-			v.startMS, v.endMS, len(v.text), v.text, len(v.event), v.event, len(v.entities))
-		for _, id := range v.entities {
-			fmt.Fprintf(&hashInput, "|%d:%s", len(id), id)
-		}
-		// The recognizer tags join the hash too, and for the same reason: a
-		// backend that re-attributes an annotation from the scorebug to the
-		// play-by-play feed has stored different provenance, so the
-		// representation must be re-derived rather than kept because the prose
-		// matches. Same length-prefixed encoding, because a tag is an opaque
-		// backend token that may contain any delimiter.
-		//
-		// The whole group is APPENDED ONLY WHEN PRESENT, unlike the entity
-		// count above. The entity list ends at a known count, so a line either
-		// stops there or continues with the source count: both readings are
-		// unambiguous. Emitting "|0" instead would change the hash input of
-		// every annotation that carries no sources, and that re-runs the
-		// recognition backend over a whole corpus of video to store a field
-		// those annotations do not have.
-		if len(v.sources) > 0 {
-			fmt.Fprintf(&hashInput, "|%d", len(v.sources))
-			for _, source := range v.sources {
-				fmt.Fprintf(&hashInput, "|%d:%s", len(source), source)
-			}
-		}
+		hashInput.WriteString(v.hashLine)
 		hashInput.WriteByte('\n')
 	}
 	return segments, hashInput.String()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3471,7 +3471,7 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 	}
 }
 
-// serializeTimeSpan renders a "time" span per df-005 0.2.0. Every optional field
+// serializeTimeSpan renders a "time" span per df-005 0.3.0. Every optional field
 // is omitted when absent, so a plain transcript span stays byte-identical to the
 // one served before this function existed.
 //
@@ -3481,6 +3481,12 @@ func buildOpenFileSpan(span model.Span) map[string]interface{} {
 // SEE why a hit matched: before this, a caller who asked for
 // events: ["home_run"] and received five hits could not confirm that all five
 // carry that event, nor tell a filtered result from an unfiltered one (#856).
+//
+// sources names the recognizers behind the annotation (df-005 0.3.0). It answers
+// "how do you know", which entities/event do not: a scorebug reading and a face
+// match carry different weight, and until this the backend sent the tags and
+// ingestion dropped them (#861). It is PROVENANCE ONLY: no filter, score, dedup
+// or citation rule reads it, so a client that ignores it ranks identically.
 //
 // The values are already on the in-memory span (the store rebuilds them from the
 // span's extra_json on every chunk read), so this costs no extra query.
@@ -3514,6 +3520,12 @@ func serializeTimeSpan(span model.Span) map[string]interface{} {
 	}
 	if event := strings.TrimSpace(span.Event); event != "" {
 		out["event"] = event
+	}
+	// Omitted entirely when the annotation names no recognizer, never served as
+	// null or []: df-005 makes the field optional, and an empty array would
+	// claim the producer said something about provenance when it said nothing.
+	if sources := model.NormalizeSources(span.Sources); len(sources) > 0 {
+		out["sources"] = sources
 	}
 	return out
 }
@@ -3877,6 +3889,14 @@ func spanDefinitionSchema() map[string]interface{} {
 						"type":        "string",
 						"enum":        []string{"observed", "generated"},
 						"description": "Optional (SPEC 5.4): whether this span records something observed or something a model generated. Absent means observed. A client MUST NOT present a generated span as a record of what happened.",
+					},
+					// df-005 0.3.0, and declared for the same reason as the two
+					// fields above: this server emits it, so the advertised
+					// branch must accept it.
+					"sources": map[string]interface{}{
+						"type":        "array",
+						"items":       map[string]interface{}{"type": "string"},
+						"description": "Optional (df-005): the recognizers that contributed to this annotation, for example [\"scorebug\"] or [\"playbyplay\",\"face\"]. Producer-defined tags, not a closed set and not a relevance signal. A client MAY use them to explain or weigh a hit, and MUST render an unknown tag verbatim rather than error.",
 					},
 				},
 				"required": []string{"kind", "start_ms", "end_ms"},

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -325,6 +325,22 @@ type Span struct {
 	// the "time" span's extra_json.
 	Entities []string
 	Event    string
+	// Sources names the recognizers that produced this annotation, for example
+	// ["scorebug"] or ["playbyplay", "face"] (df-005 0.3.0). The vocabulary is
+	// producer-defined: a backend declares its own tags, so this side never
+	// enumerates them.
+	//
+	// It answers a different question from Entities/Event, which say WHAT the
+	// annotation is about. Sources says WHO said it, which is what lets a
+	// caller weigh a scorebug reading against a face match when the two
+	// disagree.
+	//
+	// PROVENANCE ONLY (df-005 0.3.0): no filter, no score and no dedup key
+	// reads it, and a client MUST NOT have to read it to rank or filter
+	// correctly. Metadata only, exactly like Speaker: it never changes chunk
+	// text or span bounds, and it is empty on every representation that is not
+	// a recognition annotation. Persisted in the "time" span's extra_json.
+	Sources []string
 }
 
 // WordSpan is one per-word timestamp on a "time" span (spec §8.6.1). The JSON
@@ -626,21 +642,42 @@ func (f Filter) MatchesAnnotation(span Span) bool {
 // that emitted a stray blank id would re-derive a representation whose stored
 // attribution is byte-identical.
 func NormalizeEntityIDs(ids []string) []string {
-	if len(ids) == 0 {
+	return normalizeOpaqueTags(ids)
+}
+
+// NormalizeSources applies the same rule to a span's recognizer tags (df-005
+// 0.3.0 `sources`): trim, drop empties, de-duplicate, keep first-seen order.
+// Order is the producer's, so the tag a backend names first stays first. A
+// repeated tag names the same recognizer twice and adds nothing, so it is
+// dropped exactly as a repeated entity id is.
+//
+// Ingestion and persistence share this one rule for the same reason
+// NormalizeEntityIDs is shared: the derivation hash covers what is STORED, so
+// a backend that emits a stray blank tag must not re-derive a representation
+// whose stored provenance is byte-identical.
+func NormalizeSources(sources []string) []string {
+	return normalizeOpaqueTags(sources)
+}
+
+// normalizeOpaqueTags is the shared body of NormalizeEntityIDs and
+// NormalizeSources. Both carry backend-declared opaque tokens, so both trim,
+// drop empties and de-duplicate while preserving first-seen order.
+func normalizeOpaqueTags(values []string) []string {
+	if len(values) == 0 {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(ids))
-	out := make([]string, 0, len(ids))
-	for _, id := range ids {
-		id = strings.TrimSpace(id)
-		if id == "" {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
 			continue
 		}
-		if _, dup := seen[id]; dup {
+		if _, dup := seen[value]; dup {
 			continue
 		}
-		seen[id] = struct{}{}
-		out = append(out, id)
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/store/sqlite_store.go
+++ b/internal/store/sqlite_store.go
@@ -3200,7 +3200,7 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 			return model.Span{Kind: "lines"}
 		}
 		speaker, speakerLabel := speakerFromExtraJSON(extraJSON)
-		entities, event := annotationFromExtraJSON(extraJSON)
+		entities, event, sources := annotationFromExtraJSON(extraJSON)
 		return model.Span{
 			Kind: "time", StartMS: start, EndMS: end,
 			Words:        wordsFromExtraJSON(extraJSON),
@@ -3208,6 +3208,7 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 			SpeakerLabel: speakerLabel,
 			Entities:     entities,
 			Event:        event,
+			Sources:      sources,
 		}
 	case "region":
 		return regionSpanFromRow(start, end, extraJSON)
@@ -3220,22 +3221,26 @@ func spanFromRow(kind string, start, end int, extraJSON string) model.Span {
 }
 
 // annotationFromExtraJSON reconstructs a recognition annotation's structured
-// attribution (design 0004 §7) from a "time" span's stored extra_json. A
-// NULL/empty/malformed payload yields no entities and no event, so a span that
-// predates this (or comes from a transcript) degrades to exactly the behaviour
-// it had before, rather than erroring.
-func annotationFromExtraJSON(extraJSON string) (entities []string, event string) {
+// attribution (design 0004 §7) and its recognizer provenance (`sources`,
+// df-005 0.3.0) from a "time" span's stored extra_json. A NULL/empty/malformed
+// payload yields no entities, no event and no sources, so a span that predates
+// this (or comes from a transcript) degrades to exactly the behaviour it had
+// before, rather than erroring.
+func annotationFromExtraJSON(extraJSON string) (entities []string, event string, sources []string) {
 	if strings.TrimSpace(extraJSON) == "" {
-		return nil, ""
+		return nil, "", nil
 	}
 	var payload struct {
 		Entities []string `json:"entities"`
 		Event    string   `json:"event"`
+		Sources  []string `json:"sources"`
 	}
 	if err := json.Unmarshal([]byte(extraJSON), &payload); err != nil {
-		return nil, ""
+		return nil, "", nil
 	}
-	return model.NormalizeEntityIDs(payload.Entities), strings.TrimSpace(payload.Event)
+	return model.NormalizeEntityIDs(payload.Entities),
+		strings.TrimSpace(payload.Event),
+		model.NormalizeSources(payload.Sources)
 }
 
 // wordsFromExtraJSON reconstructs per-word timing for a "time" span from its
@@ -4122,7 +4127,7 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 		if span.StartMS < 0 || span.EndMS < 0 || span.EndMS < span.StartMS {
 			return "", 0, 0, "", errors.New("invalid time span")
 		}
-		extra, eErr := timeSpanExtraJSON(span.Words, span.Speaker, span.SpeakerLabel, span.Entities, span.Event)
+		extra, eErr := timeSpanExtraJSON(span)
 		if eErr != nil {
 			return "", 0, 0, "", eErr
 		}
@@ -4135,25 +4140,27 @@ func spanToRow(span model.Span) (kind string, start int, end int, extraJSON stri
 }
 
 // timeSpanExtraJSON marshals the optional metadata of a "time" span into the
-// stored extra_json object: per-word timing (`words`, spec §8.6.1) plus the
-// diarized speaker attribution (`speaker`/`speaker_label`, spec §8.6.8). Each
-// field is emitted only when present (omitempty), so a transcript with neither
+// stored extra_json object: per-word timing (`words`, spec §8.6.1), the
+// diarized speaker attribution (`speaker`/`speaker_label`, spec §8.6.8), and a
+// recognition annotation's attribution (`entities`/`event`, design 0004 §7)
+// plus its recognizer provenance (`sources`, df-005 0.3.0). Each field is
+// emitted only when present (omitempty), so a transcript with none of them
 // returns the empty string (stored as SQL NULL) and round-trips byte-identically
 // to before diarization existed. speaker/speaker_label are trimmed; an empty
 // speaker drops both (a label without a stable id is not a valid attribution).
-func timeSpanExtraJSON(
-	words []model.WordSpan, speaker, speakerLabel string, entities []string, event string,
-) (string, error) {
-	speaker = strings.TrimSpace(speaker)
-	speakerLabel = strings.TrimSpace(speakerLabel)
+func timeSpanExtraJSON(span model.Span) (string, error) {
+	words := span.Words
+	speaker := strings.TrimSpace(span.Speaker)
+	speakerLabel := strings.TrimSpace(span.SpeakerLabel)
 	if speaker == "" {
 		// A label with no stable id is not a valid attribution; drop both so the
 		// stored shape never carries a dangling speaker_label.
 		speakerLabel = ""
 	}
-	entities = model.NormalizeEntityIDs(entities)
-	event = strings.TrimSpace(event)
-	if len(words) == 0 && speaker == "" && len(entities) == 0 && event == "" {
+	entities := model.NormalizeEntityIDs(span.Entities)
+	event := strings.TrimSpace(span.Event)
+	sources := model.NormalizeSources(span.Sources)
+	if len(words) == 0 && speaker == "" && len(entities) == 0 && event == "" && len(sources) == 0 {
 		return "", nil
 	}
 	payload := struct {
@@ -4162,9 +4169,10 @@ func timeSpanExtraJSON(
 		SpeakerLabel string           `json:"speaker_label,omitempty"`
 		Entities     []string         `json:"entities,omitempty"`
 		Event        string           `json:"event,omitempty"`
+		Sources      []string         `json:"sources,omitempty"`
 	}{
 		Words: words, Speaker: speaker, SpeakerLabel: speakerLabel,
-		Entities: entities, Event: event,
+		Entities: entities, Event: event, Sources: sources,
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {

--- a/tests/conformance/span_attribution_856_test.go
+++ b/tests/conformance/span_attribution_856_test.go
@@ -353,7 +353,7 @@ func TestSpan_NonRecognitionSpanCarriesNoAttribution(t *testing.T) {
 			continue
 		}
 		checked++
-		for _, field := range []string{"entities", "event", "derivation"} {
+		for _, field := range []string{"entities", "event", "derivation", "sources"} {
 			if _, present := span[field]; present {
 				t.Errorf("a non-recognition span carries %q: %#v", field, span)
 			}
@@ -407,11 +407,15 @@ func TestSpan_ServedSpansValidateAgainstCanonicalSchema(t *testing.T) {
 // declare. Without this, a validator that resolved to "accept anything" would
 // make every canonical check in this file pass vacuously.
 //
-// It uses `sources` as the undeclared field on purpose. That is the field
-// #861 asks about, and this is the machine-readable reason this PR does not
-// serve it: the canonical time branch is additionalProperties:false and does not
-// declare it, so a span carrying it would make a strict client reject the whole
-// tool result.
+// It uses `confidence` as the undeclared field on purpose. The recognize wire
+// carries a per-annotation confidence (design 0004 §5) and the canonical time
+// branch does not declare it, so it is the shape of a real mistake rather than a
+// nonsense token: the branch is additionalProperties:false, and a span carrying
+// it would make a strict client reject the whole tool result.
+//
+// It used to use `sources`. dirstral-spec 0.52.0 (df-005 0.3.0) declares that
+// field, and #861 now serves it, so it is no longer an undeclared field and
+// would make this control pass for the wrong reason.
 func TestSpan_CanonicalValidatorRejectsAnUndeclaredField(t *testing.T) {
 	t.Parallel()
 	validator := canonicalSpanValidator(t)
@@ -419,6 +423,7 @@ func TestSpan_CanonicalValidatorRejectsAnUndeclaredField(t *testing.T) {
 	conforming := map[string]interface{}{
 		"kind": "time", "start_ms": float64(0), "end_ms": float64(1000),
 		"entities": []interface{}{"player:heliot-ramos"}, "event": "home_run",
+		"sources": []interface{}{"scorebug"},
 	}
 	if err := validator.Validate(conforming); err != nil {
 		t.Fatalf("the canonical Span validator rejected a conforming time span: %v", err)
@@ -426,10 +431,10 @@ func TestSpan_CanonicalValidatorRejectsAnUndeclaredField(t *testing.T) {
 
 	undeclared := map[string]interface{}{
 		"kind": "time", "start_ms": float64(0), "end_ms": float64(1000),
-		"sources": []interface{}{"pbp-feed"},
+		"confidence": float64(0.97),
 	}
 	if err := validator.Validate(undeclared); err == nil {
-		t.Fatal("the canonical Span validator accepted an undeclared `sources` field, so every canonical check in this file would pass vacuously")
+		t.Fatal("the canonical Span validator accepted an undeclared `confidence` field, so every canonical check in this file would pass vacuously")
 	}
 }
 

--- a/tests/conformance/span_sources_861_test.go
+++ b/tests/conformance/span_sources_861_test.go
@@ -1,0 +1,341 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+	"github.com/dirstral/dir2mcp/internal/store"
+)
+
+// The WIRE half of issue #861, on the production SDK transport.
+//
+// A recognition annotation is produced by one or more recognizers: a
+// play-by-play feed, a scorebug reader, a face matcher. The backend has always
+// sent those tags, ingestion dropped them, and a viewer asking "how do you know"
+// could not be told which component spoke. dirstral-spec 0.52.0 (df-005 0.3.0)
+// puts `sources` on the `time` span, so the server can now say so.
+//
+// df-005 is explicit that `sources` is PROVENANCE ONLY: an implementation MUST
+// NOT require a client to read it to rank or filter correctly. The last test in
+// this file is that rule, pinned as a byte-for-byte comparison.
+
+// sources861 is the tag list the seeded annotations carry. Two tags, in a fixed
+// order, so a served span can be checked for order as well as content.
+var sources861 = []string{"playbyplay", "scorebug"}
+
+// recognitionCorpus861 seeds the same three documents as the #856 corpus, with
+// the recognizer tags under test on the two annotations. Passing nil sources
+// seeds the identical corpus WITHOUT provenance, which is the control the
+// provenance-only test compares against.
+func recognitionCorpus861(t *testing.T, st *store.SQLiteStore, sources []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	seed := func(relPath, docType, repType, text string, span model.Span) {
+		if err := st.UpsertDocument(ctx, model.Document{
+			RelPath: relPath, DocType: docType, SourceType: "local", Status: "ok",
+		}); err != nil {
+			t.Fatalf("UpsertDocument(%s): %v", relPath, err)
+		}
+		doc, err := st.GetDocumentByPath(ctx, relPath)
+		if err != nil {
+			t.Fatalf("GetDocumentByPath(%s): %v", relPath, err)
+		}
+		repID, err := st.UpsertRepresentation(ctx, model.Representation{
+			DocID: doc.DocID, RepType: repType, RepHash: relPath + repType, CreatedUnix: 1,
+		})
+		if err != nil {
+			t.Fatalf("UpsertRepresentation(%s): %v", relPath, err)
+		}
+		if _, err := st.InsertChunkWithSpans(ctx, model.Chunk{
+			RepID: repID, Ordinal: 0, Text: text,
+			IndexKind: "text", EmbeddingStatus: "ok",
+		}, []model.Span{span}); err != nil {
+			t.Fatalf("InsertChunkWithSpans(%s): %v", relPath, err)
+		}
+	}
+
+	seed("game.mp4", "video", "recognition",
+		"Heliot Ramos hits a home run to left field",
+		model.Span{
+			Kind: "time", StartMS: 3346398, EndMS: 3354398,
+			Entities: []string{"player:heliot-ramos"},
+			Event:    "home_run",
+			Sources:  sources,
+		})
+	seed("game2.mp4", "video", "recognition",
+		"Logan Webb throws a home run ball on a pitch to the plate",
+		model.Span{
+			Kind: "time", StartMS: 120000, EndMS: 128000,
+			Entities: []string{"player:logan-webb"},
+			Event:    "pitch",
+			Sources:  sources,
+		})
+	seed("notes.md", "md", "raw_text",
+		"match report: the home run in the seventh decided the game",
+		model.Span{Kind: "lines", StartLine: 1, EndLine: 2})
+}
+
+// recognitionServer861 wires the production chain behind the production SDK
+// transport, over a corpus seeded with (or without) recognizer tags. The warm
+// load reads each chunk back out of the store, so the provenance reaches
+// serialization exactly the way it does after a daemon restart.
+func recognitionServer861(t *testing.T, sources []string) (*runningServer, config.Config) {
+	t.Helper()
+	ctx := context.Background()
+	tmp := t.TempDir()
+
+	st := store.NewSQLiteStore(filepath.Join(tmp, "meta.sqlite"))
+	if err := st.Init(ctx); err != nil {
+		t.Fatalf("store init: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	recognitionCorpus861(t, st, sources)
+
+	idx := index.NewHNSWIndex("")
+	svc := retrieval.NewService(st, idx, spanStaticEmbedder856{}, nil)
+
+	tasks, err := st.ListEmbeddedChunkMetadata(ctx, "text", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEmbeddedChunkMetadata: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("warm load returned %d chunks, want 3", len(tasks))
+	}
+	for i, task := range tasks {
+		meta := task.Metadata
+		vec := make([]float32, spanVectorDim856)
+		vec[0] = 1
+		vec[1] = float32(i) / 1000
+		if err := idx.Upsert(ctx, vec, model.IndexPayload{
+			ChunkID: meta.ChunkID, RelPath: meta.RelPath, DocType: meta.DocType,
+			RepType: meta.RepType, Span: meta.Span,
+			StartMS: meta.Span.StartMS, EndMS: meta.Span.EndMS,
+		}); err != nil {
+			t.Fatalf("Upsert(%d): %v", meta.ChunkID, err)
+		}
+		svc.SetChunkMetadata(meta.ChunkID, meta.ToSearchHit())
+	}
+
+	cfg := defaultConfig()
+	cfg.StateDir = tmp
+	return newServerWithRetriever(t, cfg, svc, mcp.WithStore(st)), cfg
+}
+
+// assertSources861 requires a span to name its recognizers, in the order the
+// producer named them.
+func assertSources861(t *testing.T, span map[string]interface{}, label string) {
+	t.Helper()
+	raw, ok := span["sources"].([]interface{})
+	if !ok {
+		pretty, _ := json.MarshalIndent(span, "", "  ")
+		t.Fatalf("%s carries no sources array, so a caller cannot learn which recognizer produced it:\n%s", label, pretty)
+	}
+	if len(raw) != len(sources861) {
+		t.Fatalf("%s span.sources = %#v, want %v", label, raw, sources861)
+	}
+	for i, want := range sources861 {
+		if raw[i] != want {
+			t.Fatalf("%s span.sources[%d] = %#v, want %q (order is the producer's)", label, i, raw[i], want)
+		}
+	}
+}
+
+// TestSearch_HitNamesTheRecognizersBehindTheAnnotation is #861's acceptance
+// criterion on the wire. It FAILS before the fix: ingestion dropped the tags, so
+// the served span carries no `sources` at all.
+func TestSearch_HitNamesTheRecognizersBehindTheAnnotation(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer861(t, sources861)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameSearch,
+		`{"query":"home run","events":["home_run"],"k":20}`)
+	spans := spansOf856(t, structured, "hits")
+	if len(spans) != 1 {
+		t.Fatalf("events:[\"home_run\"] returned %d hits, want 1 (the annotation only)", len(spans))
+	}
+	assertSources861(t, spans[0], "the dir2mcp_search hit")
+}
+
+// TestAsk_CitationSpanNamesTheRecognizers covers the other tool that serves a
+// Span. #849 exists because five tools disagreed with their own schemas, so a
+// fix that only reaches dir2mcp_search is not a fix.
+func TestAsk_CitationSpanNamesTheRecognizers(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer861(t, sources861)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameAsk,
+		`{"question":"who hit a home run?","events":["home_run"],"k":20}`)
+	for _, field := range []string{"hits", "citations"} {
+		spans := spansOf856(t, structured, field)
+		if len(spans) != 1 {
+			t.Fatalf("dir2mcp_ask returned %d %s, want 1", len(spans), field)
+		}
+		assertSources861(t, spans[0], "the dir2mcp_ask "+field+" entry")
+	}
+}
+
+// TestSpan_NoSourcesOmitsTheFieldEntirely is the optionality rule. df-005 makes
+// `sources` optional, so an annotation that names no recognizer must omit the
+// key: not `null`, not `[]`. A decoded payload distinguishes all three, because
+// both of the wrong shapes leave the key present.
+func TestSpan_NoSourcesOmitsTheFieldEntirely(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer861(t, nil)
+
+	structured := callToolStructured856(t, srv, cfg, protocol.ToolNameSearch,
+		`{"query":"home run","k":20}`)
+	spans := spansOf856(t, structured, "hits")
+	if len(spans) != 3 {
+		t.Fatalf("an unfiltered search returned %d hits, want all 3", len(spans))
+	}
+	for _, span := range spans {
+		if value, present := span["sources"]; present {
+			pretty, _ := json.MarshalIndent(span, "", "  ")
+			t.Errorf("a span with no recognizer tags still carries sources=%#v:\n%s", value, pretty)
+		}
+	}
+}
+
+// TestSpan_ServedSourcesValidateAgainstCanonicalSchema validates the spans a
+// client actually receives against the canonical Span in the PINNED submodule.
+// Every Span branch is additionalProperties:false, so serving a field the
+// contract does not declare makes a strict client reject the whole tool result:
+// the #397 "Failed to call tool" class. This is the guard that makes emitting
+// `sources` safe, and it only passes on a submodule pinned at 0.52.0 or later.
+func TestSpan_ServedSourcesValidateAgainstCanonicalSchema(t *testing.T) {
+	t.Parallel()
+	srv, cfg := recognitionServer861(t, sources861)
+	validator := canonicalSpanValidator(t)
+
+	cases := []struct {
+		tool, arguments, field string
+	}{
+		{protocol.ToolNameSearch, `{"query":"home run","k":20}`, "hits"},
+		{protocol.ToolNameAsk, `{"question":"who hit a home run?","k":20}`, "hits"},
+		{protocol.ToolNameAsk, `{"question":"who hit a home run?","k":20}`, "citations"},
+	}
+	var checked int
+	for _, tc := range cases {
+		structured := callToolStructured856(t, srv, cfg, tc.tool, tc.arguments)
+		spans := spansOf856(t, structured, tc.field)
+		if len(spans) == 0 {
+			t.Fatalf("%s %s returned no %s, so this check would be vacuous", tc.tool, tc.arguments, tc.field)
+		}
+		for i, span := range spans {
+			if _, present := span["sources"]; present {
+				checked++
+			}
+			if err := validator.Validate(span); err != nil {
+				pretty, _ := json.MarshalIndent(span, "", "  ")
+				t.Errorf("%s %s[%d] is invalid against the canonical common.json Span: %v\nspan:\n%s", tc.tool, tc.field, i, err, pretty)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no served span carried sources, so this check validated nothing")
+	}
+}
+
+// withoutSources returns a deep copy of a decoded payload with the `sources` key
+// removed from every span object. A span is identified by its own required
+// fields (kind + start_ms), so an unrelated field of the same name elsewhere in
+// a payload is left alone and the comparison stays honest.
+func withoutSources(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, child := range typed {
+			out[key] = withoutSources(child)
+		}
+		_, isSpan := out["kind"]
+		if _, hasStart := out["start_ms"]; isSpan && hasStart {
+			delete(out, "sources")
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for _, child := range typed {
+			out = append(out, withoutSources(child))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// countSources reports how many span objects in a payload carry `sources`.
+func countSources(value interface{}) int {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		total := 0
+		for _, child := range typed {
+			total += countSources(child)
+		}
+		if _, present := typed["sources"]; present {
+			total++
+		}
+		return total
+	case []interface{}:
+		total := 0
+		for _, child := range typed {
+			total += countSources(child)
+		}
+		return total
+	default:
+		return 0
+	}
+}
+
+// TestSources_AreProvenanceOnly pins the rule df-005 0.3.0 states: an
+// implementation MUST NOT require a client to read `sources` to rank or filter
+// correctly. Two corpora that differ ONLY in the recognizer tags must answer
+// every query identically: same hits, same order, same scores, same citations.
+//
+// The comparison is byte-for-byte on the served payload with the tags removed,
+// so a scoring, filtering, dedup or citation rule that started to read the tags
+// fails here even if it kept the hit count the same.
+func TestSources_AreProvenanceOnly(t *testing.T) {
+	t.Parallel()
+	tagged, taggedCfg := recognitionServer861(t, sources861)
+	plain, plainCfg := recognitionServer861(t, nil)
+
+	cases := []struct{ tool, arguments string }{
+		{protocol.ToolNameSearch, `{"query":"home run","k":20}`},
+		{protocol.ToolNameSearch, `{"query":"home run","events":["home_run"],"k":20}`},
+		{protocol.ToolNameSearch, `{"query":"home run","entities":["player:logan-webb"],"k":20}`},
+		{protocol.ToolNameAsk, `{"question":"who hit a home run?","k":20}`},
+	}
+	for _, tc := range cases {
+		withTags := callToolStructured856(t, tagged, taggedCfg, tc.tool, tc.arguments)
+		withoutTags := callToolStructured856(t, plain, plainCfg, tc.tool, tc.arguments)
+
+		if countSources(withTags) == 0 {
+			t.Fatalf("%s %s served no sources at all, so this comparison would be vacuous", tc.tool, tc.arguments)
+		}
+		if got := countSources(withoutTags); got != 0 {
+			t.Fatalf("%s %s served %d sources from a corpus that has none", tc.tool, tc.arguments, got)
+		}
+
+		strippedTagged, err := json.Marshal(withoutSources(withTags))
+		if err != nil {
+			t.Fatalf("marshal tagged payload: %v", err)
+		}
+		strippedPlain, err := json.Marshal(withoutSources(withoutTags))
+		if err != nil {
+			t.Fatalf("marshal untagged payload: %v", err)
+		}
+		if string(strippedTagged) != string(strippedPlain) {
+			t.Errorf("%s %s answers differently once recognizer tags are present, so the tags are no longer provenance only:\nwith sources:    %s\nwithout sources: %s",
+				tc.tool, tc.arguments, strippedTagged, strippedPlain)
+		}
+	}
+}

--- a/tests/ingest/recognize_sources_861_test.go
+++ b/tests/ingest/recognize_sources_861_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// dirstral-spec 0.52.0 (df-005 0.3.0): a recognition annotation MAY name the
+// recognizers that produced it, and that provenance MUST survive ingestion.
+//
+// It did not. `recognizeWireResponse` decoded `sources` and `Recognize` copied
+// it onto the annotation, then `recognitionSegments` rebuilt each annotation as
+// {startMS, endMS, text, entities, event} and the tags stopped there. So the
+// backend named the scorebug reader or the face matcher, and no client could
+// ever learn which one spoke (#861).
+
+// sourced builds one annotation that names its recognizers.
+func sourced(text, event string, entities, sources []string, start, end int) model.RecognizedAnnotation {
+	return model.RecognizedAnnotation{
+		StartMS: start, EndMS: end, Text: text,
+		Event: event, Entities: entities, Sources: sources,
+	}
+}
+
+func TestAnnotationSourcesReachTheChunkSpan(t *testing.T) {
+	segments, _ := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		sourced("Heliot Ramos hits a home run", "home_run",
+			[]string{"player:heliot-ramos"}, []string{"playbyplay", "scorebug", "face"},
+			20300, 28300),
+	})
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	got := segments[0].Span.Sources
+	want := []string{"playbyplay", "scorebug", "face"}
+	if len(got) != len(want) {
+		t.Fatalf("span.Sources = %v, want %v", got, want)
+	}
+	for i, tag := range want {
+		if got[i] != tag {
+			// Order is the producer's and df-005 keeps it: the tags come back
+			// exactly as the backend named them.
+			t.Fatalf("span.Sources[%d] = %q, want %q", i, got[i], tag)
+		}
+	}
+}
+
+// TestAnAnnotationWithNoSourcesIsUnchanged: `sources` is optional, so a backend
+// that sends none produces exactly the span it produced before.
+func TestAnAnnotationWithNoSourcesIsUnchanged(t *testing.T) {
+	segments, _ := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		sourced("something happened", "pitch", []string{"player:a"}, nil, 0, 1000),
+	})
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segments))
+	}
+	if len(segments[0].Span.Sources) != 0 {
+		t.Fatalf("an annotation with no sources gained provenance: %+v", segments[0].Span)
+	}
+}
+
+// TestChangedSourcesRederiveTheRepresentation: the derivation hash covers what
+// is stored (§8.6.7), and the tags are now stored. A backend that re-attributes
+// an annotation from the scorebug to the face matcher must re-derive the
+// representation, not keep the old provenance because the prose still matches.
+func TestChangedSourcesRederiveTheRepresentation(t *testing.T) {
+	base := []model.RecognizedAnnotation{
+		sourced("Ramos hits a home run", "home_run", []string{"player:a"}, []string{"scorebug"}, 1, 2),
+	}
+	changed := []model.RecognizedAnnotation{
+		sourced("Ramos hits a home run", "home_run", []string{"player:a"}, []string{"face"}, 1, 2),
+	}
+	added := []model.RecognizedAnnotation{
+		sourced("Ramos hits a home run", "home_run", []string{"player:a"}, []string{"scorebug", "face"}, 1, 2),
+	}
+
+	_, h0 := ingest.RecognitionSegments(base)
+	_, h1 := ingest.RecognitionSegments(changed)
+	_, h2 := ingest.RecognitionSegments(added)
+
+	if h0 == h1 {
+		t.Fatal("re-attributing the annotation to another recognizer left the derivation hash input unchanged")
+	}
+	if h0 == h2 {
+		t.Fatal("adding a recognizer left the derivation hash input unchanged")
+	}
+}
+
+// TestSourceTagsCannotCollideInTheHash mirrors the entity-id guard. A tag is an
+// opaque backend token, so any delimiter can appear inside one and the encoding
+// must stay length-prefixed.
+func TestSourceTagsCannotCollideInTheHash(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+	}{
+		{"pipe inside a tag", []string{"a|b"}, []string{"a", "b"}},
+		{"colon inside a tag", []string{"feed:x", "y"}, []string{"feed", "x:y"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				sourced("same text", "pitch", nil, tc.a, 1, 2),
+			})
+			_, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				sourced("same text", "pitch", nil, tc.b, 1, 2),
+			})
+			if ha == hb {
+				t.Fatalf("%v and %v hash identically: %q", tc.a, tc.b, ha)
+			}
+		})
+	}
+}
+
+// TestSourceNormalisationMakesTheHashAgreeWithWhatIsStored: a blank or repeated
+// tag is dropped before persistence, so it must also be dropped before hashing.
+// Otherwise a backend that emits a stray blank tag re-derives a representation
+// whose stored provenance is byte-identical.
+func TestSourceNormalisationMakesTheHashAgreeWithWhatIsStored(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []string
+	}{
+		{"a blank tag is not a difference", []string{"scorebug", ""}, []string{"scorebug"}},
+		{"whitespace is trimmed", []string{" scorebug "}, []string{"scorebug"}},
+		{"a repeat is not a difference", []string{"scorebug", "scorebug"}, []string{"scorebug"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				sourced("same text", "pitch", nil, tc.a, 1, 2),
+			})
+			_, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+				sourced("same text", "pitch", nil, tc.b, 1, 2),
+			})
+			if ha != hb {
+				t.Fatalf("%v and %v hash differently (%q vs %q) but store identically", tc.a, tc.b, ha, hb)
+			}
+		})
+	}
+}
+
+// TestASourcelessAnnotationKeepsItsOldHashInput is the upgrade guard. Recognition
+// is the most expensive derivation in the tree: a changed hash input re-runs the
+// backend over every video in a corpus. An annotation that names no recognizer
+// gains no stored provenance, so its hash input MUST stay exactly what it was
+// before this field existed, and only an annotation that carries tags re-derives.
+func TestASourcelessAnnotationKeepsItsOldHashInput(t *testing.T) {
+	_, plain := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		sourced("same text", "pitch", nil, nil, 1, 2),
+	})
+	const want = "1|2|9:same text|5:pitch|0\n"
+	if plain != want {
+		t.Fatalf("a sourceless annotation hashes as %q, want %q: every existing corpus would re-run its recognition backend", plain, want)
+	}
+	_, tagged := ingest.RecognitionSegments([]model.RecognizedAnnotation{
+		sourced("same text", "pitch", nil, []string{"scorebug"}, 1, 2),
+	})
+	if !strings.HasPrefix(tagged, want[:len(want)-1]) || tagged == plain {
+		t.Fatalf("a tagged annotation must extend the same input, got %q vs %q", tagged, plain)
+	}
+}

--- a/tests/ingest/recognize_sources_861_test.go
+++ b/tests/ingest/recognize_sources_861_test.go
@@ -141,6 +141,34 @@ func TestSourceNormalisationMakesTheHashAgreeWithWhatIsStored(t *testing.T) {
 	}
 }
 
+// TestAnnotationOrderDoesNotFlapTheHash: the serve contract makes no ordering
+// guarantee, so two annotations that share bounds and text but name different
+// recognizers must sort into one fixed order. Without a tie-break past the text
+// the sort leaves them in the order the backend sent them, the hash input
+// follows, and a re-ordered response re-derives the representation for no
+// change: the exact flap the sort exists to prevent.
+func TestAnnotationOrderDoesNotFlapTheHash(t *testing.T) {
+	first := sourced("same text", "pitch", nil, []string{"scorebug"}, 1, 2)
+	second := sourced("same text", "pitch", nil, []string{"face"}, 1, 2)
+
+	forward, ha := ingest.RecognitionSegments([]model.RecognizedAnnotation{first, second})
+	reversed, hb := ingest.RecognitionSegments([]model.RecognizedAnnotation{second, first})
+
+	if ha != hb {
+		t.Fatalf("the same two annotations hash differently when re-ordered:\n%q\n%q", ha, hb)
+	}
+	if len(forward) != 2 || len(reversed) != 2 {
+		t.Fatalf("expected 2 segments each, got %d and %d", len(forward), len(reversed))
+	}
+	for i := range forward {
+		got := strings.Join(forward[i].Span.Sources, ",")
+		want := strings.Join(reversed[i].Span.Sources, ",")
+		if got != want {
+			t.Fatalf("segment %d differs by input order: %q vs %q", i, got, want)
+		}
+	}
+}
+
 // TestASourcelessAnnotationKeepsItsOldHashInput is the upgrade guard. Recognition
 // is the most expensive derivation in the tree: a changed hash input re-runs the
 // backend over every video in a corpus. An annotation that names no recognizer

--- a/tests/store/annotation_sources_861_test.go
+++ b/tests/store/annotation_sources_861_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// A recognition annotation's recognizer tags ride in the "time" span's
+// extra_json alongside `entities`/`event` (df-005 0.3.0 `sources`). These pin
+// the round trip: a client can only be told who spoke if the value comes back
+// out of the store.
+
+func TestAnnotationSourcesRoundTrip(t *testing.T) {
+	st := newAnnotationStore(t)
+	sources := []string{"playbyplay", "scorebug", "face"}
+	chunkID := annotationChunk(t, st, "game.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 20300, EndMS: 28300,
+		Entities: []string{"player:robbie-ray"}, Event: "pitch",
+		Sources: sources,
+	})
+
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if strings.Join(span.Sources, ",") != strings.Join(sources, ",") {
+		// Order is the producer's: df-005 keeps the tags as the backend named them.
+		t.Fatalf("sources did not round-trip: %v, want %v", span.Sources, sources)
+	}
+	// The provenance must not disturb the attribution stored next to it.
+	if span.Event != "pitch" || strings.Join(span.Entities, ",") != "player:robbie-ray" {
+		t.Fatalf("attribution disturbed by sources: %+v", span)
+	}
+}
+
+// TestASpanWithNoSourcesStoresNone: `sources` is optional, so a span without it
+// must read back empty rather than as an empty list, and a transcript span must
+// be untouched by the new key.
+func TestASpanWithNoSourcesStoresNone(t *testing.T) {
+	st := newAnnotationStore(t)
+	annotation := annotationChunk(t, st, "plain.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 0, EndMS: 1,
+		Entities: []string{"player:a"}, Event: "pitch",
+	})
+	transcript := annotationChunk(t, st, "talk.mp3", "transcript", model.Span{
+		Kind: "time", StartMS: 0, EndMS: 1000, Speaker: "S1", SpeakerLabel: "Host",
+	})
+	for name, chunkID := range map[string]int64{"annotation": annotation, "transcript": transcript} {
+		_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+		if err != nil {
+			t.Fatalf("ChunkMediaSpanByID(%s): %v", name, err)
+		}
+		if len(span.Sources) != 0 {
+			t.Fatalf("a %s span gained recognizer provenance: %+v", name, span)
+		}
+	}
+}
+
+// TestDuplicateAndBlankSourceTagsAreNormalised: a backend that repeats a tag, or
+// pads one, must not inflate the stored provenance or store a blank tag that
+// renders as an empty recognizer name.
+func TestDuplicateAndBlankSourceTagsAreNormalised(t *testing.T) {
+	st := newAnnotationStore(t)
+	chunkID := annotationChunk(t, st, "dupes.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 0, EndMS: 1,
+		Sources: []string{" scorebug ", "scorebug", "", "   ", "face"},
+	})
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if strings.Join(span.Sources, ",") != "scorebug,face" {
+		t.Fatalf("sources = %v, want the trimmed de-duplicated pair", span.Sources)
+	}
+}
+
+// TestSourcesAloneStillPersist: the extra_json object is written only when some
+// optional field is present. A span whose ONLY optional field is `sources` must
+// still write the object, or the provenance is dropped at the last step.
+func TestSourcesAloneStillPersist(t *testing.T) {
+	st := newAnnotationStore(t)
+	chunkID := annotationChunk(t, st, "only-sources.mp4", "recognition", model.Span{
+		Kind: "time", StartMS: 5, EndMS: 10, Sources: []string{"scorebug"},
+	})
+	_, _, span, err := st.ChunkMediaSpanByID(context.Background(), chunkID)
+	if err != nil {
+		t.Fatalf("ChunkMediaSpanByID: %v", err)
+	}
+	if strings.Join(span.Sources, ",") != "scorebug" {
+		t.Fatalf("sources = %v, want [scorebug]", span.Sources)
+	}
+	if span.StartMS != 5 || span.EndMS != 10 {
+		t.Fatalf("span bounds disturbed: %+v", span)
+	}
+}


### PR DESCRIPTION
## The defect

`internal/ingest/recognize.go` read a recognizer's `sources` off the wire, copied
it onto `model.RecognizedAnnotation`, and then dropped it. `recognitionSegments`
rebuilt each annotation as `{startMS, endMS, text, entities, event}`, so the tags
stopped one function short of the span. A client could see WHAT an annotation was
about (`entities`, `event`) but never WHO said it: a scorebug reading and a face
match looked the same.

`entities` and `event` had the same defect. #856 fixed those. #862 left `sources`
alone on purpose, because the canonical `time` branch is
`additionalProperties: false` and did not declare it.

## The spec is in now

dirstral-spec PR #92 merged as 0.52.0 (df-005 0.3.0). It adds the optional
`sources` array to the `time` span. This PR re-pins the submodule to `5beca83`,
the merge commit on the spec's default branch.

## What changed

The tags now take the same path `entities` and `event` take:

- `internal/model/types.go`: `Span.Sources`, plus `NormalizeSources` (trim, drop
  blanks, de-duplicate, keep the producer's order).
- `internal/ingest/recognize.go`: `recognitionSegments` carries the tags onto the
  span instead of dropping them.
- `internal/store/sqlite_store.go`: `timeSpanExtraJSON` persists `sources` in the
  span's extra_json; `annotationFromExtraJSON` rebuilds it on every chunk read.
- `internal/mcp/tools.go`: `serializeTimeSpan` serves it, and the advertised time
  branch declares it.

Every handler that serves a Span goes through `serializeTimeSpan`, so `search`,
`ask`, `related`, `open_file` and `open_media_clip` gain the field together. The
five served output schemas share one Span definition, so they gain it together
too. The declaration is mandatory: every Span branch is
`additionalProperties: false`, so a field the server emits but does not advertise
makes a strict client reject the whole tool result (the #397 class).

## Provenance only

df-005 0.3.0 is explicit: an implementation MUST NOT require a client to read
`sources` to rank or filter correctly. Nothing here scores, filters, dedups or
selects citations on the field. `TestSources_AreProvenanceOnly` pins that: two
corpora that differ ONLY in the tags run the same four queries, and the served
payloads must be byte-identical once the tags are removed. A ranking rule that
started to read them fails the test even if the hit count stayed the same.

## Optional means absent

An annotation that names no recognizer omits the key entirely: not `null`, not
`[]`. `TestSpan_NoSourcesOmitsTheFieldEntirely` checks the decoded payload, which
tells all three shapes apart.

## The derivation hash

The hash covers what is STORED, and the tags are now stored, so they join the
hash input: a backend that re-attributes an annotation from the scorebug to the
face matcher must re-derive rather than keep the old provenance because the prose
matches. The tag group is APPENDED ONLY WHEN PRESENT. The entity list ends at a
known count, so both readings stay unambiguous, and an annotation with no tags
keeps the exact hash input it had before. That matters: recognition is the most
expensive derivation in the tree, and a blanket change would re-run the backend
over every video in every corpus for a field those annotations do not have.
`TestASourcelessAnnotationKeepsItsOldHashInput` pins the old string.

## Tests

New, and each fails without the matching half of the fix:

- `tests/ingest/recognize_sources_861_test.go`: the tags reach the span in order;
  a change re-derives; the length-prefixed encoding cannot collide; a blank or
  repeated tag is not a difference; a sourceless annotation keeps its old hash.
- `tests/store/annotation_sources_861_test.go`: the round trip through
  extra_json, including a span whose only optional field is `sources`.
- `tests/conformance/span_sources_861_test.go`: the served payload on the
  production SDK transport, validated against the canonical `common.json` inside
  the pinned submodule, plus the omission rule and the provenance-only rule.

`tests/conformance/span_attribution_856_test.go` changes in two places. Its
non-recognition guard now also requires `sources` to be absent. Its negative
control moves off `sources`, which the canonical schema now declares, onto
`confidence`, which the recognize wire carries and the span branch still does not
declare, so the control keeps rejecting a real mistake.

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMUGXpNtkZH63icDRKLCZ9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional recognizer provenance to time-span annotations through a normalized `sources` array.
  - Provenance is now preserved in stored annotations and surfaced in search results and ask citations.
  - Source details are omitted when unavailable and do not affect ranking, filtering, scores, ordering, or citation behavior.

- **Bug Fixes**
  - Changes to recognition sources now correctly trigger annotation re-derivation.
  - Improved handling of duplicate, blank, and malformed source values.

- **Tests**
  - Added coverage for ingestion, persistence, schema validation, search, and citation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->