### PR TITLE
fix: bound the four reads #682 left, and gate raw text on the configured cap (#830)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,36 @@ strategy selector. The key is now unrecognized, so a config that still carries i
 with the warning above and no longer publishes the key back into the saved config or the
 effective snapshot.
 
+#### Ingest size cap
+
+```yaml
+ingest:
+  max_file_mb: 20      # default: 20
+```
+
+`ingest.max_file_mb` is the per-file size policy, and it is enforced as a bound on the
+reads themselves, not only as a check at discovery. Discovery refuses a file over it, and
+so does every read that follows: the document read, the subtitle sidecar, the
+object-store download, the multimodal media read, and the on-demand `annotate` /
+`transcribe` reads. A check only measures a file at one instant; a file that grows
+afterwards, or an object that serves more bytes than it listed, is caught by the read.
+(`open_file` answers a window rather than a whole file, so its raw-text read carries its
+own budget derived from `max_chars`; the cap still bounds the source read it needs to
+locate cached extracted text.)
+
+During indexing a file over the cap is a **skip, not an error**: it keeps a visible
+`skipped` row with reason `size_cap`, it is counted in the skip breakdown `dir2mcp status`
+reports, and its chunks leave retrieval. It was refused by policy, not by a failure, so it
+never lands in the failure list. On a tool request the refusal is reported as
+`FILE_TOO_LARGE`, which names the setting instead of a generic failure.
+
+Raw text now follows this setting exactly. Earlier releases gated raw-text indexing on a
+hard-coded 10 MiB, so a 15 MiB text file was admitted by the configured cap and then
+failed anyway. Text, code, markdown, data and HTML files between 10 MiB and the
+configured cap are indexed. To keep the old ceiling, set `max_file_mb: 10`.
+
+Zero or a negative value is not "unlimited": it selects the built-in default bound.
+
 #### Retrieval answer keys
 
 ```yaml

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -930,6 +930,9 @@ func (a *App) buildRetrieverForAsk(ctx context.Context, cfg config.Config, st mo
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)
+	// Bound the retrieval-time source reads with the SAME resolved cap ingest
+	// enforces (#830), from the one resolver.
+	ret.SetMaxFileBytes(ingest.ResolvedMaxFileBytes(cfg))
 	// Plumb ingest's ACTIVE OCR/transcript derivation identities into open_file's
 	// cache lookup so it keys the OCR/transcript cache the SAME identity-aware way
 	// ingest's writer does (issue #488). The ask path is read-only and builds no

--- a/internal/cli/embed_worker.go
+++ b/internal/cli/embed_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/config"
 	"github.com/dirstral/dir2mcp/internal/embedqueue"
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -209,7 +210,7 @@ func (a *App) runEmbedWorkerLoop(ctx context.Context, cfg config.Config, global 
 	logger := pickEmbedLogger(a.stderr, global.jsonOutput)
 	// The standalone embed-worker (#249) has no local IndexingState, so it needs no
 	// embedded_ok guard (the count hook is inert without a state to increment).
-	embedders := buildAxisEmbedders(chunkSource, textIx, codeIx, embedder, nil, (*appstate.IndexingState)(nil), (*embedqueue.EmbeddedGuard)(nil), textModel, codeModel, cfg.RootDir, corpusFS, logger)
+	embedders := buildAxisEmbedders(chunkSource, textIx, codeIx, embedder, nil, (*appstate.IndexingState)(nil), (*embedqueue.EmbeddedGuard)(nil), textModel, codeModel, cfg.RootDir, corpusFS, logger, ingest.ResolvedMaxFileBytes(cfg))
 	if len(embedders) == 0 {
 		writeCLIError(a.stderr, global.jsonOutput, exitConfigInvalid, "CONFIG_INVALID: no index axis configured for embed-worker")
 		return exitConfigInvalid

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -99,6 +99,9 @@ func (a *App) runUp(ctx context.Context, opts upOptions) int {
 	ret.SetCodeIndex(codeIx)
 	ret.SetRootDir(cfg.RootDir)
 	ret.SetStateDir(cfg.StateDir)
+	// Bound the retrieval-time source reads with the SAME resolved cap ingest
+	// enforces (#830), from the one resolver.
+	ret.SetMaxFileBytes(ingest.ResolvedMaxFileBytes(cfg))
 	ret.SetProtocolVersion(cfg.ProtocolVersion)
 	ret.SetRAGSystemPrompt(cfg.RAGSystemPrompt)
 	ret.SetMaxContextChars(cfg.RAGMaxContextChars)
@@ -1357,6 +1360,7 @@ func startEmbeddingWorkers(
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	lateChunking bool,
+	maxFileBytes int64,
 	wg *sync.WaitGroup,
 ) {
 	if st == nil || embedder == nil {
@@ -1379,6 +1383,10 @@ func startEmbeddingWorkers(
 			BatchSize:    32,
 			Logger:       logger,
 			LateChunking: lateChunking,
+			// The media read is bounded by the SAME cap discovery and the ingest
+			// source reads enforce (#830); the caller resolves it once via
+			// ingest.ResolvedMaxFileBytes.
+			MaxFileBytes: maxFileBytes,
 			OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
 				if ret != nil {
 					ret.SetChunkMetadataForIndex(workerKind, label, metadata.ToSearchHit())
@@ -1759,7 +1767,7 @@ func startEmbeddingIfNotReadOnly(ctx context.Context, cfg config.Config, readOnl
 	if cfg.DistributedEmbed.Enabled {
 		return startDistributedEmbedding(ctx, cfg, st, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, wg)
 	}
-	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking, wg)
+	startEmbeddingWorkers(ctx, chunkSource, textIx, codeIx, embedder, ret, indexingState, embedErrCh, embedLogger, embedModelText, embedModelCode, rootDir, corpusFS, cfg.IngestLateChunking, ingest.ResolvedMaxFileBytes(cfg), wg)
 	return nil
 }
 

--- a/internal/cli/up_distributed_embed.go
+++ b/internal/cli/up_distributed_embed.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dirstral/dir2mcp/internal/embedqueue"
 	"github.com/dirstral/dir2mcp/internal/identity"
 	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/ingest"
 	"github.com/dirstral/dir2mcp/internal/model"
 	"github.com/dirstral/dir2mcp/internal/retrieval"
 )
@@ -100,7 +101,7 @@ func startDistributedEmbedding(
 
 	// Build a per-kind embedder reusing the in-process embedding path so the
 	// distributed worker shares all embed/media-load/index/mark logic.
-	embedders := buildAxisEmbedders(chunkSource, textIndex, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger)
+	embedders := buildAxisEmbedders(chunkSource, textIndex, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, ingest.ResolvedMaxFileBytes(cfg))
 	if len(embedders) == 0 {
 		// Post-open abort: close the broker and release the lock so its SQLite
 		// handle and the coordinator lock are not leaked.
@@ -274,6 +275,7 @@ func newEmbedStep(
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	logger *log.Logger,
+	maxFileBytes int64,
 	kind string,
 ) *index.EmbeddingWorker {
 	return &index.EmbeddingWorker{
@@ -289,6 +291,9 @@ func newEmbedStep(
 		Corpus:       corpusFS,
 		BatchSize:    distributedEmbedBatchSize,
 		Logger:       logger,
+		// Same bound as the in-process loop: the distributed worker runs the same
+		// media read, so it must not read past the operator's cap either (#830).
+		MaxFileBytes: maxFileBytes,
 		OnIndexedChunk: func(label uint64, metadata model.ChunkMetadata) {
 			// Refreshing metadata is idempotent, so it runs on every (re-)embed.
 			if ret != nil {
@@ -319,13 +324,14 @@ func buildAxisEmbedders(
 	textModel, codeModel, rootDir string,
 	corpusFS corpusfs.CorpusFS,
 	logger *log.Logger,
+	maxFileBytes int64,
 ) map[string]embedqueue.Embedder {
 	embedders := make(map[string]embedqueue.Embedder)
 	if textIndex != nil {
-		embedders["text"] = newEmbedStep(chunkSource, textIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, "text")
+		embedders["text"] = newEmbedStep(chunkSource, textIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, maxFileBytes, "text")
 	}
 	if codeIndex != nil {
-		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, "code")
+		embedders["code"] = newEmbedStep(chunkSource, codeIndex, embedder, ret, indexingState, embeddedGuard, textModel, codeModel, rootDir, corpusFS, logger, maxFileBytes, "code")
 	}
 	return embedders
 }

--- a/internal/corpusfs/corpusfs.go
+++ b/internal/corpusfs/corpusfs.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"math"
 	"sort"
 )
 
@@ -23,6 +24,32 @@ const defaultMaxFileSizeBytes int64 = 10 * 1024 * 1024
 // DefaultMaxFileSizeBytes returns the default discovery file-size cap.
 func DefaultMaxFileSizeBytes() int64 {
 	return defaultMaxFileSizeBytes
+}
+
+// ResolveReadCapBytes turns a plumbed per-file cap into the positive value a
+// bounded read enforces. It is the single place that decision is made, so the
+// readers outside this package (the embedding worker's media read, retrieval's
+// source hash, ingest's raw-text read) cannot each grow their own copy (#830).
+//
+// A zero or negative input selects the 10 MiB default rather than disabling the
+// bound, so a caller that forgets to plumb the value still gets one. The upper
+// clamp keeps `configured+1` representable: every bound is a limit+1, and
+// math.MaxInt64 overflows that sum to a negative number, which io.LimitReader
+// reads as "zero bytes allowed" (#682 review finding 2). A cap this large is
+// unbounded in every practical sense, so clamping it loses nothing.
+//
+// The configured value itself comes from ingest.ResolvedMaxFileBytes, the one
+// resolver for `ingest.max_file_mb`; this function only makes it safe to use as a
+// limit.
+func ResolveReadCapBytes(configured int64) int64 {
+	switch {
+	case configured <= 0:
+		return defaultMaxFileSizeBytes
+	case configured > math.MaxInt64-1:
+		return math.MaxInt64 - 1
+	default:
+		return configured
+	}
 }
 
 // StateDirName is the name of the state directory dir2mcp writes under the

--- a/internal/corpusfs/local.go
+++ b/internal/corpusfs/local.go
@@ -20,8 +20,8 @@ import (
 // to their own fatal-error classification without string matching.
 var ErrPathEscapesRoot = errors.New("corpusfs: path escapes the corpus root")
 
-// ErrObjectTooLarge is returned by an object-store backend when the bytes it
-// actually served passed the configured per-file cap (#682).
+// ErrObjectTooLarge reports that the bytes a read actually obtained passed the
+// configured per-file cap (#682).
 //
 // It is a distinct sentinel from a transport failure for one reason: the two need
 // opposite answers. A transport failure is retried, because the next attempt may
@@ -29,8 +29,15 @@ var ErrPathEscapesRoot = errors.New("corpusfs: path escapes the corpus root")
 // it is permanent for as long as the object stays that size, and callers report it
 // as the `size_cap` skip it is rather than as an error.
 //
-// LocalFS never returns it. A local Localize hands back the in-root path and
-// copies nothing, so it has no read to bound; the caller's own read is the
+// It is the ONE sentinel for that condition across the repository, not only inside
+// this package (#830). An object-store backend raises it from its own transport,
+// and a reader outside a backend raises it when its own limited read passes the
+// same cap: the embedding worker's media read, retrieval's source hash, and the
+// MCP on-demand document read. One sentinel means one classification, so every
+// caller maps the cap to §14.4 FILE_TOO_LARGE instead of to a wrong cause.
+//
+// LocalFS itself never returns it. A local Localize hands back the in-root path
+// and copies nothing, so it has no read to bound; the caller's own read is the
 // boundary there.
 var ErrObjectTooLarge = errors.New("corpusfs: object exceeds the configured max file size")
 

--- a/internal/corpusfs/s3.go
+++ b/internal/corpusfs/s3.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -55,7 +54,7 @@ type S3FS struct {
 	// callers fall back to Localize.
 	presign presignFunc
 	// maxBytes is the per-object read/download cap (#682). It is always positive:
-	// resolveMaxBytes turns a zero or negative configured value into the 10 MiB
+	// ResolveReadCapBytes turns a zero or negative configured value into the 10 MiB
 	// default, so no construction path can leave the backend unbounded.
 	maxBytes int64
 }
@@ -76,26 +75,6 @@ type S3Config struct {
 	// Zero or negative selects DefaultMaxFileSizeBytes. There is deliberately no
 	// "unlimited" value: an unbounded download is the defect this field closes.
 	MaxBytes int64
-}
-
-// resolveMaxBytes turns a configured per-object cap into the positive value the
-// backend enforces. A zero or negative input selects the 10 MiB default rather
-// than disabling the bound, so a caller that forgets the field still gets one.
-//
-// The upper clamp keeps `maxBytes+1` representable. Every bound in this file is a
-// limit+1, and math.MaxInt64 would overflow that sum to a negative number, which
-// io.LimitReader reads as "zero bytes allowed": Localize would then write an empty
-// file and report SUCCESS, and a read would return an empty document. S3Config is
-// exported, so this invariant is enforced here rather than trusted to the caller.
-func resolveMaxBytes(configured int64) int64 {
-	switch {
-	case configured <= 0:
-		return defaultMaxFileSizeBytes
-	case configured > math.MaxInt64-1:
-		return math.MaxInt64 - 1
-	default:
-		return configured
-	}
 }
 
 // NewS3FS constructs an S3FS over the provided client and config. The client is
@@ -122,7 +101,12 @@ func newS3FSWithPresign(client s3API, cfg S3Config, presign presignFunc) (*S3FS,
 		prefix:   normalizeS3Prefix(cfg.Prefix),
 		cacheDir: cfg.CacheDir,
 		presign:  presign,
-		maxBytes: resolveMaxBytes(cfg.MaxBytes),
+		// S3Config is exported, so the cap is made safe HERE rather than trusted to
+		// the caller: an unclamped math.MaxInt64 overflows the backend's own
+		// `maxBytes+1` sums, and Localize would then write an empty file and report
+		// SUCCESS. ResolveReadCapBytes is shared with every other bounded reader, so
+		// the backend cannot enforce a different number from them (#830).
+		maxBytes: ResolveReadCapBytes(cfg.MaxBytes),
 	}, nil
 }
 

--- a/internal/corpusfs/s3reader.go
+++ b/internal/corpusfs/s3reader.go
@@ -51,7 +51,7 @@ type s3RangeReader struct {
 	key    string
 	size   int64
 	// maxBytes caps the bytes this reader will deliver in total (#682). It is
-	// always positive (see resolveMaxBytes), so the reader is never unbounded.
+	// always positive (see ResolveReadCapBytes), so the reader is never unbounded.
 	maxBytes int64
 
 	offset int64

--- a/internal/index/embedding_worker.go
+++ b/internal/index/embedding_worker.go
@@ -86,6 +86,18 @@ type EmbeddingWorker struct {
 	// corpusFS() so callers never observe a nil backend.
 	Corpus corpusfs.CorpusFS
 
+	// MaxFileBytes is the resolved `ingest.max_file_mb` cap in bytes, supplied by
+	// the caller from the single resolver (ingest.ResolvedMaxFileBytes) so this
+	// worker enforces the SAME number discovery and the ingest source reads do
+	// (#830). It bounds the whole-file media read (image and PDF bytes), which is
+	// held in memory for the embed call.
+	//
+	// Zero or negative selects corpusfs.DefaultMaxFileSizeBytes, so a caller that
+	// forgets to set it gets the default bound rather than no bound at all. There
+	// is deliberately no unlimited setting: a 29 GB file that reached a corpus is
+	// what OOM-killed a live daemon (#682).
+	MaxFileBytes int64
+
 	// Logger is optional; if non‑nil its Printf method will be used for
 	// informational messages. When nil the standard library's log package
 	// is used. Logging is only performed for transient/retryable errors or
@@ -291,7 +303,7 @@ func (w *EmbeddingWorker) loadMediaInput(ctx context.Context, t model.ChunkTask,
 		}
 		return model.MediaInput{MimeType: mediaMIMEType(ref), Data: data}, nil
 	default: // image and other whole-file media
-		data, rerr := cache.readWholeMedia(ctx, fsys, ref)
+		data, rerr := cache.readWholeMedia(ctx, fsys, ref, w.mediaReadCapBytes())
 		if rerr != nil {
 			return model.MediaInput{}, fatalIfEscape(fmt.Errorf("read media %q: %w", ref, rerr))
 		}
@@ -357,14 +369,17 @@ func (c *mediaBatchCache) cleanup() {
 // filesystem only on the first request for that ref within the batch and serving
 // cached bytes to sibling chunks. A nil cache falls back to an uncached read so
 // the helper is usable without a batch context.
-func (c *mediaBatchCache) readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
+//
+// maxBytes bounds the read (#830). The cap is one value per worker, so it is not
+// part of the cache key: a cached entry was admitted under the same cap.
+func (c *mediaBatchCache) readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string, maxBytes int64) ([]byte, error) {
 	if c == nil {
-		return readWholeMedia(ctx, fsys, ref)
+		return readWholeMedia(ctx, fsys, ref, maxBytes)
 	}
 	if data, ok := c.wholeFile[ref]; ok {
 		return data, nil
 	}
-	data, err := readWholeMedia(ctx, fsys, ref)
+	data, err := readWholeMedia(ctx, fsys, ref, maxBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -437,16 +452,50 @@ func fatalIfEscape(err error) error {
 	return err
 }
 
-// readWholeMedia reads the entire object at ref through the corpus filesystem.
-// Callers within a batch should go through mediaBatchCache.readWholeMedia so the
-// read is shared across sibling chunks of the same MediaRef (issue #279).
-func readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string) ([]byte, error) {
+// mediaReadCapBytes is the resolved per-file cap this worker bounds its media
+// reads with. It hands the caller-supplied MaxFileBytes to the shared resolver,
+// so an unset field selects the default bound and an absurd one is clamped rather
+// than allowed to overflow a limit+1 (#830).
+func (w *EmbeddingWorker) mediaReadCapBytes() int64 {
+	return corpusfs.ResolveReadCapBytes(w.MaxFileBytes)
+}
+
+// readWholeMedia reads the object at ref through the corpus filesystem under a
+// hard byte bound of maxBytes (#830). Callers within a batch should go through
+// mediaBatchCache.readWholeMedia so the read is shared across sibling chunks of
+// the same MediaRef (issue #279).
+//
+// The bound is on the READ, and that is the whole point. Discovery measured the
+// file with a stat (local) or a list entry (S3) many minutes earlier, and chunk
+// rows outlive that measurement: a file that grew after it was chunked is read
+// HERE, into memory, whole, for the embed call. A repeated size check would only
+// produce a second measurement, so it cannot constrain this read; a limit reader
+// can, and it is the only thing that catches a local file that grew.
+//
+// It reads at most maxBytes+1 bytes. The extra byte is the only evidence that
+// separates a file of exactly the cap (inside the operator's policy, embed it)
+// from a file one byte past it (refuse it). Past the cap the prefix is DROPPED
+// and corpusfs.ErrObjectTooLarge is returned, so no caller can embed part of a
+// file as though it were the whole of it.
+//
+// The error is deliberately not ErrFatal. An over-cap file is one document's
+// problem, and ErrFatal stops the worker for the whole corpus. Left non-fatal and
+// non-transient, the batch bisects, this chunk alone is marked failed with a
+// reason that names the cap, and its healthy siblings still embed.
+func readWholeMedia(ctx context.Context, fsys corpusfs.CorpusFS, ref string, maxBytes int64) ([]byte, error) {
 	rc, err := fsys.Open(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = rc.Close() }()
-	return io.ReadAll(rc)
+	data, err := io.ReadAll(io.LimitReader(rc, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w (cap %d bytes)", corpusfs.ErrObjectTooLarge, maxBytes)
+	}
+	return data, nil
 }
 
 // loadPDFPage extracts the chunk's single page (from its `page` span) into a
@@ -468,7 +517,7 @@ func (w *EmbeddingWorker) loadPDFPage(ctx context.Context, t model.ChunkTask, fs
 	if !strings.EqualFold(strings.TrimSpace(t.Metadata.Span.Kind), "page") || t.Metadata.Span.Page < 1 {
 		return nil, fmt.Errorf("%w: pdf media chunk %d has invalid page span", ErrFatal, t.Metadata.ChunkID)
 	}
-	data, err := cache.readWholeMedia(ctx, fsys, ref)
+	data, err := cache.readWholeMedia(ctx, fsys, ref, w.mediaReadCapBytes())
 	if err != nil {
 		return nil, fmt.Errorf("read media %q: %w", ref, err)
 	}

--- a/internal/ingest/errcode_test.go
+++ b/internal/ingest/errcode_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/model"
 )
 
@@ -68,14 +69,34 @@ func TestManifestErrorCode_FileTooLarge(t *testing.T) {
 
 // TestGenerateRawTextFromContent_OversizeTaggedFileTooLarge proves the raw-text
 // size check wraps ErrFileTooLarge, so an oversize document is classified
-// FILE_TOO_LARGE on the run manifest.
+// FILE_TOO_LARGE on the run manifest. The generator here has no cap plumbed in, so
+// the resolved bound is the shared default (#830).
 func TestGenerateRawTextFromContent_OversizeTaggedFileTooLarge(t *testing.T) {
 	rg := &RepresentationGenerator{} // size check runs before any store access
-	content := make([]byte, defaultMaxFileSizeBytes+1)
+	content := make([]byte, corpusfs.DefaultMaxFileSizeBytes()+1)
 	err := rg.GenerateRawTextFromContent(context.Background(), model.Document{RelPath: "big.txt"}, content)
 	if err == nil {
 		t.Fatal("expected an oversize error, got nil")
 	}
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Fatalf("error not tagged ErrFileTooLarge: %v", err)
+	}
+	if got := manifestErrorCode(err); got != manifestErrFileTooLarge {
+		t.Fatalf("manifestErrorCode = %q, want %q", got, manifestErrFileTooLarge)
+	}
+}
+
+// TestGenerateRawTextFromContent_ConfiguredCapTaggedFileTooLarge proves the same
+// classification holds for the CONFIGURED cap (#830), not only for the default: a
+// generator with `ingest.max_file_mb` plumbed in refuses content past that value
+// with ErrFileTooLarge, so the run manifest still reports §14.4 FILE_TOO_LARGE. The
+// cap is set FAR below the default here, so a pass cannot be explained by the
+// default bound.
+func TestGenerateRawTextFromContent_ConfiguredCapTaggedFileTooLarge(t *testing.T) {
+	const configured int64 = 4096
+	rg := &RepresentationGenerator{} // the size check runs before any store access
+	rg.SetMaxFileBytes(configured)
+	err := rg.GenerateRawTextFromContent(context.Background(), model.Document{RelPath: "big.txt"}, make([]byte, configured+1))
 	if !errors.Is(err, ErrFileTooLarge) {
 		t.Fatalf("error not tagged ErrFileTooLarge: %v", err)
 	}

--- a/internal/ingest/gitignore.go
+++ b/internal/ingest/gitignore.go
@@ -10,11 +10,6 @@ import (
 	"github.com/dirstral/dir2mcp/internal/corpusfs"
 )
 
-// defaultMaxFileSizeBytes mirrors corpusfs.DefaultMaxFileSizeBytes() as a
-// package constant for representation generators that compare against it
-// directly.
-const defaultMaxFileSizeBytes int64 = 10 * 1024 * 1024
-
 // shouldSkipDirectory reports whether the incremental file watch skips a
 // directory. The set comes from the same DiscoverOptions the initial scan uses
 // (DiscoverOptionsFromConfig), so the watcher applies the operator's

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -13,6 +14,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
 	"github.com/dirstral/dir2mcp/internal/ingest/docling"
 	"github.com/dirstral/dir2mcp/internal/langdetect"
 	"github.com/dirstral/dir2mcp/internal/model"
@@ -105,6 +107,30 @@ type RepresentationGenerator struct {
 	// means the feature is off — the Service binds it only when contextual
 	// retrieval is effectively enabled.
 	contextualizer ChunkContextualizer
+	// maxFileBytes is the resolved `ingest.max_file_mb` cap in bytes, set by the
+	// Service from the single resolver (ResolvedMaxFileBytes). Zero means "not set"
+	// and selects the shared 10 MiB default bound.
+	//
+	// Before #830 the raw-text gate compared against a HARD-CODED 10 MiB instead,
+	// so the operator's setting was not the one enforced: with the 20 MiB default a
+	// 15 MiB text file passed discovery and then failed here, and the error did not
+	// name the reason. The configured value is authoritative now.
+	maxFileBytes int64
+}
+
+// SetMaxFileBytes plumbs the resolved `ingest.max_file_mb` cap (in bytes) into the
+// raw-text size gate and the raw-text read (#830). Callers pass
+// ResolvedMaxFileBytes(cfg) so this gate cannot enforce a different number from
+// discovery and the source reads.
+func (rg *RepresentationGenerator) SetMaxFileBytes(maxBytes int64) {
+	rg.maxFileBytes = maxBytes
+}
+
+// rawTextCapBytes is the resolved cap the raw-text paths enforce. The shared
+// resolver turns an unset value into the default bound and clamps an absurd one,
+// so `cap+1` never overflows into a negative limit.
+func (rg *RepresentationGenerator) rawTextCapBytes() int64 {
+	return corpusfs.ResolveReadCapBytes(rg.maxFileBytes)
 }
 
 // SetLanguageDetection enables or disables best-effort raw_text language
@@ -182,23 +208,40 @@ func NewRepresentationGenerator(store model.RepresentationStore) *Representation
 // - For code/text/md/data/html doc types
 // - Normalize to UTF-8 with \n line endings
 // - Route code → index_kind=code, others → index_kind=text
+//
+// The read is bounded at cap+1 bytes (#830). It used to be a stat followed by an
+// unbounded os.ReadFile, and the stat could not constrain the read: a file that
+// grew between the two was pulled into memory whole, at whatever size it had
+// reached. The stat is gone because it measured nothing the bounded read does not
+// decide for itself.
 func (rg *RepresentationGenerator) GenerateRawText(ctx context.Context, doc model.Document, absPath string) error {
-	info, err := os.Stat(absPath)
+	capBytes := rg.rawTextCapBytes()
+	f, err := os.Open(absPath)
 	if err != nil {
-		return fmt.Errorf("stat file %s: %w", doc.RelPath, err)
+		return fmt.Errorf("open file %s: %w", doc.RelPath, err)
 	}
-	if info.Size() > defaultMaxFileSizeBytes {
-		return fmt.Errorf("%w: file %s too large (%d bytes); limit %d", ErrFileTooLarge, doc.RelPath, info.Size(), defaultMaxFileSizeBytes)
-	}
-
-	// Read file content first so we can delegate to the new helper which
-	// accepts pre-loaded bytes.  This keeps the original behaviour intact
-	// while allowing callers that already have the content to avoid the I/O.
-	content, err := os.ReadFile(absPath)
+	defer func() { _ = f.Close() }()
+	// cap+1: the extra byte separates a file of exactly the cap (admitted) from one
+	// byte past it (refused). The prefix is dropped rather than indexed, so half a
+	// document is never stored as though it were the whole one.
+	content, err := io.ReadAll(io.LimitReader(f, capBytes+1))
 	if err != nil {
 		return fmt.Errorf("read file %s: %w", doc.RelPath, err)
 	}
+	if int64(len(content)) > capBytes {
+		return rg.rawTextOverCapError(doc.RelPath, capBytes)
+	}
 	return rg.GenerateRawTextFromContent(ctx, doc, content)
+}
+
+// rawTextOverCapError renders the over-cap verdict for the raw-text paths. It
+// wraps ErrFileTooLarge so §14.4 classification keeps reporting FILE_TOO_LARGE,
+// and it names the setting the operator has to change. It does NOT report the
+// file's size: the read stopped at cap+1 by design, so the size is unknown here,
+// and reading to the end just to measure it would spend the resources the bound
+// exists to save.
+func (rg *RepresentationGenerator) rawTextOverCapError(relPath string, capBytes int64) error {
+	return fmt.Errorf("%w: file %s passed the ingest.max_file_mb cap (%d bytes)", ErrFileTooLarge, relPath, capBytes)
 }
 
 // GenerateRawTextFromContent behaves like GenerateRawText but takes the
@@ -208,10 +251,13 @@ func (rg *RepresentationGenerator) GenerateRawText(ctx context.Context, doc mode
 // simply read the file to supply the content.  Removing the parameter
 // simplifies the API and avoids unused variable warnings.
 func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Context, doc model.Document, content []byte) error {
-	// Guard against huge files to avoid OOM.  We mirror the same limit used by
-	// discovery since raw-text ingestion should follow the same policy.
-	if int64(len(content)) > defaultMaxFileSizeBytes {
-		return fmt.Errorf("%w: file %s too large (%d bytes); limit %d", ErrFileTooLarge, doc.RelPath, len(content), defaultMaxFileSizeBytes)
+	// Guard against huge files to avoid OOM, against the cap the operator
+	// CONFIGURED (#830). This gate used to compare against a hard-coded 10 MiB, so
+	// with the 20 MiB default a 15 MiB text file was admitted by discovery and then
+	// refused here: the operator's `ingest.max_file_mb` was not the number enforced.
+	// The configured value wins, so a file between 10 MiB and the cap is indexed.
+	if capBytes := rg.rawTextCapBytes(); int64(len(content)) > capBytes {
+		return rg.rawTextOverCapError(doc.RelPath, capBytes)
 	}
 
 	// Validate and normalize UTF-8

--- a/internal/ingest/represent.go
+++ b/internal/ingest/represent.go
@@ -109,12 +109,18 @@ type RepresentationGenerator struct {
 	contextualizer ChunkContextualizer
 	// maxFileBytes is the resolved `ingest.max_file_mb` cap in bytes, set by the
 	// Service from the single resolver (ResolvedMaxFileBytes). Zero means "not set"
-	// and selects the shared 10 MiB default bound.
+	// and falls back to corpusfs.ResolveReadCapBytes's own bound, which is what a
+	// caller that never plumbed the value gets.
 	//
-	// Before #830 the raw-text gate compared against a HARD-CODED 10 MiB instead,
-	// so the operator's setting was not the one enforced: with the 20 MiB default a
-	// 15 MiB text file passed discovery and then failed here, and the error did not
-	// name the reason. The configured value is authoritative now.
+	// Two different numbers meet here, so both are named. The CONFIGURED default of
+	// `ingest.max_file_mb` is 20 MiB (config.Default). The FALLBACK bound, for a
+	// generator with nothing plumbed in, is corpusfs.DefaultMaxFileSizeBytes.
+	//
+	// Before #830 this gate compared against a HARD-CODED copy of that fallback
+	// instead of the configured value, so the operator's setting was not the one
+	// enforced: on a default install a 15 MiB text file passed discovery and then
+	// failed here, and the error did not name the reason. The configured value is
+	// authoritative now.
 	maxFileBytes int64
 }
 
@@ -253,9 +259,10 @@ func (rg *RepresentationGenerator) rawTextOverCapError(relPath string, capBytes 
 func (rg *RepresentationGenerator) GenerateRawTextFromContent(ctx context.Context, doc model.Document, content []byte) error {
 	// Guard against huge files to avoid OOM, against the cap the operator
 	// CONFIGURED (#830). This gate used to compare against a hard-coded 10 MiB, so
-	// with the 20 MiB default a 15 MiB text file was admitted by discovery and then
-	// refused here: the operator's `ingest.max_file_mb` was not the number enforced.
-	// The configured value wins, so a file between 10 MiB and the cap is indexed.
+	// with `ingest.max_file_mb` at its 20 MiB default a 15 MiB text file was admitted
+	// by discovery and then refused here: the operator's setting was not the number
+	// enforced. The configured value wins, so a file between the old hard-coded gate
+	// and the configured cap is indexed.
 	if capBytes := rg.rawTextCapBytes(); int64(len(content)) > capBytes {
 		return rg.rawTextOverCapError(doc.RelPath, capBytes)
 	}

--- a/internal/ingest/service.go
+++ b/internal/ingest/service.go
@@ -853,6 +853,9 @@ func NewService(cfg config.Config, store model.Store) (*Service, error) {
 		svc.repGen = NewRepresentationGenerator(rs)
 		// Best-effort raw_text language auto-detection (SPEC §8.8), on by default.
 		svc.repGen.SetLanguageDetection(cfg.LanguageDetectionEnabled)
+		// The raw-text gate and read enforce the CONFIGURED cap, from the one
+		// resolver, not a hard-coded 10 MiB (#830).
+		svc.repGen.SetMaxFileBytes(ResolvedMaxFileBytes(cfg))
 	} else {
 		// #398/#364: the shipped store always satisfies model.RepresentationStore
 		// (enforced by a compile-time guard in the cli package). If a

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2582,6 +2582,12 @@ func mapSearchError(err error) *toolExecutionError {
 // mapOpenFileError converts an open-file error into a toolExecutionError.
 func mapOpenFileError(err error) *toolExecutionError {
 	switch {
+	case errors.Is(err, corpusfs.ErrObjectTooLarge):
+		// #830: retrieval bounded its source-byte hash read, so a source past the cap
+		// stops there. The default branch would report INTERNAL_ERROR as retryable,
+		// and a retry cannot help: the file is over the operator's cap until the file
+		// or the cap changes.
+		return &toolExecutionError{Code: "FILE_TOO_LARGE", Message: "file exceeds the configured ingest.max_file_mb cap", Retryable: false}
 	case errors.Is(err, model.ErrForbidden):
 		return &toolExecutionError{Code: protocol.ErrorCodeForbidden, Message: "forbidden", Retryable: false}
 	case errors.Is(err, model.ErrPathOutsideRoot):
@@ -2900,6 +2906,11 @@ func mapFileAccessError(err error) *toolExecutionError {
 
 func mapReadDocumentError(err error) *toolExecutionError {
 	switch {
+	case errors.Is(err, corpusfs.ErrObjectTooLarge):
+		// #830: the bytes read passed the configured cap, so the read was refused.
+		// The default branch would report "permission denied", which names the wrong
+		// cause and sends the operator to the wrong setting.
+		return &toolExecutionError{Code: "FILE_TOO_LARGE", Message: "file exceeds the configured ingest.max_file_mb cap", Retryable: false}
 	case errors.Is(err, os.ErrNotExist):
 		return &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
 	case errors.Is(err, model.ErrForbidden):
@@ -2987,6 +2998,9 @@ func (s *Server) ensureTranscriptForAudioDoc(ctx context.Context, doc model.Docu
 // limit).
 func annotationReadError(err error) *toolExecutionError {
 	switch {
+	case errors.Is(err, corpusfs.ErrObjectTooLarge):
+		// #830, as in mapReadDocumentError: name the cap, not "permission denied".
+		return &toolExecutionError{Code: "FILE_TOO_LARGE", Message: "file exceeds the configured ingest.max_file_mb cap", Retryable: false}
 	case errors.Is(err, os.ErrNotExist):
 		return &toolExecutionError{Code: protocol.ErrorCodeFileNotFound, Message: "file not found", Retryable: false}
 	case errors.Is(err, model.ErrForbidden):
@@ -3104,13 +3118,35 @@ func (s *Server) refuseIfSecretContent(text string) *toolExecutionError {
 	return nil
 }
 
+// readDocumentContent reads a document's bytes for the on-demand tool paths
+// (annotate, transcribe) under a hard byte bound (#830).
+//
+// The bound matters for a LOCAL corpus. A remote object is already bounded by
+// Localize (#682), but for a local corpus Localize copies nothing and hands back
+// the in-root path, so the read here IS the boundary. The read used to be an
+// unbounded os.ReadFile, so a file that grew after discovery measured it was
+// pulled whole into the server process: an operator-visible OOM, on a request an
+// unprivileged client can send.
+//
+// Past the cap the prefix is dropped and corpusfs.ErrObjectTooLarge is returned,
+// which the tool error mappers report as §14.4 FILE_TOO_LARGE. Truncating instead
+// would hand the annotator or the transcriber part of a file as though it were the
+// whole of it.
 func (s *Server) readDocumentContent(ctx context.Context, relPath string) ([]byte, error) {
 	targetReal, cleanup, err := s.localizeDocument(ctx, relPath)
 	defer cleanup()
 	if err != nil {
 		return nil, err
 	}
-	return os.ReadFile(targetReal)
+	maxBytes := s.ingestMaxFileBytes()
+	content, tooLarge, err := readBoundedFile(targetReal, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if tooLarge {
+		return nil, fmt.Errorf("%w: %s (cap %d bytes)", corpusfs.ErrObjectTooLarge, relPath, maxBytes)
+	}
+	return content, nil
 }
 
 // noopCleanup is the cleanup returned whenever nothing was materialized, so the

--- a/internal/retrieval/service.go
+++ b/internal/retrieval/service.go
@@ -205,7 +205,11 @@ type Service struct {
 	// local filesystem. It is injected only for object-store backends (S3) so a
 	// remote corpus returns content instead of failing on a missing local path
 	// (#432); nil preserves the historical local-filesystem read path exactly.
-	corpusFS        corpusfs.CorpusFS
+	corpusFS corpusfs.CorpusFS
+	// maxFileBytes is the resolved `ingest.max_file_mb` cap in bytes, plumbed in by
+	// SetMaxFileBytes from the single resolver (#830). It bounds the source-byte
+	// hash read. Zero means "not set" and selects the shared default bound.
+	maxFileBytes    int64
 	protocolVersion string
 	pathExcludes    []string
 	// cached compiled regexps for exclude patterns; keys are normalized patterns
@@ -966,6 +970,30 @@ func (s *Service) SetCorpusFS(fsys corpusfs.CorpusFS) {
 	s.metaMu.Lock()
 	s.corpusFS = fsys
 	s.metaMu.Unlock()
+}
+
+// SetMaxFileBytes plumbs the resolved `ingest.max_file_mb` cap (in bytes) into
+// the retrieval-time source reads (#830). Callers pass
+// ingest.ResolvedMaxFileBytes(cfg), the single resolver for that setting, so
+// retrieval enforces the same number discovery, the ingest source reads, the
+// object-store backend, and the MCP tool paths do.
+//
+// Zero or negative keeps the shared default (corpusfs.ResolveReadCapBytes), so a
+// caller that does not set it still reads under a bound.
+func (s *Service) SetMaxFileBytes(maxBytes int64) {
+	s.metaMu.Lock()
+	s.maxFileBytes = maxBytes
+	s.metaMu.Unlock()
+}
+
+// sourceReadCapBytes is the resolved per-file cap the retrieval source reads are
+// bounded by. The shared resolver turns an unset value into the default bound and
+// clamps an absurd one, so `cap+1` never overflows into a negative limit.
+func (s *Service) sourceReadCapBytes() int64 {
+	s.metaMu.RLock()
+	configured := s.maxFileBytes
+	s.metaMu.RUnlock()
+	return corpusfs.ResolveReadCapBytes(configured)
 }
 
 func (s *Service) SetStateDir(stateDir string) {
@@ -2262,6 +2290,22 @@ func (s *Service) openSource(ctx context.Context, corpusFS corpusfs.CorpusFS, re
 // directory target with the same DOC_TYPE_UNSUPPORTED mapping the raw-text path
 // uses. It is the fallback for ocrCacheKeyForOpen: a store that can report the
 // already-known base hash (ocrSourceHashProvider) skips this full object GET.
+//
+// The read is bounded at cap+1 bytes (#830), and the REASON differs from the other
+// bounded reads in the repository. This one streams into a hasher, so it holds
+// constant memory and cannot OOM the daemon. What it consumed without a bound was
+// BANDWIDTH and time: one open_file call on a remote corpus pulled a whole object
+// of any size, so a single client request could download tens of gigabytes (metered
+// egress, and the request occupied a server slot for as long as it took). The
+// severity is lower than the memory cases; the class is the same, because a size
+// check is still only a measurement and the object is still free to serve more than
+// it reported.
+//
+// Refusing past the cap loses nothing real. A file over the cap was refused by
+// discovery, so ingest never wrote a derivation cache entry for it, so the key this
+// hash would have produced cannot hit. The old behavior paid for the whole download
+// and then answered OCR_NOT_READY; this one stops at cap+1 and answers with the
+// cause (§14.4 FILE_TOO_LARGE, via corpusfs.ErrObjectTooLarge).
 func (s *Service) hashSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusFS, resolvedAbs, relPath string) (string, error) {
 	var reader io.Reader
 	if corpusFS != nil {
@@ -2291,9 +2335,18 @@ func (s *Service) hashSourceBytes(ctx context.Context, corpusFS corpusfs.CorpusF
 		reader = sourceFile
 	}
 
+	capBytes := s.sourceReadCapBytes()
 	hasher := sha256.New()
-	if _, err := io.Copy(hasher, reader); err != nil {
+	// cap+1: the extra byte is the only evidence that separates a file of exactly
+	// the cap (inside the operator's policy, hash it) from one byte past it. A
+	// partial hash is never returned, because a hash of a prefix is a claim about
+	// bytes that are not the file.
+	read, err := io.Copy(hasher, io.LimitReader(reader, capBytes+1))
+	if err != nil {
 		return "", err
+	}
+	if read > capBytes {
+		return "", fmt.Errorf("%w: %s (cap %d bytes)", corpusfs.ErrObjectTooLarge, relPath, capBytes)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/tests/index/media_read_bound_830_test.go
+++ b/tests/index/media_read_bound_830_test.go
@@ -1,0 +1,241 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/index"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// These tests cover site 1 of #830: the embedding worker's whole-file media read
+// (image and PDF bytes) held no byte bound, so the bytes of a file that grew after
+// it was chunked were pulled into the daemon's memory whole, at whatever size the
+// file had reached.
+//
+// Every case asserts on TWO things: the outcome (embedded, or marked failed with a
+// reason that names the cap), and the number of bytes the source was actually asked
+// for. A repeated size check could produce the first without the second, and the
+// second is the defect.
+
+// generatedReader serves total bytes without ever reporting a size, and counts the
+// bytes it actually delivered. It is the shape a size check cannot constrain: the
+// caller learns how big the source is only by reading it.
+//
+// The bytes are generated, never allocated: on the unbounded code the read consumes
+// everything the reader offers, so a fixture held in a []byte would have to be
+// materialized in full before the test could prove anything about it.
+type generatedReader struct {
+	total     int64
+	pos       int64
+	delivered *int64
+	mu        *sync.Mutex
+}
+
+func (r *generatedReader) Read(p []byte) (int, error) {
+	if r.pos >= r.total {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if remaining := r.total - r.pos; remaining < n {
+		n = remaining
+	}
+	for i := int64(0); i < n; i++ {
+		p[i] = 'x'
+	}
+	r.pos += n
+	r.mu.Lock()
+	*r.delivered += n
+	r.mu.Unlock()
+	return int(n), nil
+}
+
+func (r *generatedReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.pos = offset
+	case io.SeekCurrent:
+		r.pos += offset
+	case io.SeekEnd:
+		r.pos = r.total + offset
+	}
+	return r.pos, nil
+}
+
+func (r *generatedReader) Close() error { return nil }
+
+// generatingCorpusFS serves each ref as a generatedReader of the configured size
+// and records the total bytes every read pulled.
+type generatingCorpusFS struct {
+	sizes     map[string]int64
+	mu        sync.Mutex
+	delivered int64
+}
+
+func (f *generatingCorpusFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	size, ok := f.sizes[relPath]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return &generatedReader{total: size, delivered: &f.delivered, mu: &f.mu}, nil
+}
+
+func (f *generatingCorpusFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("generatingCorpusFS: Walk not implemented")
+}
+
+func (f *generatingCorpusFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("generatingCorpusFS: Localize not implemented")
+}
+
+func (f *generatingCorpusFS) bytesDelivered() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.delivered
+}
+
+const mediaReadTestCap int64 = 64 * 1024
+
+// TestMediaRead_BoundsTheReadOnAnUnsizedSource is the core case: a source that
+// reports no size and serves 16x the cap is read to at most cap+1 bytes, and the
+// chunk is marked failed with a reason that names the cap.
+//
+// The bound cannot be replaced by a check. This reader never states a size, so
+// "the file is small enough" is not a claim anyone can verify before the read; only
+// the limit on the read itself holds.
+func TestMediaRead_BoundsTheReadOnAnUnsizedSource(t *testing.T) {
+	fsys := &generatingCorpusFS{sizes: map[string]int64{"big.png": mediaReadTestCap * 16}}
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(1, "big.png", "image")}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		MaxFileBytes: mediaReadTestCap,
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err == nil {
+		t.Fatal("an over-cap media read must not report success")
+	}
+	if errors.Is(err, index.ErrFatal) {
+		t.Fatalf("one over-cap file must not stop the worker for the whole corpus: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("indexed = %d, want 0", n)
+	}
+	if got := fsys.bytesDelivered(); got != mediaReadTestCap+1 {
+		t.Fatalf("the source delivered %d bytes, want exactly %d (cap+1): the read is bounded neither short nor long", got, mediaReadTestCap+1)
+	}
+	if len(source.failedLabels) != 1 || source.failedLabels[0] != 1 {
+		t.Fatalf("failed labels = %#v, want [1]", source.failedLabels)
+	}
+	if !strings.Contains(source.failedReason, "max file size") {
+		t.Fatalf("failure reason %q does not name the size cap", source.failedReason)
+	}
+}
+
+// TestMediaRead_FileAtTheCapIsStillEmbedded is the off-by-one guard, and it is why
+// the read asks for cap+1 rather than cap: a file of exactly
+// `ingest.max_file_mb` is inside the operator's policy and must embed cleanly.
+func TestMediaRead_FileAtTheCapIsStillEmbedded(t *testing.T) {
+	fsys := &generatingCorpusFS{sizes: map[string]int64{"exact.png": mediaReadTestCap}}
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(1, "exact.png", "image")}}
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: emb,
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		MaxFileBytes: mediaReadTestCap,
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("a file of exactly the cap must embed, got err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1", n)
+	}
+	if len(emb.gotMedia) != 1 || int64(len(emb.gotMedia[0].Data)) != mediaReadTestCap {
+		t.Fatalf("embedder received %d item(s) with %d bytes, want 1 with %d", len(emb.gotMedia), len(emb.gotMedia[0].Data), mediaReadTestCap)
+	}
+	if got := fsys.bytesDelivered(); got != mediaReadTestCap {
+		t.Fatalf("the source delivered %d bytes, want %d", got, mediaReadTestCap)
+	}
+}
+
+// TestMediaRead_LocalFileThatGrewAfterChunkingIsRefused is the production shape of
+// the defect, on the real LocalFS: the chunk row was written when the file was
+// small, the file is large by the time the embed loop reaches it, and nothing
+// between the two re-measures it. The read is the only place the growth can be
+// caught.
+//
+// It also pins the blast radius: a healthy sibling chunk in the same batch still
+// embeds, so one over-cap file costs one chunk, not the batch and not the worker.
+func TestMediaRead_LocalFileThatGrewAfterChunkingIsRefused(t *testing.T) {
+	root := t.TempDir()
+	// Chunked while small (the row that survives), then grown past the cap.
+	small := filepath.Join(root, "small.png")
+	if err := os.WriteFile(small, []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	grown := filepath.Join(root, "grown.png")
+	if err := os.WriteFile(grown, make([]byte, mediaReadTestCap*4), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	source := &fakeChunkSource{tasks: []model.ChunkTask{
+		mediaTask(1, "grown.png", "image"),
+		mediaTask(2, "small.png", "image"),
+	}}
+	emb := &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: emb,
+		RootDir: root, BatchSize: 4, ModelForText: "gemini-embedding-2",
+		MaxFileBytes: mediaReadTestCap,
+	}
+
+	n, err := worker.RunOnce(context.Background(), "text")
+	if err != nil {
+		t.Fatalf("the healthy sibling must still embed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("indexed = %d, want 1 (the small file only)", n)
+	}
+	if len(source.failedLabels) != 1 || source.failedLabels[0] != 1 {
+		t.Fatalf("failed labels = %#v, want [1] (the grown file only)", source.failedLabels)
+	}
+	if !strings.Contains(source.failedReason, "max file size") {
+		t.Fatalf("failure reason %q does not name the size cap", source.failedReason)
+	}
+	// The grown file's bytes must never reach the embedder.
+	for _, item := range emb.gotMedia {
+		if int64(len(item.Data)) > mediaReadTestCap {
+			t.Fatalf("the embedder received %d bytes, past the %d-byte cap", len(item.Data), mediaReadTestCap)
+		}
+	}
+}
+
+// TestMediaRead_UnsetCapStillBoundsTheRead pins the fail-closed default: a worker
+// built without MaxFileBytes reads under the shared default bound, not without one.
+func TestMediaRead_UnsetCapStillBoundsTheRead(t *testing.T) {
+	defaultCap := corpusfs.DefaultMaxFileSizeBytes()
+	fsys := &generatingCorpusFS{sizes: map[string]int64{"huge.png": defaultCap * 2}}
+	source := &fakeChunkSource{tasks: []model.ChunkTask{mediaTask(1, "huge.png", "image")}}
+	worker := &index.EmbeddingWorker{
+		Source: source, Index: index.NewHNSWIndex(""), Embedder: &fakeMultimodalEmbedder{mediaVecs: [][]float32{{1, 0}}},
+		Corpus: fsys, RootDir: t.TempDir(), BatchSize: 4, ModelForText: "gemini-embedding-2",
+		// MaxFileBytes deliberately unset.
+	}
+
+	if _, err := worker.RunOnce(context.Background(), "text"); err == nil {
+		t.Fatal("an unset cap must not mean an unbounded read")
+	}
+	if got := fsys.bytesDelivered(); got != defaultCap+1 {
+		t.Fatalf("the source delivered %d bytes, want %d (default cap+1)", got, defaultCap+1)
+	}
+}

--- a/tests/ingest/raw_text_cap_830_test.go
+++ b/tests/ingest/raw_text_cap_830_test.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/dirstral/dir2mcp/internal/ingest"
@@ -104,76 +102,6 @@ func TestGenerateRawText_OneBytePastTheConfiguredCapIsRefused(t *testing.T) {
 	}
 	if len(st.chunks) != 0 || len(st.reps) != 0 {
 		t.Fatalf("refused file persisted %d chunk(s) and %d representation(s), want 0 and 0", len(st.chunks), len(st.reps))
-	}
-}
-
-// TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure is the case a size
-// check cannot catch, which is the whole argument of #682 and #830.
-//
-// The source is a FIFO. os.Stat reports size 0 for it, and the bytes then arrive
-// from a later, separate operation that serves as many as the writer sends: the
-// stat's number and the read's number are unrelated by construction, exactly as
-// they are for a file that grows after discovery or for an object that serves more
-// than it listed.
-//
-// Before the fix this path stat'ed (0, comfortably under any cap), then called an
-// unbounded os.ReadFile and swallowed everything the writer produced, and the
-// 10 MiB gate afterwards passed too because the payload is smaller than that. With
-// the read bounded the pipe delivers at most cap+1 bytes and the document is
-// refused.
-func TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("mkfifo is not available on windows")
-	}
-	fifo := filepath.Join(t.TempDir(), "grows.txt")
-	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
-		t.Skipf("mkfifo unsupported here: %v", err)
-	}
-
-	// The payload is 4x the cap and, deliberately, still under the old hard-coded
-	// 10 MiB gate: only a bound on the READ refuses it.
-	payload := rawTextTestCap * 4
-	writeDone := make(chan int64, 1)
-	go func() {
-		// Opening a FIFO for write blocks until a reader opens it, so this is the
-		// read the generator performs.
-		w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
-		if err != nil {
-			writeDone <- 0
-			return
-		}
-		defer func() { _ = w.Close() }()
-		block := []byte(strings.Repeat("b", 64*1024))
-		var sent int64
-		for sent < payload {
-			n, werr := w.Write(block)
-			sent += int64(n)
-			if werr != nil {
-				// EPIPE once the bounded reader stops and closes: that is the bound
-				// working, not a test failure.
-				break
-			}
-		}
-		writeDone <- sent
-	}()
-
-	st := &fakeRepStore{failAfter: -1}
-	rg := newCappedRepGen(t, st, rawTextTestCap)
-	doc := model.Document{DocID: 1, RelPath: "grows.txt", DocType: "text"}
-	err := rg.GenerateRawText(context.Background(), doc, fifo)
-	if err == nil {
-		t.Fatal("a source that served past the cap must be refused; the read was not bounded")
-	}
-	if !errors.Is(err, ingest.ErrFileTooLarge) {
-		t.Fatalf("error is not tagged ingest.ErrFileTooLarge: %v", err)
-	}
-	if len(st.chunks) != 0 {
-		t.Fatalf("%d chunk(s) were persisted from a refused read, want 0", len(st.chunks))
-	}
-	// The reader must have stopped near the bound instead of draining the source.
-	sent := <-writeDone
-	if sent > rawTextTestCap*2 {
-		t.Fatalf("the source delivered %d bytes against a cap of %d; the read is not bounded", sent, rawTextTestCap)
 	}
 }
 

--- a/tests/ingest/raw_text_cap_830_test.go
+++ b/tests/ingest/raw_text_cap_830_test.go
@@ -145,7 +145,7 @@ func TestGenerateRawTextFromContent_PastTheConfiguredCapIsRefused(t *testing.T) 
 	if !errors.Is(err, ingest.ErrFileTooLarge) {
 		t.Fatalf("content past the configured cap must be refused with ErrFileTooLarge, got: %v", err)
 	}
-	if len(st.chunks) != 0 {
-		t.Fatalf("%d chunk(s) were persisted past the cap, want 0", len(st.chunks))
+	if len(st.chunks) != 0 || len(st.reps) != 0 {
+		t.Fatalf("content past the cap persisted %d chunk(s) and %d representation(s), want 0 and 0", len(st.chunks), len(st.reps))
 	}
 }

--- a/tests/ingest/raw_text_cap_830_test.go
+++ b/tests/ingest/raw_text_cap_830_test.go
@@ -1,0 +1,223 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// These tests cover item 4 of #830: raw-text generation gated on a HARD-CODED
+// 10 MiB instead of the configured `ingest.max_file_mb`, and read the file with an
+// unbounded os.ReadFile after a stat that constrains nothing.
+//
+// Two separate defects, so two separate groups of cases below:
+//
+//  1. the CAP: the operator's configured value is the one enforced now, so a file
+//     between 10 MiB and the configured cap is INDEXED rather than refused;
+//  2. the READ: it stops at cap+1 bytes, so a source whose size a stat cannot
+//     measure is still bounded.
+
+const rawTextTestCap int64 = 1 << 20 // 1 MiB, small enough to keep these tests fast
+
+// newCappedRepGen returns a generator whose raw-text cap is capBytes, plumbed the
+// way ingest.NewService plumbs it from ResolvedMaxFileBytes.
+func newCappedRepGen(t *testing.T, st model.RepresentationStore, capBytes int64) *ingest.RepresentationGenerator {
+	t.Helper()
+	rg := ingest.NewRepresentationGenerator(st)
+	rg.SetMaxFileBytes(capBytes)
+	return rg
+}
+
+// writeSizedTextFile writes a file of exactly size bytes of printable text (so it
+// is not detected as binary) and returns its path.
+func writeSizedTextFile(t *testing.T, size int64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sized.txt")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Fatalf("close %s: %v", path, cerr)
+		}
+	}()
+	line := []byte(strings.Repeat("a", 1023) + "\n")
+	for written := int64(0); written < size; {
+		chunk := line
+		if remaining := size - written; remaining < int64(len(chunk)) {
+			chunk = chunk[:remaining]
+		}
+		n, werr := f.Write(chunk)
+		if werr != nil {
+			t.Fatalf("write %s: %v", path, werr)
+		}
+		written += int64(n)
+	}
+	return path
+}
+
+// TestGenerateRawText_AtTheConfiguredCapIsAdmitted is the off-by-one guard: a file
+// of exactly `ingest.max_file_mb` is inside the operator's policy, so it must read
+// cleanly and produce chunks. A bound that refused AT the cap would fail here.
+func TestGenerateRawText_AtTheConfiguredCapIsAdmitted(t *testing.T) {
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, rawTextTestCap)
+	path := writeSizedTextFile(t, rawTextTestCap)
+
+	doc := model.Document{DocID: 1, RelPath: "at-cap.txt", DocType: "text"}
+	if err := rg.GenerateRawText(context.Background(), doc, path); err != nil {
+		t.Fatalf("a file of exactly the cap must be indexed, got err: %v", err)
+	}
+	if len(st.chunks) == 0 {
+		t.Fatal("no chunks were inserted for a file at the cap")
+	}
+}
+
+// TestGenerateRawText_OneBytePastTheConfiguredCapIsRefused is the other half of the
+// off-by-one: cap+1 is outside the policy and must be refused, tagged with the
+// existing ErrFileTooLarge sentinel (§14.4 FILE_TOO_LARGE), and must persist
+// nothing.
+func TestGenerateRawText_OneBytePastTheConfiguredCapIsRefused(t *testing.T) {
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, rawTextTestCap)
+	path := writeSizedTextFile(t, rawTextTestCap+1)
+
+	doc := model.Document{DocID: 1, RelPath: "past-cap.txt", DocType: "text"}
+	err := rg.GenerateRawText(context.Background(), doc, path)
+	if err == nil {
+		t.Fatal("a file one byte past the cap must be refused")
+	}
+	if !errors.Is(err, ingest.ErrFileTooLarge) {
+		t.Fatalf("error is not tagged ingest.ErrFileTooLarge: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ingest.max_file_mb") {
+		t.Fatalf("error must name the setting the operator has to change, got: %v", err)
+	}
+	if len(st.chunks) != 0 || len(st.reps) != 0 {
+		t.Fatalf("refused file persisted %d chunk(s) and %d representation(s), want 0 and 0", len(st.chunks), len(st.reps))
+	}
+}
+
+// TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure is the case a size
+// check cannot catch, which is the whole argument of #682 and #830.
+//
+// The source is a FIFO. os.Stat reports size 0 for it, and the bytes then arrive
+// from a later, separate operation that serves as many as the writer sends: the
+// stat's number and the read's number are unrelated by construction, exactly as
+// they are for a file that grows after discovery or for an object that serves more
+// than it listed.
+//
+// Before the fix this path stat'ed (0, comfortably under any cap), then called an
+// unbounded os.ReadFile and swallowed everything the writer produced, and the
+// 10 MiB gate afterwards passed too because the payload is smaller than that. With
+// the read bounded the pipe delivers at most cap+1 bytes and the document is
+// refused.
+func TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mkfifo is not available on windows")
+	}
+	fifo := filepath.Join(t.TempDir(), "grows.txt")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	// The payload is 4x the cap and, deliberately, still under the old hard-coded
+	// 10 MiB gate: only a bound on the READ refuses it.
+	payload := rawTextTestCap * 4
+	writeDone := make(chan int64, 1)
+	go func() {
+		// Opening a FIFO for write blocks until a reader opens it, so this is the
+		// read the generator performs.
+		w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+		if err != nil {
+			writeDone <- 0
+			return
+		}
+		defer func() { _ = w.Close() }()
+		block := []byte(strings.Repeat("b", 64*1024))
+		var sent int64
+		for sent < payload {
+			n, werr := w.Write(block)
+			sent += int64(n)
+			if werr != nil {
+				// EPIPE once the bounded reader stops and closes: that is the bound
+				// working, not a test failure.
+				break
+			}
+		}
+		writeDone <- sent
+	}()
+
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, rawTextTestCap)
+	doc := model.Document{DocID: 1, RelPath: "grows.txt", DocType: "text"}
+	err := rg.GenerateRawText(context.Background(), doc, fifo)
+	if err == nil {
+		t.Fatal("a source that served past the cap must be refused; the read was not bounded")
+	}
+	if !errors.Is(err, ingest.ErrFileTooLarge) {
+		t.Fatalf("error is not tagged ingest.ErrFileTooLarge: %v", err)
+	}
+	if len(st.chunks) != 0 {
+		t.Fatalf("%d chunk(s) were persisted from a refused read, want 0", len(st.chunks))
+	}
+	// The reader must have stopped near the bound instead of draining the source.
+	sent := <-writeDone
+	if sent > rawTextTestCap*2 {
+		t.Fatalf("the source delivered %d bytes against a cap of %d; the read is not bounded", sent, rawTextTestCap)
+	}
+}
+
+// TestGenerateRawTextFromContent_BetweenTheTwoCapsIsIndexed is item 4's behavior
+// decision, stated as a test: with `ingest.max_file_mb` raised above 10 MiB, a file
+// larger than the old hard-coded gate but inside the configured cap is INDEXED.
+//
+// Before the fix this returned FILE_TOO_LARGE, so the operator who raised the
+// setting did not get what the setting says. It is a behavior change for those
+// deployments, and this is the case that changes.
+func TestGenerateRawTextFromContent_BetweenTheTwoCapsIsIndexed(t *testing.T) {
+	const hardCodedCap = 10 * 1024 * 1024 // the pre-#830 gate
+	const configuredCap = 20 * 1024 * 1024
+
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, configuredCap)
+	// Just past the old gate, comfortably inside the configured cap.
+	content := []byte(strings.Repeat("between the two caps\n", (hardCodedCap/21)+64))
+	if int64(len(content)) <= hardCodedCap {
+		t.Fatalf("fixture is %d bytes, must exceed the old %d-byte gate to be meaningful", len(content), hardCodedCap)
+	}
+
+	doc := model.Document{DocID: 1, RelPath: "big-but-allowed.txt", DocType: "text"}
+	if err := rg.GenerateRawTextFromContent(context.Background(), doc, content); err != nil {
+		t.Fatalf("a file inside the CONFIGURED cap must be indexed, got err: %v", err)
+	}
+	if len(st.chunks) == 0 {
+		t.Fatal("no chunks were inserted for a file inside the configured cap")
+	}
+}
+
+// TestGenerateRawTextFromContent_PastTheConfiguredCapIsRefused confirms the gate is
+// still a gate: content past the configured cap is refused with the existing
+// sentinel. A LOWERED cap is used, so a pass cannot be explained by the default.
+func TestGenerateRawTextFromContent_PastTheConfiguredCapIsRefused(t *testing.T) {
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, rawTextTestCap)
+
+	doc := model.Document{DocID: 1, RelPath: "over.txt", DocType: "text"}
+	err := rg.GenerateRawTextFromContent(context.Background(), doc, make([]byte, rawTextTestCap+1))
+	if !errors.Is(err, ingest.ErrFileTooLarge) {
+		t.Fatalf("content past the configured cap must be refused with ErrFileTooLarge, got: %v", err)
+	}
+	if len(st.chunks) != 0 {
+		t.Fatalf("%d chunk(s) were persisted past the cap, want 0", len(st.chunks))
+	}
+}

--- a/tests/ingest/raw_text_cap_fifo_830_unix_test.go
+++ b/tests/ingest/raw_text_cap_fifo_830_unix_test.go
@@ -80,13 +80,12 @@ func TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure(t *testing.T) 
 	var err error
 	select {
 	case err = <-readDone:
+	case werr := <-writeErr:
+		// The writer never attached, so the read is blocked on the fifo and the
+		// timeout below would report a bound failure for a fixture failure.
+		t.Fatalf("the fifo writer could not attach: %v", werr)
 	case <-time.After(30 * time.Second):
 		t.Fatal("GenerateRawText never returned: the read is not bounded, or no writer attached to the fifo")
-	}
-	select {
-	case werr := <-writeErr:
-		t.Fatalf("the fifo writer could not attach: %v", werr)
-	default:
 	}
 	if err == nil {
 		t.Fatal("a source that served past the cap must be refused; the read was not bounded")
@@ -94,8 +93,8 @@ func TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure(t *testing.T) 
 	if !errors.Is(err, ingest.ErrFileTooLarge) {
 		t.Fatalf("error is not tagged ingest.ErrFileTooLarge: %v", err)
 	}
-	if len(st.chunks) != 0 {
-		t.Fatalf("%d chunk(s) were persisted from a refused read, want 0", len(st.chunks))
+	if len(st.chunks) != 0 || len(st.reps) != 0 {
+		t.Fatalf("a refused read persisted %d chunk(s) and %d representation(s), want 0 and 0", len(st.chunks), len(st.reps))
 	}
 	// The reader must have stopped near the bound instead of draining the source.
 	sent := <-writeDone

--- a/tests/ingest/raw_text_cap_fifo_830_unix_test.go
+++ b/tests/ingest/raw_text_cap_fifo_830_unix_test.go
@@ -1,0 +1,105 @@
+//go:build unix
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/dirstral/dir2mcp/internal/ingest"
+	"github.com/dirstral/dir2mcp/internal/model"
+)
+
+// The FIFO case lives in a unix-only file. syscall.Mkfifo is not declared on
+// Windows, so a runtime.GOOS skip inside the shared file would fail to COMPILE
+// there rather than skip: the constraint has to be a build tag.
+
+// TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure is the case a size
+// check cannot catch, which is the whole argument of #682 and #830.
+//
+// The source is a FIFO. os.Stat reports size 0 for it, and the bytes then arrive
+// from a later, separate operation that serves as many as the writer sends: the
+// stat's number and the read's number are unrelated by construction, exactly as
+// they are for a file that grows after discovery or for an object that serves more
+// than it listed.
+//
+// Before the fix this path stat'ed (0, comfortably under any cap), then called an
+// unbounded os.ReadFile and swallowed everything the writer produced, and the
+// 10 MiB gate afterwards passed too because the payload is smaller than that. With
+// the read bounded the pipe delivers at most cap+1 bytes and the document is
+// refused.
+func TestGenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "grows.txt")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	// The payload is 4x the cap and, deliberately, still under the old hard-coded
+	// 10 MiB gate: only a bound on the READ refuses it.
+	payload := rawTextTestCap * 4
+	writeDone := make(chan int64, 1)
+	writeErr := make(chan error, 1)
+	go func() {
+		// Opening a FIFO for write blocks until a reader opens it, so this open
+		// completes when the generator performs its read.
+		w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+		if err != nil {
+			writeErr <- err
+			writeDone <- 0
+			return
+		}
+		defer func() { _ = w.Close() }()
+		block := []byte(strings.Repeat("b", 64*1024))
+		var sent int64
+		for sent < payload {
+			n, werr := w.Write(block)
+			sent += int64(n)
+			if werr != nil {
+				// EPIPE once the bounded reader stops and closes: that is the bound
+				// working, not a test failure.
+				break
+			}
+		}
+		writeDone <- sent
+	}()
+
+	st := &fakeRepStore{failAfter: -1}
+	rg := newCappedRepGen(t, st, rawTextTestCap)
+	doc := model.Document{DocID: 1, RelPath: "grows.txt", DocType: "text"}
+	// A read with no bound on a source with no end does not return, so the call is
+	// watched: a hang is reported as the failure it is instead of stalling the suite
+	// until the package timeout.
+	readDone := make(chan error, 1)
+	go func() { readDone <- rg.GenerateRawText(context.Background(), doc, fifo) }()
+	var err error
+	select {
+	case err = <-readDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("GenerateRawText never returned: the read is not bounded, or no writer attached to the fifo")
+	}
+	select {
+	case werr := <-writeErr:
+		t.Fatalf("the fifo writer could not attach: %v", werr)
+	default:
+	}
+	if err == nil {
+		t.Fatal("a source that served past the cap must be refused; the read was not bounded")
+	}
+	if !errors.Is(err, ingest.ErrFileTooLarge) {
+		t.Fatalf("error is not tagged ingest.ErrFileTooLarge: %v", err)
+	}
+	if len(st.chunks) != 0 {
+		t.Fatalf("%d chunk(s) were persisted from a refused read, want 0", len(st.chunks))
+	}
+	// The reader must have stopped near the bound instead of draining the source.
+	sent := <-writeDone
+	if sent > rawTextTestCap*2 {
+		t.Fatalf("the source delivered %d bytes against a cap of %d; the read is not bounded", sent, rawTextTestCap)
+	}
+}

--- a/tests/mcp/read_bound_830_test.go
+++ b/tests/mcp/read_bound_830_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/config"
+	"github.com/dirstral/dir2mcp/internal/mcp"
+	"github.com/dirstral/dir2mcp/internal/protocol"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// These tests cover site 3 of #830 (the MCP on-demand document read) and the tool
+// surface of site 2 (retrieval's source-byte hash).
+//
+// Both are reachable by an ordinary client request, so an unbounded read here is
+// remote-triggerable: annotate on a local file was an os.ReadFile with no limit, and
+// a file that had grown since discovery measured it was pulled whole into the server
+// process.
+//
+// The fixtures below all seed the document row from a SMALL file and then grow the
+// file on disk. That is the state a size check cannot catch: the row, the stat that
+// produced it, and the bytes the read obtains are three separate things.
+
+const mcpReadCapMB = 1
+const mcpReadCapBytes = mcpReadCapMB * 1024 * 1024
+
+// growFile overwrites the corpus file at relPath with size bytes of printable
+// filler, simulating growth after discovery recorded the small original.
+func growFile(t *testing.T, rootDir, relPath string, size int) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(rootDir, relPath), bytes.Repeat([]byte("g"), size), 0o644); err != nil {
+		t.Fatalf("grow %s: %v", relPath, err)
+	}
+}
+
+// TestAnnotate_LocalFileGrownPastTheCapIsRefused is the core case for
+// readDocumentContent: the document row says 5 bytes, the file is 4 MiB, the cap is
+// 1 MiB, and the read must refuse instead of loading the file.
+//
+// FILE_TOO_LARGE (§14.4) is the existing code for this condition. Before the fix the
+// read succeeded and the tool went on to call the model with the whole file.
+func TestAnnotate_LocalFileGrownPastTheCapIsRefused(t *testing.T) {
+	cfg, st, rootDir := setupMCPToolStore(t, "note.txt", "text", []byte("small"))
+	cfg.IngestMaxFileMB = mcpReadCapMB
+	growFile(t, rootDir, "note.txt", mcpReadCapBytes*4)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":8301,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "FILE_TOO_LARGE")
+}
+
+// TestAnnotate_LocalFileAtTheCapIsRead is the off-by-one guard on the same path: a
+// file of exactly the cap must be READ, not refused.
+//
+// The read is observable without any provider: the bytes carry a secret-pattern
+// match, so the #407 secret gate answers FORBIDDEN, which can only happen once the
+// content has been read in full.
+func TestAnnotate_LocalFileAtTheCapIsRead(t *testing.T) {
+	const secret = "AKIA_AT_THE_CAP_SECRET"
+	cfg, st, rootDir := setupMCPToolStore(t, "note.txt", "text", []byte("small"))
+	cfg.IngestMaxFileMB = mcpReadCapMB
+	cfg.SecretPatterns = []string{"AKIA_[A-Z_]+"}
+
+	// Exactly the cap, with the marker at the very END: a truncated read would not
+	// see it, so FORBIDDEN also proves the whole file arrived.
+	filler := bytes.Repeat([]byte("f"), mcpReadCapBytes-len(secret))
+	if err := os.WriteFile(filepath.Join(rootDir, "note.txt"), append(filler, []byte(secret)...), 0o644); err != nil {
+		t.Fatalf("write at-cap file: %v", err)
+	}
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":8302,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, protocol.ErrorCodeForbidden)
+}
+
+// TestOpenFile_LocalSourceGrownPastTheCapReportsFileTooLarge is the tool-surface half
+// of site 2: retrieval bounds its source-byte hash, and the MCP layer reports the
+// cap rather than a retryable INTERNAL_ERROR.
+//
+// The retrieval service is the real one, so this pins the whole chain: bounded read →
+// corpusfs.ErrObjectTooLarge → §14.4 FILE_TOO_LARGE, non-retryable. A retry cannot
+// help; the file is over the operator's cap until the file or the cap changes.
+func TestOpenFile_LocalSourceGrownPastTheCapReportsFileTooLarge(t *testing.T) {
+	cfg, st, rootDir := setupMCPToolStore(t, "act.pdf", "pdf", []byte("%PDF-1.4 small"))
+	cfg.IngestMaxFileMB = mcpReadCapMB
+	growFile(t, rootDir, "act.pdf", mcpReadCapBytes*4)
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(cfg.RootDir)
+	svc.SetStateDir(cfg.StateDir)
+	svc.SetMaxFileBytes(int64(cfg.IngestMaxFileMB) * 1024 * 1024)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, svc, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":8303,"method":"tools/call","params":{"name":"dir2mcp_open_file","arguments":{"rel_path":"act.pdf"}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "FILE_TOO_LARGE")
+}
+
+// TestAnnotate_DefaultCapStillBoundsTheRead pins the fail-closed default on the tool
+// path: with `ingest.max_file_mb` left at its default the read is still bounded, so
+// no deployment depends on setting the value to get a bound.
+func TestAnnotate_DefaultCapStillBoundsTheRead(t *testing.T) {
+	cfg, st, rootDir := setupMCPToolStore(t, "note.txt", "text", []byte("small"))
+	defaults := config.Default()
+	cfg.IngestMaxFileMB = defaults.IngestMaxFileMB
+	growFile(t, rootDir, "note.txt", (cfg.IngestMaxFileMB*1024*1024)+1)
+
+	server := httptest.NewServer(mcp.NewServer(cfg, nil, mcp.WithStore(st)).Handler())
+	defer server.Close()
+
+	sessionID := initializeSession(t, server.URL+cfg.MCPPath)
+	resp := postRPC(t, server.URL+cfg.MCPPath, sessionID,
+		`{"jsonrpc":"2.0","id":8304,"method":"tools/call","params":{"name":"dir2mcp_annotate","arguments":{"rel_path":"note.txt","schema_json":{"type":"object"}}}}`)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertToolCallErrorCode(t, resp, "FILE_TOO_LARGE")
+}

--- a/tests/retrieval/source_hash_bound_830_test.go
+++ b/tests/retrieval/source_hash_bound_830_test.go
@@ -1,0 +1,213 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/dirstral/dir2mcp/internal/corpusfs"
+	"github.com/dirstral/dir2mcp/internal/model"
+	"github.com/dirstral/dir2mcp/internal/retrieval"
+)
+
+// These tests cover site 2 of #830: open_file's source-byte hash (hashSourceBytes),
+// the fallback that derives the OCR/transcript cache key when the store cannot
+// report the base content hash.
+//
+// The severity differs from the memory cases and the reason is worth stating,
+// because it is the reason this bound exists at all. The hash streams into a
+// hasher, so it holds constant memory and cannot OOM the daemon. What it consumed
+// without a bound was BANDWIDTH: one open_file call pulled a whole remote object of
+// any size, so an unprivileged client could make the server download tens of
+// gigabytes of metered egress per request. Same class, lower severity: a size check
+// is still only a measurement, and the object still chooses how many bytes it
+// serves.
+
+const sourceHashTestCap int64 = 64 * 1024
+
+// unsizedSourceFS is a CorpusFS whose objects report no size. It serves either
+// explicit bytes or a generated run of a given length, and counts every byte it
+// delivered so a test can assert on what the read actually pulled rather than on
+// what a check believed.
+type unsizedSourceFS struct {
+	contents map[string][]byte
+	sizes    map[string]int64
+
+	mu        sync.Mutex
+	delivered int64
+}
+
+func (f *unsizedSourceFS) Open(_ context.Context, relPath string) (io.ReadSeekCloser, error) {
+	if data, ok := f.contents[relPath]; ok {
+		return &countingSource{inner: bytes.NewReader(data), fs: f}, nil
+	}
+	if size, ok := f.sizes[relPath]; ok {
+		return &countingSource{inner: &runReader{total: size}, fs: f}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (f *unsizedSourceFS) Walk(context.Context, string, corpusfs.Options) ([]corpusfs.DiscoveredFile, error) {
+	return nil, errors.New("unsizedSourceFS: Walk not implemented")
+}
+
+func (f *unsizedSourceFS) Localize(context.Context, string) (string, func(), error) {
+	return "", func() {}, errors.New("unsizedSourceFS: Localize not implemented")
+}
+
+func (f *unsizedSourceFS) bytesDelivered() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.delivered
+}
+
+// runReader generates total bytes of filler. The bytes are generated rather than
+// allocated: on the unbounded code the hash consumes the whole object, so a fixture
+// held in a []byte would have to be materialized in full first.
+type runReader struct {
+	total int64
+	pos   int64
+}
+
+func (r *runReader) Read(p []byte) (int, error) {
+	if r.pos >= r.total {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if remaining := r.total - r.pos; remaining < n {
+		n = remaining
+	}
+	for i := int64(0); i < n; i++ {
+		p[i] = 'x'
+	}
+	r.pos += n
+	return int(n), nil
+}
+
+func (r *runReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.pos = offset
+	case io.SeekCurrent:
+		r.pos += offset
+	case io.SeekEnd:
+		r.pos = r.total + offset
+	}
+	return r.pos, nil
+}
+
+// countingSource records every byte read through it on the owning filesystem.
+type countingSource struct {
+	inner io.ReadSeeker
+	fs    *unsizedSourceFS
+}
+
+func (c *countingSource) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	c.fs.mu.Lock()
+	c.fs.delivered += int64(n)
+	c.fs.mu.Unlock()
+	return n, err
+}
+
+func (c *countingSource) Seek(offset int64, whence int) (int64, error) {
+	return c.inner.Seek(offset, whence)
+}
+
+func (c *countingSource) Close() error { return nil }
+
+// newBoundedHashService builds an open_file service with the cap plumbed in the way
+// the CLI plumbs it (from ingest.ResolvedMaxFileBytes) and no store, so the
+// source-hash fallback is the path under test.
+func newBoundedHashService(t *testing.T, root, stateDir string, fsys corpusfs.CorpusFS, capBytes int64) *retrieval.Service {
+	t.Helper()
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(stateDir)
+	svc.SetCorpusFS(fsys)
+	svc.SetMaxFileBytes(capBytes)
+	svc.SetDerivationCacheIdentities("ocr|docling|||", "")
+	return svc
+}
+
+// TestOpenFileSourceHash_BoundsTheReadOnAnUnsizedSource is the core case: an object
+// that reports no size and serves 16x the cap is read to at most cap+1 bytes, and
+// the refusal names the cap through the existing sentinel (which the MCP layer maps
+// to §14.4 FILE_TOO_LARGE) rather than a retryable INTERNAL_ERROR.
+func TestOpenFileSourceHash_BoundsTheReadOnAnUnsizedSource(t *testing.T) {
+	root := t.TempDir()
+	fsys := &unsizedSourceFS{sizes: map[string]int64{"docs/huge.pdf": sourceHashTestCap * 16}}
+	svc := newBoundedHashService(t, root, filepath.Join(root, ".dir2mcp"), fsys, sourceHashTestCap)
+
+	_, err := svc.OpenFile(context.Background(), "docs/huge.pdf", model.Span{}, 20000)
+	if err == nil {
+		t.Fatal("an over-cap source must not be hashed to completion")
+	}
+	if !errors.Is(err, corpusfs.ErrObjectTooLarge) {
+		t.Fatalf("error is not the cap sentinel: %v", err)
+	}
+	if got := fsys.bytesDelivered(); got != sourceHashTestCap+1 {
+		t.Fatalf("the source delivered %d bytes, want exactly %d (cap+1): the read is bounded neither short nor long", got, sourceHashTestCap+1)
+	}
+}
+
+// TestOpenFileSourceHash_AtTheCapHashesTheWholeFile is the off-by-one guard AND the
+// correctness guard: a source of exactly the cap must be hashed in full, and the
+// digest must still be ingest's, so the cached OCR text is FOUND. A bound that
+// stopped at the cap, or one that hashed a prefix, would miss the entry.
+func TestOpenFileSourceHash_AtTheCapHashesTheWholeFile(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, ".dir2mcp")
+
+	content := bytes.Repeat([]byte("x"), int(sourceHashTestCap))
+	fsys := &unsizedSourceFS{contents: map[string][]byte{"docs/exact.pdf": content}}
+
+	const ocrText = "# Extracted\n\nthe cached text for a file of exactly the cap"
+	cacheDir := filepath.Join(stateDir, "cache", "ocr")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir ocr cache: %v", err)
+	}
+	key := ingestOCRCacheKey(t, stateDir, content)
+	if err := os.WriteFile(filepath.Join(cacheDir, key+".md"), []byte(ocrText), 0o644); err != nil {
+		t.Fatalf("write ocr cache: %v", err)
+	}
+
+	svc := newBoundedHashService(t, root, stateDir, fsys, sourceHashTestCap)
+	out, err := svc.OpenFile(context.Background(), "docs/exact.pdf", model.Span{}, 20000)
+	if err != nil {
+		t.Fatalf("a source of exactly the cap must be hashed and served: %v", err)
+	}
+	if out != ocrText {
+		t.Fatalf("open_file returned %q, want the cached OCR text (the digest must be over the WHOLE file)", out)
+	}
+	if got := fsys.bytesDelivered(); got != sourceHashTestCap {
+		t.Fatalf("the source delivered %d bytes, want %d", got, sourceHashTestCap)
+	}
+}
+
+// TestOpenFileSourceHash_UnsetCapStillBoundsTheRead pins the fail-closed default: a
+// service with no cap plumbed in reads under the shared default bound, not without
+// one.
+func TestOpenFileSourceHash_UnsetCapStillBoundsTheRead(t *testing.T) {
+	root := t.TempDir()
+	defaultCap := corpusfs.DefaultMaxFileSizeBytes()
+	fsys := &unsizedSourceFS{sizes: map[string]int64{"docs/huge.pdf": defaultCap * 2}}
+
+	svc := retrieval.NewService(nil, nil, nil, nil)
+	svc.SetRootDir(root)
+	svc.SetStateDir(filepath.Join(root, ".dir2mcp"))
+	svc.SetCorpusFS(fsys)
+	// SetMaxFileBytes deliberately not called.
+
+	if _, err := svc.OpenFile(context.Background(), "docs/huge.pdf", model.Span{}, 20000); !errors.Is(err, corpusfs.ErrObjectTooLarge) {
+		t.Fatalf("an unset cap must not mean an unbounded read, got err: %v", err)
+	}
+	if got := fsys.bytesDelivered(); got != defaultCap+1 {
+		t.Fatalf("the source delivered %d bytes, want %d (default cap+1)", got, defaultCap+1)
+	}
+}


### PR DESCRIPTION
Closes #830.

## What was still unbounded, and why a check could not fix it

#682 (PR #829) bounded every read on the ingest path and the S3 transport, and left four sites because each needed the cap plumbed into a package that did not carry it. This is those four.

The argument is the same one, and it is worth restating because it decides the shape of the fix. A size check is a **measurement**. It describes the file at the instant it ran and constrains nothing that happens afterwards: the bytes arrive from a later, separate operation, and a local file can grow between the two while an object can serve more than it listed. Re-checking the size produces a second measurement, not a bound. So every site below reads at most **cap+1** bytes and then judges. The one extra byte is the only evidence that separates "exactly at the cap" (inside the operator's policy, admit it) from "one byte past it" (refuse it).

This is not theoretical. An unbounded read in this class already killed a live deployment: a 29 GB file entered a corpus, the daemon reached 31 GB of 31 GB RSS, and the kernel SIGKILLed it into a systemd restart loop.

| site | before | after |
| --- | --- | --- |
| `index.readWholeMedia` | `io.ReadAll(rc)` on the whole media file, held in memory for the embed call | reads cap+1, drops the prefix, returns `corpusfs.ErrObjectTooLarge` |
| `retrieval.hashSourceBytes` | `io.Copy(hasher, reader)` over the whole object | copies cap+1 into the hasher, refuses past the cap |
| `mcp.readDocumentContent` | `os.ReadFile` on a local corpus file | the existing `readBoundedFile` with the resolved cap |
| `ingest represent.go` (`GenerateRawText`) | `os.Stat` then unbounded `os.ReadFile`, gated on a hard-coded 10 MiB | reads cap+1 against the CONFIGURED cap; the stat is gone because it measured nothing the bounded read does not decide itself |

### Site 1: the media read holds memory

Chunk rows outlive the stat that admitted the file. A media file that grew after it was chunked was read HERE, whole, into the daemon's memory, at whatever size it had reached.

The over-cap error is deliberately **not** `ErrFatal`. `ErrFatal` stops the worker for the whole corpus, and one over-cap file is one document's problem. Left non-fatal and non-transient, the batch bisects (#399), that chunk alone is marked failed with a reason that names the cap, and its healthy siblings still embed. `MediaRead_LocalFileThatGrewAfterChunkingIsRefused` pins exactly that blast radius.

### Site 2: the hash holds bandwidth, not memory

This one streams into a hasher, so memory is constant and it cannot OOM anything. What it consumed without a bound was **bandwidth and time**: one `open_file` call pulled a whole remote object of any size, so a single unprivileged client request could make the server download tens of gigabytes of metered egress and hold a request slot for as long as it took. Lower severity, same class, and the code comment says so rather than implying the two are equivalent.

Refusing past the cap loses nothing real. A file over the cap was refused by discovery, so ingest never wrote a derivation cache entry for it, so the key this hash would have produced cannot hit. The old behavior paid for the whole download and then answered `OCR_NOT_READY`; this one stops at cap+1 and names the cause.

### Site 3: the on-demand tool read is remote-triggerable

`readDocumentContent` serves `annotate` and `transcribe`. A remote object is already bounded by `Localize` (#682), but for a LOCAL corpus `Localize` copies nothing and hands back the in-root path, so the read here IS the boundary. Any client could ask for a file that had grown since discovery measured it and have it pulled whole into the server process.

## One resolver, not a fourth copy

`ingest.ResolvedMaxFileBytes` stays the single resolver for `ingest.max_file_mb`. Every site touched here reads that same value, plumbed in by the caller: a new `EmbeddingWorker.MaxFileBytes` field (wired in the in-process loop, the distributed coordinator, and the standalone embed-worker), `retrieval.Service.SetMaxFileBytes`, `RepresentationGenerator.SetMaxFileBytes`, and the MCP server's existing `ingestMaxFileBytes()`.

Turning a plumbed value into a safe limit is now shared too: `corpusfs.ResolveReadCapBytes` is the exported form of the S3 backend's own clamp, and the backend now calls it instead of keeping a private copy. Zero or negative selects the 10 MiB default (fail-closed: a caller that forgets to plumb the value still reads under a bound, and three tests pin that), and an absurd value is clamped so `cap+1` cannot overflow into a negative limit, which `io.LimitReader` reads as "zero bytes allowed" (#829 review finding 2). The duplicated `defaultMaxFileSizeBytes` constant in `internal/ingest` is deleted; it had no production caller left.

`corpusfs.ErrObjectTooLarge` becomes the ONE sentinel for the condition, and its doc says so. One sentinel means one classification.

## SPEC: no dirstral-spec PR needed

Verified in the vendored submodule before writing code.

* **§15.2** closes the `skip_reasons` enum for a spec minor and already defines `size_cap`: *"exceeded the configured max file size"* (`dirstral-spec/docs/SPEC.md`, the CorpusStats schema; the same list appears at §3.2 for `file_skip`). That is precisely this condition, on the ingest surface that reports skips.
* **§14.4** already defines `FILE_TOO_LARGE`, which is the tool-surface answer.

Nothing new is needed for any of the four. Sites 2 and 3 are tool surfaces, so they report `FILE_TOO_LARGE`; site 4 wraps the existing `ErrFileTooLarge`, which `manifestErrorCode` already maps to `FILE_TOO_LARGE`. Site 1 is the embed loop, which has no document-skip surface at all: it reports through the existing per-chunk `embedding_status=error` category with a reason that names the cap, so no enum is involved and none had to be invented. The submodule pointer is untouched.

Three MCP mappers gained the cap case, because the default branches named the wrong cause: `mapReadDocumentError` and `annotationReadError` reported `permission denied` (which sends the operator to the wrong setting), and `mapOpenFileError` reported `INTERNAL_ERROR` as **retryable**, when a retry cannot help until the file or the cap changes.

## BEHAVIOR CHANGE: a file between the two caps is now indexed

Item 4 of the issue is a behavior change, not a bug fix, so the decision is explicit: **the configured cap wins, and a text file between 10 MiB and `ingest.max_file_mb` is INDEXED.**

The reasoning: `ingest.max_file_mb` is the operator's policy statement, discovery already admitted the file under it, and the hard-coded 10 MiB was never a second policy: it was a copy of the DEFAULT, frozen into a comparison. Keeping it would mean the setting does not do what it says, and the failure did not even name the reason. Truncating instead was never an option: half a document indexed as though it were the whole one is the truncated-document failure #487 had to fix once already.

**Who this breaks.** Every deployment with a text/code/markdown/data/html file between 10 MiB and its configured cap. Note the default is **20 MiB**, so this is not limited to deployments that raised the setting: on a default install, files of 10 to 20 MiB were admitted by discovery and then failed with `FILE_TOO_LARGE`.

**Migration consequence.** On the first scan after upgrade those files stop erroring and start indexing. They were error rows, so the incremental gate re-reads them: expect new representations, new chunks, and a one-time rise in embed calls and provider spend proportional to how much such content the corpus holds. An operator who prefers the old ceiling can set `ingest.max_file_mb: 10`, which is now honestly the same number everywhere.

## Tests

New: `tests/index/media_read_bound_830_test.go`, `tests/retrieval/source_hash_bound_830_test.go`, `tests/mcp/read_bound_830_test.go`, `tests/ingest/raw_text_cap_830_test.go` (plus a unix-tagged fifo file), and one internal case in `internal/ingest/errcode_test.go`.

Each bound is asserted on the READ, not on a prior size check:

* the index and retrieval cases count the bytes the source actually delivered and require **exactly cap+1**, so a bound that stopped short fails too;
* the sources report no size at all, so "the file is small enough" is not a claim anyone could have verified before the read;
* the raw-text case reads a **FIFO**, whose stat size is 0 while the read serves as much as the writer sends: the stat's number and the read's number are unrelated by construction, which is the case a check cannot catch;
* the MCP cases seed the document row from a SMALL file and then grow the file on disk, which is a file that grew after discovery;
* the index case also grows a real file under a real `LocalFS`.

Also covered: a file exactly AT the cap is admitted on all four paths (the off-by-one guard, and the reason the read asks for cap+1); cap+1 is refused; the reported error is the existing enum value (`FILE_TOO_LARGE` end-to-end through the MCP tool layer, `ErrFileTooLarge` into `manifestErrorCode` for ingest); item 4's between-the-caps file indexes; an unset cap still bounds the read; and a refused read persists neither chunks nor a representation.

### Verified against the unbounded code

`git stash` is banned in this repo, so the four files were copied aside, the read logic alone was reverted to `io.ReadAll` / `io.Copy` / `os.ReadFile` / the hard-coded gate while the new plumbing API was KEPT (so the tests still compile and their failures measure the BOUND, not the plumbing), the tests were run, and everything was restored.

| test | unbounded code |
| --- | --- |
| `MediaRead_BoundsTheReadOnAnUnsizedSource` | **FAIL**: over-cap media read reported success |
| `MediaRead_LocalFileThatGrewAfterChunkingIsRefused` | **FAIL**: `fatal: embedding vector count mismatch` (the 4 MiB file was read and embedded) |
| `MediaRead_UnsetCapStillBoundsTheRead` | **FAIL**: unbounded read reported success |
| `OpenFileSourceHash_BoundsTheReadOnAnUnsizedSource` | **FAIL**: whole object hashed, then `ocr not ready` |
| `OpenFileSourceHash_UnsetCapStillBoundsTheRead` | **FAIL**: same |
| `Annotate_LocalFileGrownPastTheCapIsRefused` | **FAIL**: `CONFIG_INVALID` (the 4 MiB read succeeded and the tool went on to the model) |
| `Annotate_DefaultCapStillBoundsTheRead` | **FAIL**: same |
| `OpenFile_LocalSourceGrownPastTheCapReportsFileTooLarge` | **FAIL**: `OCR_NOT_READY` after the whole read |
| `GenerateRawText_OneBytePastTheConfiguredCapIsRefused` | **FAIL**: not refused |
| `GenerateRawText_BoundsTheReadOnASourceAStatCannotMeasure` | **FAIL**: the fifo was drained and the document indexed |
| `GenerateRawTextFromContent_BetweenTheTwoCapsIsIndexed` | **FAIL**: `passed the ingest.max_file_mb cap (10485760 bytes)` |
| `GenerateRawTextFromContent_PastTheConfiguredCapIsRefused` | **FAIL**: `<nil>` |
| `GenerateRawTextFromContent_ConfiguredCapTaggedFileTooLarge` | **FAIL** (panics past the gate) |
| `MediaRead_FileAtTheCapIsStillEmbedded` | **PASS** (false-positive guard, as it must) |
| `OpenFileSourceHash_AtTheCapHashesTheWholeFile` | **PASS** (false-positive guard) |
| `Annotate_LocalFileAtTheCapIsRead` | **PASS** (false-positive guard) |
| `GenerateRawText_AtTheConfiguredCapIsAdmitted` | **PASS** (false-positive guard) |

## Review round

`coderabbit review --committed --base main`: 1 critical then 3 minor, all 4 valid, all 4 fixed; the re-review returns **no new findings**.

1. **The fifo test could not compile on Windows** (critical). `syscall.Mkfifo` is not declared there, so a `runtime.GOOS` skip fails to COMPILE rather than skip. The case moved to a `//go:build unix` file. (The `tests/ingest` package already had a pre-existing Windows-incompatible test using `syscall.Kill`, untouched here as unrelated.)
2. **A fifo writer that never attached would be reported as a bound failure** (minor). The writer's error is now a case in the same wait select, so a fixture failure is reported as itself instead of as a 30-second timeout.
3. **and 4. Two refusal cases asserted on chunks only** (minor). A regression that upserted the representation row before returning would have passed. Both now require chunks AND representations to be empty.

## Checklist

- [x] `make check` passes locally, including `gocyclo -over 15` and `misspell`
- [x] `coderabbit review` run; 4 findings, all fixed; re-review clean
- [x] new behavior has test coverage that fails against the unbounded code
- [x] no file content, offset, or secret is logged; the tool error messages name the setting, not the path
- [x] `README.md` and `docs/` remain truthful (README:677 already described the CONFIGURED cap as the policy, so it becomes more accurate, not less)
- [x] no unrelated files changed, submodule pointer untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMUGXpNtkZH63icDRKLCZ9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable maximum file-size limits are now consistently enforced during ingestion, retrieval, embedding, and document reads.
  * Oversized files stop reading promptly and return clear `FILE_TOO_LARGE` errors without processing partial content.
  * Files exactly at the configured limit continue to process successfully.
  * A safe default limit applies when no valid limit is configured.

* **Bug Fixes**
  * Prevented unbounded reads and source hashing for large or dynamically growing files.
  * Improved batch isolation so oversized media affects only the impacted item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->